### PR TITLE
Disregard GT ordering in builtin classification/detection TestImage equality

### DIFF
--- a/kolena/classification/test_image.py
+++ b/kolena/classification/test_image.py
@@ -102,3 +102,12 @@ class TestImage(BaseTestImage):
             ground_truths=[ClassificationLabel(label) for label in self.labels],
             metadata=self.metadata,
         )
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, type(self)):
+            return False
+        self_dict = self.__dict__.copy()
+        self_dict["labels"] = sorted(self_dict["labels"])
+        other_dict = other.__dict__.copy()
+        other_dict["labels"] = sorted(other_dict["labels"])
+        return self_dict == other_dict

--- a/kolena/classification/test_image.py
+++ b/kolena/classification/test_image.py
@@ -103,8 +103,7 @@ class TestImage(BaseTestImage):
             metadata=self.metadata,
         )
 
-    # TODO: remove when label ordering is ensured upstream -- Frozen.__eq__ is sufficient when ordering of self.labels
-    #  is consistent
+    # TODO: remove implementation in favor of Frozen.__eq__ once label ordering is ensured upstream
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, type(self)) and {**self.__dict__, "labels": sorted(self.labels)} == {
             **other.__dict__,

--- a/kolena/classification/test_image.py
+++ b/kolena/classification/test_image.py
@@ -103,11 +103,10 @@ class TestImage(BaseTestImage):
             metadata=self.metadata,
         )
 
-    def __eq__(self, other) -> bool:
-        if not isinstance(other, type(self)):
-            return False
-        self_dict = self.__dict__.copy()
-        self_dict["labels"] = sorted(self_dict["labels"])
-        other_dict = other.__dict__.copy()
-        other_dict["labels"] = sorted(other_dict["labels"])
-        return self_dict == other_dict
+    # TODO: remove when label ordering is ensured upstream -- Frozen.__eq__ is sufficient when ordering of self.labels
+    #  is consistent
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, type(self)) and {**self.__dict__, "labels": sorted(self.labels)} == {
+            **other.__dict__,
+            "labels": sorted(other.labels),
+        }

--- a/kolena/detection/_internal/test_case.py
+++ b/kolena/detection/_internal/test_case.py
@@ -216,6 +216,7 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
         Interface to edit a test case. Create with :meth:`TestCase.edit`.
         """
 
+        _TestImageClass: Type[BaseTestImage] = BaseTestImage
         _images: Dict[str, BaseTestImage]
         _reset: bool
         _description: str
@@ -241,7 +242,7 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
             self._edited = True
 
         @validate_arguments(config=ValidatorConfig)
-        def add(self, image: BaseTestImage) -> None:
+        def add(self, image: _TestImageClass) -> None:
             """
             Add a test image to the test case, targeting the ``ground_truths`` held by the image.
             When the test image already exists in the test case, its ground truth
@@ -258,7 +259,7 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
             self._edited = True
 
         @validate_arguments(config=ValidatorConfig)
-        def remove(self, image: BaseTestImage) -> None:
+        def remove(self, image: _TestImageClass) -> None:
             """
             Remove the image from the test case.
 
@@ -296,6 +297,7 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
         :param reset: clear any and all test samples currently in the test case.
         """
         editor = self.Editor(self.description, reset)
+        editor._TestImageClass = self._TestImageClass
         if not reset:
             for image in self.iter_images():
                 editor.add(image)

--- a/kolena/detection/test_image.py
+++ b/kolena/detection/test_image.py
@@ -83,13 +83,14 @@ class TestImage(BaseTestImage):
 
     # TODO: remove implementation in favor of Frozen.__eq__ once ground_truth ordering is ensured upstream
     def __eq__(self, other: Any) -> bool:
-        def sort_ground_truths(ground_truths: List[GroundTruth]) -> List[GroundTruth]:
-            return sorted(ground_truths, key=lambda gt: json.dumps(gt._to_dict(), sort_keys=True))
-
         return isinstance(other, type(self)) and {
             **self.__dict__,
-            "ground_truths": sort_ground_truths(self.ground_truths),
-        } == {**other.__dict__, "ground_truths": sort_ground_truths(other.ground_truths)}
+            "ground_truths": self._sort_ground_truths(self.ground_truths),
+        } == {**other.__dict__, "ground_truths": self._sort_ground_truths(other.ground_truths)}
+
+    @staticmethod
+    def _sort_ground_truths(ground_truths: List[GroundTruth]) -> List[GroundTruth]:
+        return sorted(ground_truths, key=lambda gt: json.dumps(gt._to_dict(), sort_keys=True))
 
 
 @deprecated(details="use :class:`kolena.detection.TestCase.load_images`", deprecated_in="0.26.0")

--- a/kolena/detection/test_image.py
+++ b/kolena/detection/test_image.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -79,6 +80,16 @@ class TestImage(BaseTestImage):
     @classmethod
     def _to_record(cls, image: "TestImage") -> Tuple[str, Optional[str], List[Dict[str, Any]], Dict[str, Any]]:
         return (image.locator, image.dataset, [gt._to_dict() for gt in image.ground_truths], _to_dict(image.metadata))
+
+    # TODO: remove implementation in favor of Frozen.__eq__ once ground_truth ordering is ensured upstream
+    def __eq__(self, other: Any) -> bool:
+        def sort_ground_truths(ground_truths: List[GroundTruth]) -> List[GroundTruth]:
+            return sorted(ground_truths, key=lambda gt: json.dumps(gt._to_dict(), sort_keys=True))
+
+        return isinstance(other, type(self)) and {
+            **self.__dict__,
+            "ground_truths": sort_ground_truths(self.ground_truths),
+        } == {**other.__dict__, "ground_truths": sort_ground_truths(other.ground_truths)}
 
 
 @deprecated(details="use :class:`kolena.detection.TestCase.load_images`", deprecated_in="0.26.0")

--- a/kolena/workflow/evaluator_function.py
+++ b/kolena/workflow/evaluator_function.py
@@ -171,7 +171,7 @@ class _TestCases(TestCases):
         config_description = (
             f" {_configuration_description(self._wip_configuration)}" if self._wip_configuration else ""
         )
-        message = f"computed metrics for test case {test_case.name}{config_description}"
+        message = f"Computed metrics for test case '{test_case.name}' (v{test_case.version}){config_description}"
         progress = self._n_test_cases_processed / self._n_test_cases_and_configurations
 
         log.info(message)

--- a/tests/integration/classification/test_test_case.py
+++ b/tests/integration/classification/test_test_case.py
@@ -21,6 +21,7 @@ from kolena.classification import TestImage
 from kolena.detection import TestCase as DetectionTestCase
 from kolena.errors import NotFoundError
 from kolena.errors import WorkflowMismatchError
+from tests.integration.detection.helper import assert_test_images_equal
 from tests.integration.helper import fake_random_locator
 from tests.integration.helper import with_test_prefix
 
@@ -50,8 +51,8 @@ def test__create__with_images(test_dataset: List[TestImage]) -> None:
     images = test_dataset
     test_case = TestCase.create(name, description, images)
     assert test_case.version == 1
-    assert images == test_case.load_images()
     assert test_case._workflow == WorkflowType.CLASSIFICATION
+    assert_test_images_equal(test_case.load_images(), images)
 
 
 def test__load() -> None:

--- a/tests/integration/detection/helper.py
+++ b/tests/integration/detection/helper.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import random
 from typing import List
 from typing import Tuple
 
 from kolena.detection import ground_truth
 from kolena.detection import inference
-from kolena.detection import TestImage
+from kolena.detection._internal import BaseTestImage
 
 fake_labels = [
     "car",
@@ -85,19 +84,9 @@ def fake_inference_segmentation_mask() -> inference.SegmentationMask:
     return inference.SegmentationMask(fake_label(), fake_confidence(), fake_points(random.randint(3, 15)))
 
 
-def assert_test_image_equal(a: TestImage, b: TestImage) -> None:
-    assert a.locator == b.locator
-    assert a.dataset == b.dataset
-    assert a.metadata == b.metadata
-    assert sorted(a.ground_truths, key=lambda x: json.dumps(x._to_dict(), sort_keys=True)) == sorted(
-        b.ground_truths,
-        key=lambda x: json.dumps(x._to_dict(), sort_keys=True),
-    )
-
-
-def assert_test_images_equal(actual: List[TestImage], expected: List[TestImage]) -> None:
+def assert_test_images_equal(actual: List[BaseTestImage], expected: List[BaseTestImage]) -> None:
     assert len(actual) == len(expected)
     actual = sorted(actual, key=lambda x: x.locator)
     expected = sorted(expected, key=lambda x: x.locator)
     for a, b in zip(actual, expected):
-        assert_test_image_equal(a, b)
+        assert a == b

--- a/tests/unit/classification/test_test_image.py
+++ b/tests/unit/classification/test_test_image.py
@@ -57,7 +57,7 @@ def test__test_image__serde() -> None:
         ),
         (
             TestImage(locator=TEST_LOCATOR, labels=["a", "b", "c"]),
-            TestImage(locator=TEST_LOCATOR, labels=["c", "a", "b"]),
+            TestImage(locator=TEST_LOCATOR, labels=["c", "a", "b"]),  # TODO: remove when label ordering is ensured
             True,
         ),
         (

--- a/tests/unit/classification/test_test_image.py
+++ b/tests/unit/classification/test_test_image.py
@@ -11,13 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
+
 import kolena.classification.metadata
 from kolena.classification import TestImage
+
+TEST_LOCATOR = "s3://test-bucket/path/to/file.png"
 
 
 def test__test_image__serde() -> None:
     original = TestImage(
-        locator="s3://test-bucket/path/to/file.png",
+        locator=TEST_LOCATOR,
         dataset="test-dataset",
         labels=["one", "2", "$3", "^4", "!@#$%^&*()"],
         metadata={
@@ -37,3 +41,56 @@ def test__test_image__serde() -> None:
 
     recovered = [TestImage._from_record(record) for record in df.itertuples()][0]
     assert original == recovered
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        (TestImage(locator=TEST_LOCATOR), TestImage(locator=TEST_LOCATOR), True),
+        (TestImage(locator=TEST_LOCATOR), TestImage(locator="s3://test-bucket/another/image.jpg"), False),
+        (TestImage(locator=TEST_LOCATOR, dataset="test"), TestImage(locator=TEST_LOCATOR, dataset="test"), True),
+        (TestImage(locator=TEST_LOCATOR, dataset="test"), TestImage(locator=TEST_LOCATOR, dataset="different"), False),
+        (
+            TestImage(locator=TEST_LOCATOR, labels=["a", "b", "c"]),
+            TestImage(locator=TEST_LOCATOR, labels=["a", "b", "c"]),
+            True,
+        ),
+        (
+            TestImage(locator=TEST_LOCATOR, labels=["a", "b", "c"]),
+            TestImage(locator=TEST_LOCATOR, labels=["c", "a", "b"]),
+            True,
+        ),
+        (
+            TestImage(locator=TEST_LOCATOR, labels=["a", "b", "c"]),
+            TestImage(locator=TEST_LOCATOR, labels=["a", "b"]),
+            False,
+        ),
+        (
+            TestImage(locator=TEST_LOCATOR, labels=["a", "b", "c"]),
+            TestImage(locator=TEST_LOCATOR),
+            False,
+        ),
+        (
+            TestImage(locator=TEST_LOCATOR, metadata=dict(a=1, b=True, c="c")),
+            TestImage(locator=TEST_LOCATOR, metadata=dict(a=1, b=True, c="c")),
+            True,
+        ),
+        (
+            TestImage(locator=TEST_LOCATOR, metadata=dict(a=1, b=True, c="c")),
+            TestImage(locator=TEST_LOCATOR, metadata=dict(b=True, c="c", a=1)),
+            True,
+        ),
+        (
+            TestImage(locator=TEST_LOCATOR, metadata=dict(a=1, b=True, c="c")),
+            TestImage(locator=TEST_LOCATOR, metadata=dict(b=True, c="c")),
+            False,
+        ),
+        (
+            TestImage(locator=TEST_LOCATOR, metadata=dict(a=1, b=True, c="c")),
+            TestImage(locator=TEST_LOCATOR),
+            False,
+        ),
+    ],
+)
+def test__test_image__equality(a: TestImage, b: TestImage, expected: bool) -> None:
+    assert (a == b) is expected


### PR DESCRIPTION
Addresses the red tests surfaced in #39. The ordering of classification `labels` and detection `ground_truths` is not critical, so it's acceptable to treat two test images with the same contents in a different order as equivalent.

This is intended to be a short-term fix while we work to ensure that this order is preserved upstream.