### PR TITLE
Idempotent PyPI publishing in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,16 +65,18 @@ jobs:
           aws s3 sync ./build "$BUCKET_PATH"
         working-directory: ./docs
 
-      # - name: Push 'kolena' dist to Test PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      #     repository-url: https://test.pypi.org/legacy/
+      - name: Push 'kolena' dist to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
-      # - name: Push 'kolena' dist to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Push 'kolena' dist to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true
 
       - name: Create GitHub release with 'kolena' build as artifact
         uses: marvinpinto/action-automatic-releases@v1.2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release
 
 on:
   push:
-    branches:
-      - gh/release-0.69.0
     tags:
       - "*"
 
@@ -113,6 +111,7 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
       - name: Push 'kolena-client' dist to production CodeArtifact for backward compatibility
         run: |
@@ -123,3 +122,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,6 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
-          files: |
-            ./dist/*.tar.gz
 
       #
       # backcompat: build and publish 'kolena-client' package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - gh/release-0.69.0
     tags:
       - "*"
 
@@ -63,21 +65,21 @@ jobs:
           aws s3 sync ./build "$BUCKET_PATH"
         working-directory: ./docs
 
-      - name: Push 'kolena' dist to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
+      # - name: Push 'kolena' dist to Test PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      #     repository-url: https://test.pypi.org/legacy/
 
-      - name: Push 'kolena' dist to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      # - name: Push 'kolena' dist to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Create GitHub release with 'kolena' build as artifact
         uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
-          repo_token: ${{ secrets.RELEASE_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
           files: |
             ./dist/*.tar.gz


### PR DESCRIPTION
Add `skip-existing: true` to each PyPI publish in `release.yml` to make this job rerunnable. Also use stock `GITHUB_TOKEN` for `action-automatic-release`.