### PR TITLE
Add ScoredClassificationLabel to `kolena.workflow.annotation`

### DIFF
--- a/kolena/classification/multiclass/__init__.py
+++ b/kolena/classification/multiclass/__init__.py
@@ -15,6 +15,7 @@
 # noreorder
 from .workflow import TestSample
 from .workflow import GroundTruth
+from .workflow import InferenceLabel
 from .workflow import Inference
 from .workflow import TestCase
 from .workflow import TestSuite
@@ -27,6 +28,7 @@ from .test_run import test
 __all__ = [
     "TestSample",
     "GroundTruth",
+    "InferenceLabel",
     "Inference",
     "TestCase",
     "TestSuite",

--- a/kolena/classification/multiclass/__init__.py
+++ b/kolena/classification/multiclass/__init__.py
@@ -15,7 +15,6 @@
 # noreorder
 from .workflow import TestSample
 from .workflow import GroundTruth
-from .workflow import InferenceLabel
 from .workflow import Inference
 from .workflow import TestCase
 from .workflow import TestSuite
@@ -28,7 +27,6 @@ from .test_run import test
 __all__ = [
     "TestSample",
     "GroundTruth",
-    "InferenceLabel",
     "Inference",
     "TestCase",
     "TestSuite",

--- a/kolena/classification/multiclass/_utils.py
+++ b/kolena/classification/multiclass/_utils.py
@@ -14,14 +14,16 @@
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 import numpy as np
 
 from kolena._utils import log
+from kolena.classification.multiclass import InferenceLabel
 from kolena.workflow.annotation import ScoredClassificationLabel
 
 
-def get_label_confidence(label: str, inference_labels: List[ScoredClassificationLabel]) -> float:
+def get_label_confidence(label: str, inference_labels: List[Union[ScoredClassificationLabel, InferenceLabel]]) -> float:
     for inf_label in inference_labels:
         if inf_label.label == label:
             return inf_label.score

--- a/kolena/classification/multiclass/_utils.py
+++ b/kolena/classification/multiclass/_utils.py
@@ -18,13 +18,13 @@ from typing import Tuple
 import numpy as np
 
 from kolena._utils import log
-from kolena.classification.multiclass import InferenceLabel
+from kolena.workflow.annotation import ScoredClassificationLabel
 
 
-def get_label_confidence(label: str, inference_labels: List[InferenceLabel]) -> float:
+def get_label_confidence(label: str, inference_labels: List[ScoredClassificationLabel]) -> float:
     for inf_label in inference_labels:
         if inf_label.label == label:
-            return inf_label.confidence
+            return inf_label.score
     return 0
 
 

--- a/kolena/classification/multiclass/evaluator.py
+++ b/kolena/classification/multiclass/evaluator.py
@@ -145,9 +145,9 @@ def _compute_confidence_histograms(
     ]
 
     plots = [
-        _as_confidence_histogram("Confidence Distribution (All)", confidence_all, confidence_range),
-        _as_confidence_histogram("Confidence Distribution (Correct)", confidence_correct, confidence_range),
-        _as_confidence_histogram("Confidence Distribution (Incorrect)", confidence_incorrect, confidence_range),
+        _as_confidence_histogram("Score Distribution (All)", confidence_all, confidence_range),
+        _as_confidence_histogram("Score Distribution (Correct)", confidence_correct, confidence_range),
+        _as_confidence_histogram("Score Distribution (Incorrect)", confidence_incorrect, confidence_range),
     ]
     return plots
 

--- a/kolena/classification/multiclass/evaluator.py
+++ b/kolena/classification/multiclass/evaluator.py
@@ -31,7 +31,6 @@ from kolena.classification.multiclass._utils import roc_curve
 from kolena.classification.multiclass.workflow import AggregatedMetrics
 from kolena.classification.multiclass.workflow import GroundTruth
 from kolena.classification.multiclass.workflow import Inference
-from kolena.classification.multiclass.workflow import InferenceLabel
 from kolena.classification.multiclass.workflow import TestCase
 from kolena.classification.multiclass.workflow import TestCaseMetrics
 from kolena.classification.multiclass.workflow import TestSample
@@ -46,6 +45,7 @@ from kolena.workflow import EvaluationResults
 from kolena.workflow import Histogram
 from kolena.workflow import Plot
 from kolena.workflow import TestCases
+from kolena.workflow.annotation import ScoredClassificationLabel
 
 Result = Tuple[TestSample, GroundTruth, Inference]
 
@@ -63,13 +63,13 @@ def _compute_test_sample_metric(
     if len(inference.inferences) == 0:
         return empty_metrics
 
-    sorted_indices = np.argsort([label.confidence for label in inference.inferences])
+    sorted_indices = np.argsort([label.score for label in inference.inferences])
     match = inference.inferences[sorted_indices[-1]]
-    predicted_label, confidence_score = match.label, match.confidence
+    predicted_label, confidence_score = match.label, match.score
     margin: Optional[float] = None
     if len(sorted_indices) > 1:
-        second_closest: InferenceLabel = inference.inferences[sorted_indices[-2]]
-        margin = confidence_score - second_closest.confidence
+        second_closest: ScoredClassificationLabel = inference.inferences[sorted_indices[-2]]
+        margin = confidence_score - second_closest.score
 
     if threshold_configuration.threshold is not None and confidence_score < threshold_configuration.threshold:
         return empty_metrics
@@ -136,12 +136,12 @@ def _compute_confidence_histograms(
         )
         return []
 
-    confidence_all = [mts.classification.confidence for mts in metrics if mts.classification is not None]
+    confidence_all = [mts.classification.score for mts in metrics if mts.classification is not None]
     confidence_correct = [
-        mts.classification.confidence for mts in metrics if mts.classification is not None and mts.is_correct
+        mts.classification.score for mts in metrics if mts.classification is not None and mts.is_correct
     ]
     confidence_incorrect = [
-        mts.classification.confidence for mts in metrics if mts.classification is not None and not mts.is_correct
+        mts.classification.score for mts in metrics if mts.classification is not None and not mts.is_correct
     ]
 
     plots = [
@@ -162,7 +162,7 @@ def _compute_test_case_plots(
     confidence_range: Optional[Tuple[float, float, int]],
 ) -> List[Plot]:
     gt_labels = {gt.classification.label for gt in ground_truths}
-    plots = [
+    plots: List[Plot] = [
         _as_class_metric_plot(field.name, metrics_by_label, labels)
         for field in dataclasses.fields(AggregatedMetrics)
         if len(gt_labels) > 2
@@ -362,7 +362,7 @@ def MulticlassClassificationEvaluator(
         for ts, gt, inf in zip(test_samples, ground_truths, inferences)
     ]
     test_sample_metrics: List[TestSampleMetrics] = [mts for _, mts in metrics_test_sample]
-    confidence_scores = [mts.classification.confidence for mts in test_sample_metrics if mts.classification is not None]
+    confidence_scores = [mts.classification.score for mts in test_sample_metrics if mts.classification is not None]
     confidence_range = get_histogram_range(confidence_scores)
 
     metrics_test_case: List[Tuple[TestCase, TestCaseMetrics]] = []

--- a/kolena/classification/multiclass/evaluator.py
+++ b/kolena/classification/multiclass/evaluator.py
@@ -21,6 +21,7 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 from typing import Type
+from typing import Union
 
 import numpy as np
 
@@ -31,6 +32,7 @@ from kolena.classification.multiclass._utils import roc_curve
 from kolena.classification.multiclass.workflow import AggregatedMetrics
 from kolena.classification.multiclass.workflow import GroundTruth
 from kolena.classification.multiclass.workflow import Inference
+from kolena.classification.multiclass.workflow import InferenceLabel
 from kolena.classification.multiclass.workflow import TestCase
 from kolena.classification.multiclass.workflow import TestCaseMetrics
 from kolena.classification.multiclass.workflow import TestSample
@@ -68,7 +70,7 @@ def _compute_test_sample_metric(
     predicted_label, confidence_score = match.label, match.score
     margin: Optional[float] = None
     if len(sorted_indices) > 1:
-        second_closest: ScoredClassificationLabel = inference.inferences[sorted_indices[-2]]
+        second_closest: Union[ScoredClassificationLabel, InferenceLabel] = inference.inferences[sorted_indices[-2]]
         margin = confidence_score - second_closest.score
 
     if threshold_configuration.threshold is not None and confidence_score < threshold_configuration.threshold:

--- a/kolena/classification/multiclass/workflow.py
+++ b/kolena/classification/multiclass/workflow.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 from typing import List
 from typing import Optional
+from typing import Union
 
+from deprecation import deprecated
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 
@@ -41,8 +43,26 @@ class GroundTruth(BaseGroundTruth):
 
 
 @dataclass(frozen=True)
+class InferenceLabel(ClassificationLabel):
+    """
+    :class:`InferenceLabel` is deprecated and preserved for compatibility only. Please use
+    :class:`ScoredClassificationLabel` instead.
+    """
+
+    confidence: float
+
+    @deprecated(details="use :class:`kolena.workflow.annotation.ScoredClassificationLabel`", deprecated_in="0.70.0")
+    def __post_init__(self) -> None:
+        ...
+
+    @property
+    def score(self) -> float:
+        return self.confidence
+
+
+@dataclass(frozen=True)
 class Inference(BaseInference):
-    inferences: List[ScoredClassificationLabel]
+    inferences: List[Union[ScoredClassificationLabel, InferenceLabel]]
 
 
 _workflow, TestCase, TestSuite, Model = define_workflow("Multiclass Classification", TestSample, GroundTruth, Inference)
@@ -50,7 +70,7 @@ _workflow, TestCase, TestSuite, Model = define_workflow("Multiclass Classificati
 
 @dataclass(frozen=True)
 class TestSampleMetrics(MetricsTestSample):
-    classification: Optional[ScoredClassificationLabel]
+    classification: Optional[Union[ScoredClassificationLabel, InferenceLabel]]
     margin: Optional[float]
     is_correct: bool
 

--- a/kolena/classification/multiclass/workflow.py
+++ b/kolena/classification/multiclass/workflow.py
@@ -27,6 +27,7 @@ from kolena.workflow import MetricsTestCase
 from kolena.workflow import MetricsTestSample
 from kolena.workflow import MetricsTestSuite
 from kolena.workflow.annotation import ClassificationLabel
+from kolena.workflow.annotation import ScoredClassificationLabel
 
 
 @dataclass(frozen=True)
@@ -40,13 +41,8 @@ class GroundTruth(BaseGroundTruth):
 
 
 @dataclass(frozen=True)
-class InferenceLabel(ClassificationLabel):
-    confidence: float
-
-
-@dataclass(frozen=True)
 class Inference(BaseInference):
-    inferences: List[InferenceLabel]
+    inferences: List[ScoredClassificationLabel]
 
 
 _workflow, TestCase, TestSuite, Model = define_workflow("Multiclass Classification", TestSample, GroundTruth, Inference)
@@ -54,7 +50,7 @@ _workflow, TestCase, TestSuite, Model = define_workflow("Multiclass Classificati
 
 @dataclass(frozen=True)
 class TestSampleMetrics(MetricsTestSample):
-    classification: Optional[InferenceLabel]
+    classification: Optional[ScoredClassificationLabel]
     margin: Optional[float]
     is_correct: bool
 

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -247,16 +247,30 @@ class ClassificationLabel(Annotation):
         return _AnnotationType.CLASSIFICATON_LABEL
 
 
+@dataclass(frozen=True, config=ValidatorConfig)
+class ScoredClassificationLabel(ClassificationLabel):
+    """Classification label with accompanying score."""
+
+    score: float
+
+
 _ANNOTATION_TYPES = [
     BoundingBox,
     LabeledBoundingBox,
+    ScoredBoundingBox,
+    ScoredLabeledBoundingBox,
     Polygon,
     LabeledPolygon,
+    ScoredPolygon,
+    ScoredLabeledPolygon,
     Keypoints,
     Polyline,
     BoundingBox3D,
     LabeledBoundingBox3D,
+    ScoredBoundingBox3D,
+    ScoredLabeledBoundingBox3D,
     SegmentationMask,
     BitmapMask,
     ClassificationLabel,
+    ScoredClassificationLabel,
 ]

--- a/tests/integration/classification/multiclass/test_workflow.py
+++ b/tests/integration/classification/multiclass/test_workflow.py
@@ -15,13 +15,13 @@ import random
 
 from kolena.classification.multiclass import GroundTruth
 from kolena.classification.multiclass import Inference
-from kolena.classification.multiclass import InferenceLabel
 from kolena.classification.multiclass import Model
 from kolena.classification.multiclass import test
 from kolena.classification.multiclass import TestCase
 from kolena.classification.multiclass import TestSample
 from kolena.classification.multiclass import TestSuite
 from kolena.workflow.annotation import ClassificationLabel
+from kolena.workflow.annotation import ScoredClassificationLabel
 from tests.integration.helper import fake_locator
 from tests.integration.helper import with_test_prefix
 
@@ -36,7 +36,7 @@ def test__multiclass_classification__smoke() -> None:
     def infer(_: TestSample) -> Inference:
         score = random.random()
         inferences = [("example", 1 - score), ("another", score / 2), ("third", score / 2)]
-        return Inference(inferences=[InferenceLabel(label=label, confidence=conf) for label, conf in inferences])
+        return Inference(inferences=[ScoredClassificationLabel(label=label, score=conf) for label, conf in inferences])
 
     model = Model(f"{name} model", infer=infer)
     test(model, test_suite)  # TODO: add detailed unit tests for MulticlassClassificationEvaluator


### PR DESCRIPTION
Similar to the other `Scored*` annotation definitions, this PR adds a builtin ScoredClassificationLabel annotation class to prevent the need to subclass and extend with `score` manually.

Fixes KOL-2372