### PR TITLE
Remove superfluous 'permissions' block in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
+          automatic_release_tag: latest
 
       - name: Fail
         run: exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ jobs:
     env:
       ASSET_BUCKET: kolena-client-assets
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -86,7 +83,7 @@ jobs:
       # backcompat: build and publish 'kolena-client' package
       #
 
-      - name: Build 'kolena-client' package for backward compatibility
+      - name: "[backcompat] Build 'kolena-client' package"
         run: |
           rm -rf ./dist
 
@@ -96,27 +93,27 @@ jobs:
           poetry install
           poetry build --format=sdist
 
-      - name: Install twine for package distribution on CodeArtifact for backward compatibility
+      - name: "[backcompat] Install twine for package distribution on CodeArtifact"
         run: pip install twine
 
-      - name: Push 'kolena-client' dist to trunk CodeArtifact for backward compatibility
+      - name: "[backcompat] Push 'kolena-client' dist to trunk CodeArtifact"
         run: |
           aws codeartifact login --tool twine --domain trunk --domain-owner 328803196297 --repository kolena-client
           twine upload --skip-existing --repository codeartifact ./dist/kolena_client*
 
-      - name: Push 'kolena-client' dist to Test PyPI for backward compatibility
+      - name: "[backcompat] Push 'kolena-client' dist to Test PyPI"
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
 
-      - name: Push 'kolena-client' dist to production CodeArtifact for backward compatibility
+      - name: "[backcompat] Push 'kolena-client' dist to production CodeArtifact"
         run: |
           aws codeartifact login --tool twine --domain production --domain-owner 328803196297 --repository kolena-client
           twine upload --skip-existing --repository codeartifact ./dist/kolena_cilent*
 
-      - name: Push 'kolena-client' dist to PyPI for backward compatibility
+      - name: "[backcompat] Push 'kolena-client' dist to PyPI"
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
 
-      - name: Create GitHub release with 'kolena' build as artifact
+      - name: Create GitHub release
         uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,6 @@ name: Release
 
 on:
   push:
-    # TODO: remove me
-    branches:
-      - gh/permissions
     tags:
       - "*"
 
@@ -17,17 +14,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-
-      # TODO: remove me
-      - name: Create GitHub release
-        uses: marvinpinto/action-automatic-releases@v1.2.1
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: false
-          automatic_release_tag: latest
-
-      - name: Fail
-        run: exit 1
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: Release
 
 on:
   push:
+    # TODO: remove me
+    branches:
+      - gh/permissions
     tags:
       - "*"
 
@@ -14,6 +17,16 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+
+      # TODO: remove me
+      - name: Create GitHub release
+        uses: marvinpinto/action-automatic-releases@v1.2.1
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: false
+
+      - name: Fail
+        run: exit 1
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Debugging `release.yml` CI — latest run seems to have [successfully created a release](https://github.com/kolenaIO/kolena/actions/runs/4997889675/jobs/8952729856) that I then went and manually deleted.