### PR TITLE
Set upper bound for requests instead of forcing new requests-toolbelt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ pandas = ">=1.1,<1.6"
 pandera = ">=0.9.0"
 pydantic = ">=1.8"
 dacite = ">=1.6"
-requests = ">=2.20,<2.30" # TODO: revert upper bound when urllib3 situation sorts out: https://github.com/psf/requests/issues/6443
+requests = ">=2.20,<2.30" # TODO: revert upper bound when urllib3 situation sorts out: https://github.com/psf/requests/issues/6432
 requests-toolbelt = "*"
 importlib-metadata = { version = "<5.0", python = "<3.8" }
 tqdm = ">=4,<5"


### PR DESCRIPTION
Seeing issues installing latest on `trunk` as well as the latest `0.68.0` release on different environments. Looks like it boils down to the `requests-toolbelt>=1` pin being too new (breaks compatibility with libraries that pin e.g. `requests-toolbelt^0.9`) and the `requests==2.30` release causing issues in the ecosystem that haven't fully shaken out (see https://github.com/psf/requests/issues/6443, https://github.com/psf/requests/issues/6432).

This PR addresses the problem by unpinning `requests-toolbelt`, which should be driven mostly by the `requests` version, and adding an upper bound `requests<2.30` with a TODO to rip out once things settle.