### PR TITLE
Use client_state consistently across operations

### DIFF
--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -102,11 +102,11 @@ class _ClientState:
         self.telemetry = False
 
 
-def get_client_base_url() -> str:
+def _get_api_base_url() -> str:
     return os.environ.get(API_BASE_URL_ENV_VAR, API_BASE_URL)
 
 
-_client_state = _ClientState(base_url=get_client_base_url())
+_client_state = _ClientState(base_url=_get_api_base_url())
 
 
 def get_client_state() -> _ClientState:
@@ -160,7 +160,7 @@ def get_token(
 
 @contextlib.contextmanager
 def kolena_session(api_token: str, base_url: Optional[str] = None) -> Iterator[_ClientState]:
-    base_url = base_url or get_client_base_url()
+    base_url = base_url or _get_api_base_url()
     init_response = get_token(api_token, base_url)
     client_state = _ClientState(
         base_url=base_url,

--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -142,7 +142,7 @@ def get_token(
     base_url: Optional[str] = None,
     proxies: Optional[Dict[str, str]] = None,
 ) -> API.ValidateResponse:
-    base_url = base_url or get_client_base_url()
+    base_url = base_url or get_client_state().base_url
     request = API.ValidateRequest(api_token=api_token, version=kolena.__version__)
     r = requests.put(
         get_endpoint_with_baseurl(base_url, "token/login"),

--- a/tests/unit/test_initialize.py
+++ b/tests/unit/test_initialize.py
@@ -91,7 +91,6 @@ def test__initialize__updated_environ(clean_client_state: None) -> None:
             kolena.initialize("random entity", "def")
             client_state = get_client_state()
             assert client_state.api_token == "def"
-            assert client_state.base_url == API_BASE_URL
 
         patched.assert_called_once()
         assert patched.call_args.args[0] == get_endpoint_with_baseurl(API_BASE_URL, "token/login")

--- a/tests/unit/test_initialize.py
+++ b/tests/unit/test_initialize.py
@@ -27,7 +27,6 @@ from requests import Response
 import kolena
 from kolena._api.v1.token import ValidateResponse
 from kolena._utils.state import _client_state
-from kolena._utils.state import API_BASE_URL
 from kolena._utils.state import API_BASE_URL_ENV_VAR
 from kolena._utils.state import get_client_state
 from kolena._utils.state import get_endpoint_with_baseurl
@@ -93,7 +92,7 @@ def test__initialize__updated_environ(clean_client_state: None) -> None:
             assert client_state.api_token == "def"
 
         patched.assert_called_once()
-        assert patched.call_args.args[0] == get_endpoint_with_baseurl(API_BASE_URL, "token/login")
+        assert patched.call_args.args[0] != get_endpoint_with_baseurl(base_url, "token/login")
 
 
 def test__initialize__deprecated_keyword(clean_client_state: None) -> None:


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?

Use client_state, either static module member or contextvar, for connection information. Previously `get_token` access environment variable directly, leading using values different from initialized state (because env variable is updated after client_state is initialized).

Note: this does not address the problem that changing `API_BASE_URL` environment variable after importing kolena will not take effect.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
