### PR TITLE
Logging improvements

### DIFF
--- a/examples/text_summarization/text_summarization/evaluator.py
+++ b/examples/text_summarization/text_summarization/evaluator.py
@@ -182,7 +182,7 @@ def evaluate_text_summarization(
     ]
 
     all_test_case_metrics: List[Tuple[TestCase, TestCaseMetric]] = []
-    all_test_case_plots: List[Tuple[TestCase, Plot]] = []
+    all_test_case_plots: List[Tuple[TestCase, List[Plot]]] = []
     for test_case, tc_test_samples, tc_gts, tc_infs, tc_ts_metrics in test_cases.iter(
         test_samples,
         ground_truths,

--- a/kolena/detection/_internal/model.py
+++ b/kolena/detection/_internal/model.py
@@ -149,7 +149,7 @@ class BaseModel(ABC, Frozen, WithTelemetry):
             endpoint_path=API.Path.INIT_LOAD_INFERENCES.value,
             df_class=self._LoadInferencesDataFrameClass,
         )
-        log.success(f"loaded inferences from model '{self.name}' on {test_object_display_name}")
+        log.info(f"loaded inferences from model '{self.name}' on {test_object_display_name}")
 
     @validate_arguments(config=ValidatorConfig)
     def load_inferences_by_test_case(
@@ -181,7 +181,7 @@ class BaseModel(ABC, Frozen, WithTelemetry):
             endpoint_path=API.Path.INIT_LOAD_INFERENCES_BY_TEST_CASE.value,
             df_class=self._LoadInferencesDataFrameClass,
         )
-        log.success(f"loaded inferences from model '{self.name}' on test suite '{test_suite.name}'")
+        log.info(f"loaded inferences from model '{self.name}' on test suite '{test_suite.name}'")
 
     @abstractmethod
     def _inferences_from_record(self, record: Any) -> Tuple[_TestImageClass, Optional[List[_InferenceClass]]]:

--- a/kolena/detection/_internal/test_case.py
+++ b/kolena/detection/_internal/test_case.py
@@ -179,7 +179,7 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
         ):
             for record in df.itertuples():
                 yield self._TestImageClass._from_record(record)
-        log.success(f"loaded test images for test case '{self.name}'")
+        log.info(f"loaded test images for test case '{self.name}'")
 
     @classmethod
     def create(

--- a/kolena/detection/_internal/test_case.py
+++ b/kolena/detection/_internal/test_case.py
@@ -131,9 +131,9 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
         krequests.raise_for_status(res)
         data = from_dict(data_class=CoreAPI.EntityData, data=res.json())
         obj = cls._create_from_data(data)
+        log.info(f"created test case '{name}'")
         if images is not None:
             obj._hydrate(images)
-        log.info(f"created test case '{name}'")
         return obj
 
     @classmethod

--- a/kolena/detection/_internal/test_case.py
+++ b/kolena/detection/_internal/test_case.py
@@ -131,7 +131,7 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
         krequests.raise_for_status(res)
         data = from_dict(data_class=CoreAPI.EntityData, data=res.json())
         obj = cls._create_from_data(data)
-        log.info(f"created test case '{name}'")
+        log.info(f"created test case '{name}' (v{obj.version})")
         if images is not None:
             obj._hydrate(images)
         return obj
@@ -143,8 +143,9 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
         request = CoreAPI.LoadByNameRequest(name=name, version=version)
         res = krequests.put(endpoint_path=API.Path.LOAD_BY_NAME.value, data=json.dumps(dataclasses.asdict(request)))
         krequests.raise_for_status(res)
-        log.info(f"loaded test case '{name}'")
-        return from_dict(data_class=CoreAPI.EntityData, data=res.json())
+        obj = from_dict(data_class=CoreAPI.EntityData, data=res.json())
+        log.info(f"loaded test case '{name}' (v{obj.version})")
+        return obj
 
     @validate_arguments(config=ValidatorConfig)
     def _hydrate(self, images: List[_TestImageClass], description: Optional[str] = None) -> None:
@@ -170,7 +171,7 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
     @validate_arguments(config=ValidatorConfig)
     def iter_images(self) -> Iterator[_TestImageClass]:
         """Iterate through all images with their associated ground truths in this test case."""
-        log.info(f"loading test images for test case '{self.name}'")
+        log.info(f"loading test images for test case '{self.name}' (v{self.version})")
         init_request = CoreAPI.InitLoadContentsRequest(batch_size=BatchSize.LOAD_SAMPLES.value, test_case_id=self._id)
         for df in _BatchedLoader.iter_data(
             init_request=init_request,
@@ -179,7 +180,7 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
         ):
             for record in df.itertuples():
                 yield self._TestImageClass._from_record(record)
-        log.info(f"loaded test images for test case '{self.name}'")
+        log.info(f"loaded test images for test case '{self.name}' (v{self.version})")
 
     @classmethod
     def create(
@@ -306,7 +307,7 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
         if not editor._edited:
             return
 
-        log.info(f"editing test case '{self.name}'")
+        log.info(f"editing test case '{self.name}' (v{self.version})")
         init_response = init_upload()
         df = self._to_data_frame(list(editor._images.values()))
         df_serialized = df.as_serializable()
@@ -326,4 +327,4 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
         krequests.raise_for_status(complete_res)
         test_case_data = from_dict(data_class=CoreAPI.EntityData, data=complete_res.json())
         self._populate_from_other(self._create_from_data(test_case_data))
-        log.success(f"edited test case '{self.name}'")
+        log.success(f"edited test case '{self.name}' (v{self.version})")

--- a/kolena/detection/_internal/test_run.py
+++ b/kolena/detection/_internal/test_run.py
@@ -54,6 +54,7 @@ from kolena.detection._internal.model import SampleInferences
 from kolena.errors import CustomMetricsException
 from kolena.errors import IncorrectUsageError
 from kolena.errors import InputValidationError
+from kolena.errors import WorkflowMismatchError
 
 _ImageDataFrame = Union[pa.typing.DataFrame, LoadableDataFrame]
 InferenceType = TypeVar("InferenceType")
@@ -83,14 +84,14 @@ class BaseTestRun(ABC, Frozen, WithTelemetry):
         reset: bool = False,
     ):
         if model._workflow != test_suite._workflow:
-            raise ValueError(
+            raise WorkflowMismatchError(
                 f"mismatching test suite workflow for model of type '{model._workflow}': '{test_suite._workflow}'",
             )
 
         if reset:
             log.warn("overwriting existing inferences from this model (reset=True)")
         else:
-            log.info("reset flag is disabled. update existing inferences by enabling the reset flag")
+            log.info("not overwriting any existing inferences from this model (reset=False)")
 
         request = API.CreateOrRetrieveRequest(
             model_id=model._id,

--- a/kolena/detection/_internal/test_run.py
+++ b/kolena/detection/_internal/test_run.py
@@ -164,9 +164,7 @@ class BaseTestRun(ABC, Frozen, WithTelemetry):
             self._inferences[image_id] = context_image_inferences
 
         if self._n_inferences >= BatchSize.UPLOAD_RESULTS.value:
-            log.info(f"uploading batch of '{self._n_inferences}' inference results")
             self._upload_chunk()
-            log.success(f"uploaded batch of '{self._n_inferences}' inference results")
 
     @validate_arguments(config=ValidatorConfig)
     def iter_images(self) -> Iterator[_TestImageClass]:
@@ -194,7 +192,7 @@ class BaseTestRun(ABC, Frozen, WithTelemetry):
         except StopIteration:
             # no more images
             return []
-        log.success("loaded batch of images for test run")
+        log.info("loaded batch of images for test run")
         return [self._image_from_load_image_record(record) for record in df_image_batch.itertuples()]
 
     @validate_arguments(config=ValidatorConfig)
@@ -220,7 +218,8 @@ class BaseTestRun(ABC, Frozen, WithTelemetry):
         if self._n_inferences == 0:
             # Bail if this happens to being run by fencepost immediately after being run by add_inference
             return
-        log.info("streaming inference upload for test run")
+
+        log.info(f"uploading {self._n_inferences} inferences for test run")
         if self._upload_uuid is None:
             init_response = init_upload()
             self._upload_uuid = init_response.uuid
@@ -235,7 +234,7 @@ class BaseTestRun(ABC, Frozen, WithTelemetry):
         upload_data_frame_chunk(df_chunk_serializable, load_uuid=self._upload_uuid)
         self._n_inferences = 0
         self._inferences = OrderedDict()
-        log.success("streamed inference upload for test run")
+        log.success(f"uploaded {self._n_inferences} inferences for test run")
 
     def _finalize_upload(self) -> None:
         if self._upload_uuid is None:
@@ -292,7 +291,7 @@ class BaseTestRun(ABC, Frozen, WithTelemetry):
         if self._custom_metrics_callback is None:
             return
 
-        log.info("submitting custom metrics for test run")
+        log.info("computing and uploading custom metrics for test run")
         custom_metrics = self._compute_custom_metrics()
         request = API.UpdateCustomMetricsRequest(model_id=self._model._id, metrics=custom_metrics)
         res = krequests.put(
@@ -300,4 +299,4 @@ class BaseTestRun(ABC, Frozen, WithTelemetry):
             data=json.dumps(dataclasses.asdict(request)),
         )
         krequests.raise_for_status(res)
-        log.success("submitted custom metrics for test run")
+        log.success("computed and uploaded custom metrics for test run")

--- a/kolena/detection/_internal/test_suite.py
+++ b/kolena/detection/_internal/test_suite.py
@@ -116,7 +116,7 @@ class BaseTestSuite(ABC, Frozen, WithTelemetry):
         krequests.raise_for_status(res)
         data = from_dict(data_class=CoreAPI.TestSuite.EntityData, data=res.json())
         obj = cls._create_from_data(data)
-        log.info(f"created test suite '{name}' ({get_test_suite_url(obj._id)})")
+        log.info(f"created test suite '{name}' (v{obj.version}) ({get_test_suite_url(obj._id)})")
         if test_cases is not None:
             obj._hydrate(test_cases)
         return obj
@@ -182,7 +182,7 @@ class BaseTestSuite(ABC, Frozen, WithTelemetry):
         """
         data = cls._load_by_name(name, version)
         obj = cls._create_from_data(data)
-        log.info(f"loaded test suite '{name}' ({get_test_suite_url(obj._id)})")
+        log.info(f"loaded test suite '{name}' (v{obj.version}) ({get_test_suite_url(obj._id)})")
         return obj
 
     class Editor:
@@ -236,7 +236,7 @@ class BaseTestSuite(ABC, Frozen, WithTelemetry):
             """
             name = test_case.name
             if name not in self._test_cases.keys():
-                raise KeyError(f"test case '{name}' not in suite")
+                raise KeyError(f"test case '{name}' not in test suite")
             self._test_cases.pop(name)
 
         @deprecated(details="use :meth:`add` instead", deprecated_in="0.56.0")
@@ -289,7 +289,7 @@ class BaseTestSuite(ABC, Frozen, WithTelemetry):
             log.info("no op: nothing edited")
             return
 
-        log.info(f"edited test suite '{self.name}'")
+        log.info(f"edited test suite '{self.name}' (v{self.version})")
         request = CoreAPI.TestSuite.EditRequest(
             test_suite_id=self._id,
             current_version=self.version,
@@ -301,7 +301,7 @@ class BaseTestSuite(ABC, Frozen, WithTelemetry):
         res = krequests.post(endpoint_path=API.Path.EDIT.value, data=data)
         krequests.raise_for_status(res)
         test_suite_data = from_dict(data_class=CoreAPI.TestSuite.EntityData, data=res.json())
-        log.success(f"edited test suite '{self.name}' ({get_test_suite_url(test_suite_data.id)})")
+        log.success(f"edited test suite '{self.name}' (v{self.version}) ({get_test_suite_url(test_suite_data.id)})")
         with self._unfrozen():
             self.version = test_suite_data.version
             self.description = test_suite_data.description

--- a/kolena/detection/_internal/test_suite.py
+++ b/kolena/detection/_internal/test_suite.py
@@ -116,9 +116,9 @@ class BaseTestSuite(ABC, Frozen, WithTelemetry):
         krequests.raise_for_status(res)
         data = from_dict(data_class=CoreAPI.TestSuite.EntityData, data=res.json())
         obj = cls._create_from_data(data)
+        log.info(f"created test suite '{name}' ({get_test_suite_url(obj._id)})")
         if test_cases is not None:
             obj._hydrate(test_cases)
-        log.info(f"created test suite '{name}' ({get_test_suite_url(obj._id)})")
         return obj
 
     @classmethod

--- a/kolena/detection/_internal/test_suite.py
+++ b/kolena/detection/_internal/test_suite.py
@@ -289,7 +289,7 @@ class BaseTestSuite(ABC, Frozen, WithTelemetry):
             log.info("no op: nothing edited")
             return
 
-        log.info(f"edited test suite '{self.name}' (v{self.version})")
+        log.info(f"editing test suite '{self.name}' (v{self.version})")
         request = CoreAPI.TestSuite.EditRequest(
             test_suite_id=self._id,
             current_version=self.version,

--- a/kolena/fr/model.py
+++ b/kolena/fr/model.py
@@ -150,7 +150,7 @@ class Model(Uninstantiable["Model.Data"]):
             endpoint_path=API.Path.INIT_LOAD_PAIR_RESULTS.value,
             df_class=LoadedPairResultDataFrame,
         )
-        log.success(f"loaded pair results from model '{self.data.name}' on {test_object_display_name}")
+        log.info(f"loaded pair results from model '{self.data.name}' on {test_object_display_name}")
 
 
 class InferenceModel(Model):

--- a/kolena/fr/test_case.py
+++ b/kolena/fr/test_case.py
@@ -129,9 +129,9 @@ class TestCase(ABC, Frozen, WithTelemetry):
         krequests.raise_for_status(res)
         data = from_dict(data_class=API.EntityData, data=res.json())
         obj = cls._create_from_data(data)
+        log.info(f"created test case '{name}'")
         if test_samples is not None:
             obj._hydrate(test_samples)
-        log.info(f"created test case '{name}'")
         return obj
 
     @classmethod

--- a/kolena/fr/test_case.py
+++ b/kolena/fr/test_case.py
@@ -129,7 +129,7 @@ class TestCase(ABC, Frozen, WithTelemetry):
         krequests.raise_for_status(res)
         data = from_dict(data_class=API.EntityData, data=res.json())
         obj = cls._create_from_data(data)
-        log.info(f"created test case '{name}'")
+        log.info(f"created test case '{name}' (v{obj.version})")
         if test_samples is not None:
             obj._hydrate(test_samples)
         return obj
@@ -165,7 +165,7 @@ class TestCase(ABC, Frozen, WithTelemetry):
         res = krequests.put(endpoint_path=API.Path.LOAD_BY_NAME.value, data=json.dumps(dataclasses.asdict(request)))
         krequests.raise_for_status(res)
         data = from_dict(data_class=API.EntityData, data=res.json())
-        log.info(f"loaded test case '{name}'")
+        log.info(f"loaded test case '{name}' (v{data.version})")
         return cls._create_from_data(data)
 
     def load_data(self) -> TestCaseDataFrame:
@@ -312,7 +312,7 @@ class TestCase(ABC, Frozen, WithTelemetry):
         if not editor._edited():
             return
 
-        log.info(f"editing test case '{self.name}'")
+        log.info(f"editing test case '{self.name}' (v{self.version})")
         init_response = init_upload()
         df = pd.DataFrame(editor._samples.values(), columns=TEST_CASE_COLUMNS)
         df_validated = validate_df_schema(df, TestCaseDataFrameSchema)
@@ -332,7 +332,7 @@ class TestCase(ABC, Frozen, WithTelemetry):
         krequests.raise_for_status(complete_res)
         test_case_data = from_dict(data_class=API.EntityData, data=complete_res.json())
         self._populate_from_other(self._create_from_data(test_case_data))
-        log.success(f"edited test case '{self.name}'")
+        log.success(f"edited test case '{self.name}' (v{self.version})")
 
     @validate_arguments
     def iter_data(self, batch_size: int = 10_000_000) -> Iterator[TestCaseDataFrame]:
@@ -342,11 +342,11 @@ class TestCase(ABC, Frozen, WithTelemetry):
         :param batch_size: optionally specify maximum number of rows to be returned in a single DataFrame. By default,
             limits row count to 10_000_000.
         """
-        log.info(f"loading image pairs in test case '{self.name}'")
+        log.info(f"loading image pairs in test case '{self.name}' (v{self.version})")
         init_request = API.InitLoadDataRequest(batch_size=batch_size, test_case_id=self._id)
         yield from _BatchedLoader.iter_data(
             init_request=init_request,
             endpoint_path=API.Path.INIT_LOAD_DATA.value,
             df_class=TestCaseDataFrame,
         )
-        log.info(f"loaded image pairs in test case '{self.name}'")
+        log.info(f"loaded image pairs in test case '{self.name}' (v{self.version})")

--- a/kolena/fr/test_case.py
+++ b/kolena/fr/test_case.py
@@ -349,4 +349,4 @@ class TestCase(ABC, Frozen, WithTelemetry):
             endpoint_path=API.Path.INIT_LOAD_DATA.value,
             df_class=TestCaseDataFrame,
         )
-        log.success(f"loaded image pairs in test case '{self.name}'")
+        log.info(f"loaded image pairs in test case '{self.name}'")

--- a/kolena/fr/test_images.py
+++ b/kolena/fr/test_images.py
@@ -231,7 +231,7 @@ class TestImages(Uninstantiable[None]):
             endpoint_path=API.Path.INIT_LOAD_REQUEST.value,
             df_class=TestImageDataFrame,
         )
-        log.success(f"loaded test images{from_extra}")
+        log.info(f"loaded test images{from_extra}")
 
     @staticmethod
     def _data_source_display_name(

--- a/kolena/fr/test_run.py
+++ b/kolena/fr/test_run.py
@@ -79,7 +79,7 @@ class TestRun(ABC, Frozen, WithTelemetry):
         if reset:
             log.warn("overwriting existing inferences from this model (reset=True)")
         else:
-            log.info("reset flag is disabled. update existing inferences by enabling the reset flag")
+            log.info("not overwriting any existing inferences from this model (reset=False)")
 
         request = API.CreateOrRetrieveRequest(model_id=model.data.id, test_suite_ids=[test_suite._id], reset=reset)
         res = krequests.post(

--- a/kolena/fr/test_run.py
+++ b/kolena/fr/test_run.py
@@ -143,7 +143,7 @@ class TestRun(ABC, Frozen, WithTelemetry):
                     partial_response = from_dict(data_class=LoadAPI.InitDownloadPartialResponse, data=json.loads(line))
                     load_uuid = partial_response.uuid
                     dfs.append(_BatchedLoader.load_path(partial_response.path, ImageDataFrame))
-                log.success("loaded remaining images for test run")
+                log.info("loaded remaining images for test run")
                 return _BatchedLoader.concat(dfs, ImageDataFrame)
             finally:
                 _BatchedLoader.complete_load(load_uuid)
@@ -249,7 +249,7 @@ class TestRun(ABC, Frozen, WithTelemetry):
 
                 df_embedding = _BatchedLoader.concat(dfs_embedding, EmbeddingDataFrame)
                 df_pair = _BatchedLoader.concat(dfs_pair, PairDataFrame)
-                log.success("loaded batch of image pairs for test run")
+                log.info("loaded batch of image pairs for test run")
                 return df_embedding, df_pair
             finally:
                 for uuid in [load_uuid_embedding, load_uuid_pair]:

--- a/kolena/fr/test_suite.py
+++ b/kolena/fr/test_suite.py
@@ -128,8 +128,8 @@ class TestSuite(ABC, Frozen, WithTelemetry):
         krequests.raise_for_status(res)
         data = from_dict(data_class=API.EntityData, data=res.json())
         obj = cls._create_from_data(data)
-        obj._hydrate(baseline_test_cases, non_baseline_test_cases)
         log.info(f"created test suite '{name}' ({get_test_suite_url(obj._id)})")
+        obj._hydrate(baseline_test_cases, non_baseline_test_cases)
         return obj
 
     @classmethod

--- a/kolena/fr/test_suite.py
+++ b/kolena/fr/test_suite.py
@@ -128,7 +128,7 @@ class TestSuite(ABC, Frozen, WithTelemetry):
         krequests.raise_for_status(res)
         data = from_dict(data_class=API.EntityData, data=res.json())
         obj = cls._create_from_data(data)
-        log.info(f"created test suite '{name}' ({get_test_suite_url(obj._id)})")
+        log.info(f"created test suite '{name}' (v{obj.version}) ({get_test_suite_url(obj._id)})")
         obj._hydrate(baseline_test_cases, non_baseline_test_cases)
         return obj
 
@@ -164,7 +164,7 @@ class TestSuite(ABC, Frozen, WithTelemetry):
         res = krequests.put(endpoint_path=API.Path.LOAD_BY_NAME.value, data=json.dumps(dataclasses.asdict(request)))
         krequests.raise_for_status(res)
         obj = cls._create_from_data(from_dict(data_class=API.EntityData, data=res.json()))
-        log.info(f"loaded test suite '{name}' ({get_test_suite_url(obj._id)})")
+        log.info(f"loaded test suite '{name}' (v{obj.version}) ({get_test_suite_url(obj._id)})")
         return obj
 
     def _populate_from_other(self, other: "TestSuite") -> None:
@@ -280,7 +280,7 @@ class TestSuite(ABC, Frozen, WithTelemetry):
             elif name in self._non_baseline_test_cases.keys():
                 self._non_baseline_test_cases.pop(name)
             else:
-                raise KeyError(f"test case '{name}' not in suite")
+                raise KeyError(f"test case '{name}' not in test suite")
             self._edited = True
 
         @deprecated(details="use :meth:`add` instead", deprecated_in="0.57.0")
@@ -327,7 +327,7 @@ class TestSuite(ABC, Frozen, WithTelemetry):
         if not editor._edited:
             return
 
-        log.info(f"editing test suite '{self.name}'")
+        log.info(f"editing test suite '{self.name}' (v{self.version})")
         request = API.EditRequest(
             test_suite_id=self._id,
             current_version=self.version,
@@ -340,4 +340,4 @@ class TestSuite(ABC, Frozen, WithTelemetry):
         krequests.raise_for_status(res)
         test_suite_data = from_dict(data_class=API.EntityData, data=res.json())
         self._populate_from_other(self._create_from_data(test_suite_data))
-        log.success(f"edited test suite '{self.name}' ({get_test_suite_url(self._id)})")
+        log.success(f"edited test suite '{self.name}' (v{self.version}) ({get_test_suite_url(self._id)})")

--- a/kolena/workflow/evaluator_function.py
+++ b/kolena/workflow/evaluator_function.py
@@ -171,7 +171,7 @@ class _TestCases(TestCases):
         config_description = (
             f" {_configuration_description(self._wip_configuration)}" if self._wip_configuration else ""
         )
-        message = f"Computed metrics for test case {test_case.name}{config_description}"
+        message = f"computed metrics for test case {test_case.name}{config_description}"
         progress = self._n_test_cases_processed / self._n_test_cases_and_configurations
 
         log.info(message)

--- a/kolena/workflow/model.py
+++ b/kolena/workflow/model.py
@@ -169,7 +169,7 @@ class Model(Frozen, WithTelemetry, metaclass=ABCMeta):
                 ground_truth = self.workflow.ground_truth_type._from_dict(record.ground_truth)
                 inference = self.workflow.inference_type._from_dict(record.inference)
                 yield test_sample, ground_truth, inference
-        log.success(f"loaded inferences from model '{self.name}' on test case '{test_case.name}'")
+        log.info(f"loaded inferences from model '{self.name}' on test case '{test_case.name}'")
 
     @classmethod
     def _from_data_with_infer(

--- a/kolena/workflow/test_case.py
+++ b/kolena/workflow/test_case.py
@@ -204,7 +204,7 @@ class TestCase(Frozen, WithTelemetry, metaclass=ABCMeta):
                 test_sample = test_sample_type._from_dict({**record.test_sample, "metadata": metadata_field})
                 ground_truth = ground_truth_type._from_dict(record.ground_truth)
                 yield test_sample, ground_truth
-        log.success(f"loaded test samples in test case '{self.name}' (v{self.version})")
+        log.info(f"loaded test samples in test case '{self.name}' (v{self.version})")
 
     class Editor:
         @dataclass(frozen=True)

--- a/kolena/workflow/test_case.py
+++ b/kolena/workflow/test_case.py
@@ -161,9 +161,9 @@ class TestCase(Frozen, WithTelemetry, metaclass=ABCMeta):
         krequests.raise_for_status(res)
         data = from_dict(data_class=CoreAPI.EntityData, data=res.json())
         obj = cls._create_from_data(data)
+        log.info(f"created test case '{name}' (v{obj.version})")
         if test_samples is not None:
             obj._hydrate(test_samples)
-        log.info(f"created test case '{name}' (v{obj.version})")
         return obj
 
     @classmethod

--- a/kolena/workflow/test_run.py
+++ b/kolena/workflow/test_run.py
@@ -220,7 +220,7 @@ class TestRun(Frozen, WithTelemetry, metaclass=ABCMeta):
                 ground_truth = self.test_suite.workflow.ground_truth_type._from_dict(record.ground_truth)
                 inference = self.test_suite.workflow.inference_type._from_dict(record.inference)
                 yield test_sample, ground_truth, inference
-        log.success(f"loaded inferences from model '{self.model.name}' on test suite '{self.test_suite.name}'")
+        log.info(f"loaded inferences from model '{self.model.name}' on test suite '{self.test_suite.name}'")
 
     @validate_arguments(config=ValidatorConfig)
     def upload_inferences(self, inferences: List[Tuple[TestSample, Inference]]) -> None:

--- a/kolena/workflow/test_run.py
+++ b/kolena/workflow/test_run.py
@@ -123,7 +123,7 @@ class TestRun(Frozen, WithTelemetry, metaclass=ABCMeta):
         if reset:
             log.warn("overwriting existing inferences from this model (reset=True)")
         else:
-            log.info("reset flag is disabled. update existing inferences by enabling the reset flag")
+            log.info("not overwriting any existing inferences from this model (reset=False)")
 
         self.model = model
         self.test_suite = test_suite

--- a/kolena/workflow/test_suite.py
+++ b/kolena/workflow/test_suite.py
@@ -189,9 +189,9 @@ class TestSuite(Frozen, WithTelemetry, metaclass=ABCMeta):
         krequests.raise_for_status(res)
         data = from_dict(data_class=CoreAPI.EntityData, data=res.json())
         obj = cls._create_from_data(data)
+        log.info(f"created test suite '{name}' (v{obj.version}) ({get_test_suite_url(obj._id)})")
         if test_cases is not None:
             obj._hydrate(test_cases)
-        log.info(f"created test suite '{name}' (v{obj.version}) ({get_test_suite_url(obj._id)})")
         return obj
 
     @classmethod


### PR DESCRIPTION
- Log `created` before `edited` when creating+populating test cases/test suites
- Only use `log.success` (green) on actions that modify stored state — not for loads
- Improve clarity of test run `reset=False` logs
- Consistently include version in test case/test suite logs across workflows