### PR TITLE
Only smoke test example integrations in CI

### DIFF
--- a/examples/age_estimation/tests/test_age_estimation.py
+++ b/examples/age_estimation/tests/test_age_estimation.py
@@ -19,7 +19,8 @@ from age_estimation.seed_test_suite import main as seed_test_suite_main
 
 
 def test__seed_test_suite() -> None:
-    seed_test_suite_main()
+    args = Namespace(dataset_csv="s3://kolena-public-datasets/labeled-faces-in-the-wild/meta/metadata.tiny5.csv")
+    seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__seed_test_suite"])

--- a/examples/age_estimation/tests/test_age_estimation.py
+++ b/examples/age_estimation/tests/test_age_estimation.py
@@ -18,12 +18,12 @@ from age_estimation.seed_test_run import main as seed_test_run_main
 from age_estimation.seed_test_suite import main as seed_test_suite_main
 
 
-def test__seed_test_suite() -> None:
+def test__seed_test_suite__smoke() -> None:
     args = Namespace(dataset_csv="s3://kolena-public-datasets/labeled-faces-in-the-wild/meta/metadata.tiny5.csv")
     seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__seed_test_suite"])
-def test__seed_test_run() -> None:
+def test__seed_test_run__smoke() -> None:
     args = Namespace(model="ssrnet", test_suites=["age :: labeled-faces-in-the-wild [age estimation]"])
     seed_test_run_main(args)

--- a/examples/age_estimation/tests/test_age_estimation.py
+++ b/examples/age_estimation/tests/test_age_estimation.py
@@ -23,7 +23,7 @@ def test__seed_test_suite__smoke() -> None:
     seed_test_suite_main(args)
 
 
-@pytest.mark.depends(on=["test__seed_test_suite"])
+@pytest.mark.depends(on=["test__seed_test_suite__smoke"])
 def test__seed_test_run__smoke() -> None:
     args = Namespace(model="ssrnet", test_suites=["age :: labeled-faces-in-the-wild [age estimation]"])
     seed_test_run_main(args)

--- a/examples/text_summarization/tests/test_text_summarization.py
+++ b/examples/text_summarization/tests/test_text_summarization.py
@@ -29,7 +29,7 @@ def with_init() -> Iterator[None]:
 
 
 def test__seed_test_suite() -> None:
-    args = Namespace(dataset_csv="s3://kolena-public-datasets/CNN-DailyMail/metadata/CNN_DailyMail_metadata_5.csv")
+    args = Namespace(dataset_csv="s3://kolena-public-datasets/CNN-DailyMail/metadata/metadata.tiny1.csv")
     seed_test_suite_main(args)
 
 

--- a/examples/text_summarization/tests/test_text_summarization.py
+++ b/examples/text_summarization/tests/test_text_summarization.py
@@ -11,21 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from argparse import Namespace
-from collections.abc import Iterator
 
 import pytest
-from text_summarization.seed_test_run import run as seed_test_run_main
-from text_summarization.seed_test_suite import run as seed_test_suite_main
-
-from kolena._utils.state import kolena_session
-
-
-@pytest.fixture(scope="session", autouse=True)
-def with_init() -> Iterator[None]:
-    with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
-        yield
+from text_summarization.seed_test_run import main as seed_test_run_main
+from text_summarization.seed_test_suite import main as seed_test_suite_main
 
 
 def test__seed_test_suite__smoke() -> None:
@@ -33,7 +23,7 @@ def test__seed_test_suite__smoke() -> None:
     seed_test_suite_main(args)
 
 
-@pytest.mark.depends(on=["test__seed_test_suite"])
+@pytest.mark.depends(on=["test__seed_test_suite__smoke"])
 def test__seed_test_run__smoke() -> None:
     args = Namespace(model="ada", test_suite="CNN-DailyMail :: text length", local_csv=None)
     seed_test_run_main(args)

--- a/examples/text_summarization/tests/test_text_summarization.py
+++ b/examples/text_summarization/tests/test_text_summarization.py
@@ -29,7 +29,7 @@ def with_init() -> Iterator[None]:
 
 
 def test__seed_test_suite() -> None:
-    args = Namespace(dataset_csv="s3://kolena-public-datasets/CNN-DailyMail/metadata/CNN_DailyMail_metadata_100.csv")
+    args = Namespace(dataset_csv="s3://kolena-public-datasets/CNN-DailyMail/metadata/CNN_DailyMail_metadata_5.csv")
     seed_test_suite_main(args)
 
 

--- a/examples/text_summarization/tests/test_text_summarization.py
+++ b/examples/text_summarization/tests/test_text_summarization.py
@@ -28,12 +28,12 @@ def with_init() -> Iterator[None]:
         yield
 
 
-def test__seed_test_suite() -> None:
+def test__seed_test_suite__smoke() -> None:
     args = Namespace(dataset_csv="s3://kolena-public-datasets/CNN-DailyMail/metadata/metadata.tiny1.csv")
     seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__seed_test_suite"])
-def test__seed_test_run() -> None:
+def test__seed_test_run__smoke() -> None:
     args = Namespace(model="ada", test_suite="CNN-DailyMail :: text length", local_csv=None)
     seed_test_run_main(args)

--- a/examples/text_summarization/text_summarization/seed_test_run.py
+++ b/examples/text_summarization/text_summarization/seed_test_run.py
@@ -138,7 +138,9 @@ def seed_test_run(
     test(model, test_suite, evaluate_text_summarization, reset=True)
 
 
-def run(args: Namespace) -> None:
+def main(args: Namespace) -> None:
+    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+
     mod = MODEL_MAP[args.model]
     print("loading inference CSV")
     s3_path = f"s3://kolena-public-datasets/CNN-DailyMail/results/{mod[0]}/results.csv"
@@ -167,7 +169,7 @@ def run(args: Namespace) -> None:
         seed_test_run(mod, test_suite, df_results)
 
 
-def main() -> None:
+if __name__ == "__main__":
     ap = ArgumentParser()
     ap.add_argument("model", type=str, choices=sorted(MODEL_MAP.keys()), help="The name of the model to test.")
     ap.add_argument(
@@ -180,11 +182,4 @@ def main() -> None:
         type=str,
         help="Optionally specify a local results CSV to use. Defaults to CSVs stored in S3 when absent.",
     )
-
-    args = ap.parse_args()
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
-    run(args)
-
-
-if __name__ == "__main__":
-    main()
+    main(ap.parse_args())

--- a/examples/text_summarization/text_summarization/seed_test_suite.py
+++ b/examples/text_summarization/text_summarization/seed_test_suite.py
@@ -191,7 +191,8 @@ def seed_test_suites(
     return None
 
 
-def run(args: Namespace) -> None:
+def main(args: Namespace) -> None:
+    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
     complete_tc = seed_complete_test_case(args)
 
     test_suite_names: Dict[str, Callable[[str, TestCase], TestSuite]] = {
@@ -203,7 +204,7 @@ def run(args: Namespace) -> None:
     seed_test_suites(test_suite_names, complete_tc)
 
 
-def main() -> None:
+if __name__ == "__main__":
     ap = ArgumentParser()
     ap.add_argument(
         "--dataset_csv",
@@ -212,10 +213,4 @@ def main() -> None:
         help="CSV file specifying dataset. See default CSV for details",
     )
 
-    args = ap.parse_args()
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
-    run(args)
-
-
-if __name__ == "__main__":
-    main()
+    main(ap.parse_args())


### PR DESCRIPTION
Pare down the datasets used by the `text_summarization` and `age_estimation` automated tests to just a handful of samples. This are really just smoke tests, and have been renamed as such.