### PR TITLE
Touch up release CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Install Poetry
-        run: pip install poetry==1.2.2
+        run: pip install 'poetry>=1.3'
 
       - name: Fetch tags to enable autoversioning
         run: git fetch --prune --unshallow --tags
@@ -50,7 +50,7 @@ jobs:
       - name: Build 'kolena' Python package
         run: poetry build --format=sdist
 
-      - name: Build 'kolena-client' package for backwards compatibility
+      - name: Build 'kolena-client' package for backward compatibility
         run: |
           # update first instance of 'kolena' to 'kolena-client' in pyproject.toml, kolena/__init__.py (package name)
           sed -i '0,/kolena/{s/kolena/kolena-client/}' pyproject.toml kolena/__init__.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
 name: Build
 
 on:
-  push:
+  pull_request:
     branch:
       - gh/pre-release
+  push:
     tags:
       - "*"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build
 
 on:
-  pull_request:
-    branch:
-      - gh/pre-release
   push:
     tags:
       - "*"
@@ -72,18 +69,18 @@ jobs:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
-      # - name: Push kolena dist to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Push kolena dist to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
-      # - name: Create GitHub release with kolena build as artifact
-      #   uses: marvinpinto/action-automatic-releases@v1.2.1
-      #   with:
-      #     repo_token: ${{ secrets.RELEASE_TOKEN }}
-      #     prerelease: false
-      #     files: |
-      #       ./dist/*.tar.gz
+      - name: Create GitHub release with kolena build as artifact
+        uses: marvinpinto/action-automatic-releases@v1.2.1
+        with:
+          repo_token: ${{ secrets.RELEASE_TOKEN }}
+          prerelease: false
+          files: |
+            ./dist/*.tar.gz
 
       #
       # backcompat: build and publish 'kolena-client' package
@@ -108,10 +105,10 @@ jobs:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
-      # - name: Push kolena-client dist to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Push kolena-client dist to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Push kolena-client dist to trunk CodeArtifact for backwards compatibility
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,10 @@ jobs:
           aws s3 rm --recursive "$BUCKET_PATH"
           aws s3 sync ./build "$BUCKET_PATH"
 
-          # BUCKET_PATH="s3://$ASSET_BUCKET/docs/latest"
-          # echo "pushing documentation to '$BUCKET_PATH'..."
-          # aws s3 rm --recursive "$BUCKET_PATH"
-          # aws s3 sync ./build "$BUCKET_PATH"
+          BUCKET_PATH="s3://$ASSET_BUCKET/docs/latest"
+          echo "pushing documentation to '$BUCKET_PATH'..."
+          aws s3 rm --recursive "$BUCKET_PATH"
+          aws s3 sync ./build "$BUCKET_PATH"
         working-directory: ./docs
 
       - name: Push kolena dist to Test PyPI
@@ -110,12 +110,12 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
-      - name: Push kolena-client dist to trunk CodeArtifact for backwards compatibility
+      - name: Push kolena-client dist to trunk CodeArtifact for backward compatibility
         run: |
           aws codeartifact login --tool twine --domain trunk --domain-owner 328803196297 --repository kolena-client
           twine upload --skip-existing --repository codeartifact ./dist/kolena_client*
 
-      - name: Push kolena-client dist to production CodeArtifact for backwards compatibility
+      - name: Push kolena-client dist to production CodeArtifact for backward compatibility
         run: |
           aws codeartifact login --tool twine --domain production --domain-owner 328803196297 --repository kolena-client
           # twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,17 +54,21 @@ jobs:
         run: |
           # update first instance of 'kolena' to 'kolena-client' in pyproject.toml, kolena/__init__.py (package name)
           sed -i '0,/kolena/{s/kolena/kolena-client/}' pyproject.toml kolena/__init__.py
+
           poetry build --format=sdist
+
+          # change it back to switch back to poetry env for 'kolena'
+          sed -i '0,/kolena/{s/kolena-client/kolena/}' pyproject.toml kolena/__init__.py
 
       - name: Build client documentation and push to S3
         run: |
           ./render.sh
           VERSION=$(poetry run python3 -c "import kolena; print(kolena.__version__)")
 
-          # BUCKET_PATH="s3://$ASSET_BUCKET/docs/$VERSION"
-          # echo "pushing documentation to '$BUCKET_PATH'..."
-          # aws s3 rm --recursive "$BUCKET_PATH"
-          # aws s3 sync ./build "$BUCKET_PATH"
+          BUCKET_PATH="s3://$ASSET_BUCKET/docs/$VERSION"
+          echo "pushing documentation to '$BUCKET_PATH'..."
+          aws s3 rm --recursive "$BUCKET_PATH"
+          aws s3 sync ./build "$BUCKET_PATH"
 
           # BUCKET_PATH="s3://$ASSET_BUCKET/docs/latest"
           # echo "pushing documentation to '$BUCKET_PATH'..."
@@ -72,11 +76,11 @@ jobs:
           # aws s3 sync ./build "$BUCKET_PATH"
         working-directory: ./docs
 
-      # - name: Push kolena, kolena-client dists to Test PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      #     repository-url: https://test.pypi.org/legacy/
+      - name: Push kolena, kolena-client dists to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
 
       # - name: Push kolena, kolena-client dists to PyPI
       #   uses: pypa/gh-action-pypi-publish@release/v1
@@ -84,12 +88,12 @@ jobs:
       #     password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Install twine for package distribution on CodeArtifact
-        run: pip3 install twine
+        run: pip install twine
 
       - name: Push kolena-client dist to trunk CodeArtifact for backwards compatibility
         run: |
           aws codeartifact login --tool twine --domain trunk --domain-owner 328803196297 --repository kolena-client
-          # twine upload --skip-existing --repository codeartifact ./dist/kolena_client*
+          twine upload --skip-existing --repository codeartifact ./dist/kolena_client*
         working-directory: ${{ env.working-directory }}
 
       - name: Push kolena-client dist to production CodeArtifact for backwards compatibility
@@ -103,4 +107,4 @@ jobs:
       #     repo_token: ${{ secrets.RELEASE_TOKEN }}
       #     prerelease: false
       #     files: |
-      #       ./dist/*.tar.gz
+      #       ./dist/kolena-*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   push:
+    branch:
+      - gh/pre-release
     tags:
       - "*"
 
@@ -58,27 +60,27 @@ jobs:
           ./render.sh
           VERSION=$(poetry run python3 -c "import kolena; print(kolena.__version__)")
 
-          BUCKET_PATH="s3://$ASSET_BUCKET/docs/$VERSION"
-          echo "pushing documentation to '$BUCKET_PATH'..."
-          aws s3 rm --recursive "$BUCKET_PATH"
-          aws s3 sync ./build "$BUCKET_PATH"
+          # BUCKET_PATH="s3://$ASSET_BUCKET/docs/$VERSION"
+          # echo "pushing documentation to '$BUCKET_PATH'..."
+          # aws s3 rm --recursive "$BUCKET_PATH"
+          # aws s3 sync ./build "$BUCKET_PATH"
 
-          BUCKET_PATH="s3://$ASSET_BUCKET/docs/latest"
-          echo "pushing documentation to '$BUCKET_PATH'..."
-          aws s3 rm --recursive "$BUCKET_PATH"
-          aws s3 sync ./build "$BUCKET_PATH"
+          # BUCKET_PATH="s3://$ASSET_BUCKET/docs/latest"
+          # echo "pushing documentation to '$BUCKET_PATH'..."
+          # aws s3 rm --recursive "$BUCKET_PATH"
+          # aws s3 sync ./build "$BUCKET_PATH"
         working-directory: ./docs
 
-      - name: Push kolena, kolena-client dists to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
+      # - name: Push kolena, kolena-client dists to Test PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      #     repository-url: https://test.pypi.org/legacy/
 
-      - name: Push kolena, kolena-client dists to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      # - name: Push kolena, kolena-client dists to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Install twine for package distribution on CodeArtifact
         run: pip3 install twine
@@ -86,18 +88,18 @@ jobs:
       - name: Push kolena-client dist to trunk CodeArtifact for backwards compatibility
         run: |
           aws codeartifact login --tool twine --domain trunk --domain-owner 328803196297 --repository kolena-client
-          twine upload --skip-existing --repository codeartifact ./dist/kolena_client*
+          # twine upload --skip-existing --repository codeartifact ./dist/kolena_client*
         working-directory: ${{ env.working-directory }}
 
       - name: Push kolena-client dist to production CodeArtifact for backwards compatibility
         run: |
           aws codeartifact login --tool twine --domain production --domain-owner 328803196297 --repository kolena-client
-          twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*
+          # twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*
 
-      - name: Create GitHub release with kolena build as artifact
-        uses: marvinpinto/action-automatic-releases@v1.2.1
-        with:
-          repo_token: ${{ secrets.RELEASE_TOKEN }}
-          prerelease: false
-          files: |
-            ./dist/*.tar.gz
+      # - name: Create GitHub release with kolena build as artifact
+      #   uses: marvinpinto/action-automatic-releases@v1.2.1
+      #   with:
+      #     repo_token: ${{ secrets.RELEASE_TOKEN }}
+      #     prerelease: false
+      #     files: |
+      #       ./dist/*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,16 +50,6 @@ jobs:
       - name: Build 'kolena' Python package
         run: poetry build --format=sdist
 
-      - name: Build 'kolena-client' package for backward compatibility
-        run: |
-          # update first instance of 'kolena' to 'kolena-client' in pyproject.toml, kolena/__init__.py (package name)
-          sed -i '0,/kolena/{s/kolena/kolena-client/}' pyproject.toml kolena/__init__.py
-
-          poetry build --format=sdist
-
-          # change it back to switch back to poetry env for 'kolena'
-          sed -i '0,/kolena/{s/kolena-client/kolena/}' pyproject.toml kolena/__init__.py
-
       - name: Build client documentation and push to S3
         run: |
           ./render.sh
@@ -76,30 +66,16 @@ jobs:
           # aws s3 sync ./build "$BUCKET_PATH"
         working-directory: ./docs
 
-      - name: Push kolena, kolena-client dists to Test PyPI
+      - name: Push kolena dist to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
-      # - name: Push kolena, kolena-client dists to PyPI
+      # - name: Push kolena dist to PyPI
       #   uses: pypa/gh-action-pypi-publish@release/v1
       #   with:
       #     password: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Install twine for package distribution on CodeArtifact
-        run: pip install twine
-
-      - name: Push kolena-client dist to trunk CodeArtifact for backwards compatibility
-        run: |
-          aws codeartifact login --tool twine --domain trunk --domain-owner 328803196297 --repository kolena-client
-          twine upload --skip-existing --repository codeartifact ./dist/kolena_client*
-        working-directory: ${{ env.working-directory }}
-
-      - name: Push kolena-client dist to production CodeArtifact for backwards compatibility
-        run: |
-          aws codeartifact login --tool twine --domain production --domain-owner 328803196297 --repository kolena-client
-          # twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*
 
       # - name: Create GitHub release with kolena build as artifact
       #   uses: marvinpinto/action-automatic-releases@v1.2.1
@@ -107,4 +83,42 @@ jobs:
       #     repo_token: ${{ secrets.RELEASE_TOKEN }}
       #     prerelease: false
       #     files: |
-      #       ./dist/kolena-*.tar.gz
+      #       ./dist/*.tar.gz
+
+      #
+      # backcompat: build and publish 'kolena-client' package
+      #
+
+      - name: Build 'kolena-client' package for backward compatibility
+        run: |
+          rm -rf ./dist
+
+          # update first instance of 'kolena' to 'kolena-client' in pyproject.toml, kolena/__init__.py (package name)
+          sed -i '0,/kolena/{s/kolena/kolena-client/}' pyproject.toml kolena/__init__.py
+
+          poetry install
+          poetry build --format=sdist
+
+      - name: Install twine for package distribution on CodeArtifact
+        run: pip install twine
+
+      - name: Push kolena-client dist to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+
+      # - name: Push kolena-client dist to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Push kolena-client dist to trunk CodeArtifact for backwards compatibility
+        run: |
+          aws codeartifact login --tool twine --domain trunk --domain-owner 328803196297 --repository kolena-client
+          twine upload --skip-existing --repository codeartifact ./dist/kolena_client*
+
+      - name: Push kolena-client dist to production CodeArtifact for backwards compatibility
+        run: |
+          aws codeartifact login --tool twine --domain production --domain-owner 328803196297 --repository kolena-client
+          # twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Release
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
       - "*"
 
 jobs:
-  build:
-    name: Build and publish kolena Python package and documentation
+  release:
+    name: Build and publish release of kolena Python package and documentation
     env:
       ASSET_BUCKET: kolena-client-assets
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,12 @@ jobs:
           aws-region: us-west-2
 
       - name: Install Poetry
-        run: pip install 'poetry>=1.3'
+        run: pip install poetry==1.2.2
 
       - name: Fetch tags to enable autoversioning
         run: git fetch --prune --unshallow --tags
 
-      - name: Update kolena package version to PEP 440-compliant production release tag
+      - name: Update package version to PEP 440-compliant production release tag
         run: poetry version $(git describe --tags --abbrev=0)
 
       - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
       - name: Build 'kolena' Python package
         run: poetry build --format=sdist
 
-      - name: Build client documentation and push to S3
+      - name: Build 'kolena' documentation and push to S3
         run: |
           ./render.sh
           VERSION=$(poetry run python3 -c "import kolena; print(kolena.__version__)")
@@ -63,18 +63,18 @@ jobs:
           aws s3 sync ./build "$BUCKET_PATH"
         working-directory: ./docs
 
-      - name: Push kolena dist to Test PyPI
+      - name: Push 'kolena' dist to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
-      - name: Push kolena dist to PyPI
+      - name: Push 'kolena' dist to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
-      - name: Create GitHub release with kolena build as artifact
+      - name: Create GitHub release with 'kolena' build as artifact
         uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
           repo_token: ${{ secrets.RELEASE_TOKEN }}
@@ -96,26 +96,26 @@ jobs:
           poetry install
           poetry build --format=sdist
 
-      - name: Install twine for package distribution on CodeArtifact
+      - name: Install twine for package distribution on CodeArtifact for backward compatibility
         run: pip install twine
 
-      - name: Push kolena-client dist to Test PyPI
+      - name: Push 'kolena-client' dist to trunk CodeArtifact for backward compatibility
+        run: |
+          aws codeartifact login --tool twine --domain trunk --domain-owner 328803196297 --repository kolena-client
+          twine upload --skip-existing --repository codeartifact ./dist/kolena_client*
+
+      - name: Push 'kolena-client' dist to production CodeArtifact for backward compatibility
+        run: |
+          aws codeartifact login --tool twine --domain production --domain-owner 328803196297 --repository kolena-client
+          twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*
+
+      - name: Push 'kolena-client' dist to Test PyPI for backward compatibility
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
-      - name: Push kolena-client dist to PyPI
+      - name: Push 'kolena-client' dist to PyPI for backward compatibility
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Push kolena-client dist to trunk CodeArtifact for backward compatibility
-        run: |
-          aws codeartifact login --tool twine --domain trunk --domain-owner 328803196297 --repository kolena-client
-          twine upload --skip-existing --repository codeartifact ./dist/kolena_client*
-
-      - name: Push kolena-client dist to production CodeArtifact for backward compatibility
-        run: |
-          aws codeartifact login --tool twine --domain production --domain-owner 328803196297 --repository kolena-client
-          twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,4 +118,4 @@ jobs:
       - name: Push kolena-client dist to production CodeArtifact for backward compatibility
         run: |
           aws codeartifact login --tool twine --domain production --domain-owner 328803196297 --repository kolena-client
-          # twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*
+          twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,16 +104,16 @@ jobs:
           aws codeartifact login --tool twine --domain trunk --domain-owner 328803196297 --repository kolena-client
           twine upload --skip-existing --repository codeartifact ./dist/kolena_client*
 
-      - name: Push 'kolena-client' dist to production CodeArtifact for backward compatibility
-        run: |
-          aws codeartifact login --tool twine --domain production --domain-owner 328803196297 --repository kolena-client
-          twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*
-
       - name: Push 'kolena-client' dist to Test PyPI for backward compatibility
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
+
+      - name: Push 'kolena-client' dist to production CodeArtifact for backward compatibility
+        run: |
+          aws codeartifact login --tool twine --domain production --domain-owner 328803196297 --repository kolena-client
+          twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*
 
       - name: Push 'kolena-client' dist to PyPI for backward compatibility
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align='center'>
   <a href="https://pypi.python.org/pypi/kolena"><img src="https://img.shields.io/pypi/v/kolena" /></a>
   <a href="https://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/pypi/l/kolena" /></a>
-  <a href="https://github.com/kolenaIO/kolena"><img src="https://img.shields.io/github/checks-status/kolenaIO/kolena/trunk" /></a>
+  <a href="https://github.com/kolenaIO/kolena/actions"><img src="https://img.shields.io/github/checks-status/kolenaIO/kolena/trunk" /></a>
   <a href="https://codecov.io/gh/kolenaIO/kolena" ><img src="https://codecov.io/gh/kolenaIO/kolena/branch/trunk/graph/badge.svg?token=8WOY5I8SF1"/></a>
   <a href="https://docs.kolena.io"><img src="https://img.shields.io/badge/resource-docs-6434c1" /></a>
 </p>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,12 +79,7 @@ html_sidebars = {
     "**": ["sidebar-nav-bs.html"],
 }
 html_theme_options = dict(
-    favicons=[
-        dict(
-            rel="icon",
-            href="favicon.png",
-        ),
-    ],
+    favicons=[dict(rel="icon", href="favicon.png")],
     logo=dict(
         link="index.html",
         image_light="wordmark-purple.svg",

--- a/kolena/workflow/test_suite.py
+++ b/kolena/workflow/test_suite.py
@@ -219,7 +219,8 @@ class TestSuite(Frozen, WithTelemetry, metaclass=ABCMeta):
         Load the latest version of all non-archived test suites with this workflow.
 
         :param tags: optionally specify a set of tags to apply as a filter. The loaded test suites will include only
-            test suites with tags matching each of these specified tags, i.e. ``test_suite.tags.intersection == tags``.
+            test suites with tags matching each of these specified tags, i.e.
+            ``test_suite.tags.intersection(tags) == tags``.
         :return: the latest version of all non-archived test suites, with matching tags when specified.
         """
         cls._validate_workflow()
@@ -315,7 +316,7 @@ class TestSuite(Frozen, WithTelemetry, metaclass=ABCMeta):
             name=self.name,
             description=editor._description,
             test_case_ids=[tc._id for tc in editor._test_cases],
-            tags=editor.tags,
+            tags=list(editor.tags),
         )
         res = krequests.post(endpoint_path=API.Path.EDIT, data=json.dumps(dataclasses.asdict(request)))
         krequests.raise_for_status(res)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kolena"
-version = "0.999.1"
+version = "0.999.0"
 description = "Client for Kolena's machine learning (ML) testing and debugging platform."
 authors = ["Kolena Engineering <eng@kolena.io>"]
 homepage = "https://kolena.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kolena"
-version = "0.999.0"
+version = "0.999.0"  # version is automatically set to latest git tag during release process
 description = "Client for Kolena's machine learning (ML) testing and debugging platform."
 authors = ["Kolena Engineering <eng@kolena.io>"]
 homepage = "https://kolena.io"
@@ -8,7 +8,7 @@ documentation = "https://docs.kolena.io"
 readme = "README.md"
 license = "Apache-2.0"
 keywords = ["Kolena", "ML", "testing"]
-classifiers = [  # license, versions set automatically during build
+classifiers = [  # classifiers for license, versions set automatically during Poetry build
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kolena"
-version = "0.999.0"
+version = "0.999.1"
 description = "Client for Kolena's machine learning (ML) testing and debugging platform."
 authors = ["Kolena Engineering <eng@kolena.io>"]
 homepage = "https://kolena.io"


### PR DESCRIPTION
In preparation for today's 0.69.0 release (the first to be cut out of this repository!), run the `release.yml` CI through its paces, publishing both `kolena` and `kolena-client` to test PyPI and trunk CodeArtifact. Verified that both work by installing `kolena`/`kolena-client` from test PyPI in a fresh venv.