### PR TITLE
Skip plotting early when computing roc curves for multi-class classification

### DIFF
--- a/kolena/classification/multiclass/evaluator.py
+++ b/kolena/classification/multiclass/evaluator.py
@@ -292,7 +292,7 @@ def _compute_test_case_metrics(
         macro_metrics_by_name[metric_name] = sum(metrics) / len(metrics)
 
     return TestCaseMetrics(
-        n_label=len(labels),
+        n_labels=len(labels),
         n_correct=n_correct,
         n_incorrect=n_incorrect,
         accuracy=accuracy,

--- a/kolena/classification/multiclass/workflow.py
+++ b/kolena/classification/multiclass/workflow.py
@@ -69,7 +69,7 @@ class AggregatedMetrics:
 
 @dataclass(frozen=True)
 class TestCaseMetrics(MetricsTestCase):
-    n_label: int
+    n_labels: int
     n_correct: int
     n_incorrect: int
     accuracy: float

--- a/kolena/classification/multiclass/workflow.py
+++ b/kolena/classification/multiclass/workflow.py
@@ -69,6 +69,7 @@ class AggregatedMetrics:
 
 @dataclass(frozen=True)
 class TestCaseMetrics(MetricsTestCase):
+    n_label: int
     n_correct: int
     n_incorrect: int
     accuracy: float


### PR DESCRIPTION
### Linked issue(s):
[KOL-2322](https://linear.app/kolena/issue/KOL-2322)

### What change does this PR introduce and why?
* Skip plotting early when computing roc curves for multi-class classification
* Added # of labels to TestCaseMetrics

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
