### PR TITLE
Support multiple distributions per test case in `kolena.workflow.Histogram`

### DIFF
--- a/kolena/workflow/__init__.py
+++ b/kolena/workflow/__init__.py
@@ -35,7 +35,6 @@ from .evaluator import Plot
 from .evaluator import Curve
 from .evaluator import CurvePlot
 from .evaluator import ConfusionMatrix
-from .evaluator import HistogramDistribution
 from .evaluator import Histogram
 from .evaluator import BarPlot
 from .evaluator import MetricsTestCase
@@ -73,7 +72,6 @@ __all__ = [
     "Curve",
     "CurvePlot",
     "ConfusionMatrix",
-    "HistogramDistribution",
     "Histogram",
     "BarPlot",
     "MetricsTestCase",

--- a/kolena/workflow/__init__.py
+++ b/kolena/workflow/__init__.py
@@ -35,6 +35,7 @@ from .evaluator import Plot
 from .evaluator import Curve
 from .evaluator import CurvePlot
 from .evaluator import ConfusionMatrix
+from .evaluator import HistogramDistribution
 from .evaluator import Histogram
 from .evaluator import BarPlot
 from .evaluator import MetricsTestCase
@@ -72,6 +73,7 @@ __all__ = [
     "Curve",
     "CurvePlot",
     "ConfusionMatrix",
+    "HistogramDistribution",
     "Histogram",
     "BarPlot",
     "MetricsTestCase",

--- a/kolena/workflow/evaluator.py
+++ b/kolena/workflow/evaluator.py
@@ -173,8 +173,8 @@ class Histogram(Plot):
     #: specified in increasing order.
     buckets: NumberSeries
 
-    #: For ``n`` buckets, there are ``n`` frequencies corresponding to the height of each bucket. The ``n``th frequency
-    #: corresponds to the ``n``th bucket with bounds (``n``, ``n+1``) in ``buckets``.
+    #: For ``n`` buckets, there are ``n`` frequencies corresponding to the height of each bucket. The frequency at index
+    #: ``i`` corresponds to the bucket with bounds (``i``, ``i+1``) in ``buckets``.
     #:
     #: To specify multiple distributions for a given test case, multiple frequency series can be provided, corresponding
     #: e.g. to the distribution for a given class within a test case, with name specified in ``labels``.

--- a/kolena/workflow/evaluator.py
+++ b/kolena/workflow/evaluator.py
@@ -165,8 +165,8 @@ class HistogramDistribution(DataObject):
     frequency: NumberSeries
 
     #: Label applied to this distribution, e.g. the specific class within a given test case that this distribution
-    #: corresponds to.
-    label: Optional[str] = None
+    #: represents.
+    label: str
 
     def __post_init_post_parse__(self) -> None:
         _validate_histogram_data(self.buckets, self.frequency)

--- a/kolena/workflow/evaluator.py
+++ b/kolena/workflow/evaluator.py
@@ -21,6 +21,7 @@ from typing import Tuple
 from typing import Type
 from typing import Union
 
+import numpy as np
 from pydantic import validate_arguments
 from pydantic.dataclasses import dataclass
 from pydantic.typing import Literal
@@ -157,21 +158,6 @@ class CurvePlot(Plot):
 
 
 @dataclass(frozen=True, config=ValidatorConfig)
-class HistogramDistribution(DataObject):
-    """A single distribution on a :class:`Histogram`."""
-
-    buckets: NumberSeries
-    frequency: NumberSeries
-
-    #: Label applied to this distribution, e.g. the specific class within a given test case that this distribution
-    #: represents.
-    label: str
-
-    def __post_init_post_parse__(self) -> None:
-        _validate_histogram_data(self.buckets, self.frequency)
-
-
-@dataclass(frozen=True, config=ValidatorConfig)
 class Histogram(Plot):
     """
     A plot visualizing a histogram per test case.
@@ -194,8 +180,8 @@ class Histogram(Plot):
     #: e.g. to the distribution for a given class within a test case, with name specified in ``labels``.
     frequency: Union[NumberSeries, Sequence[NumberSeries]]
 
-    #: Optionally specify a list of labels corresponding to the different series in ``frequency`` when multiple series
-    #: are specified.
+    #: Specify a list of labels corresponding to the different ``frequency`` series when multiple series are provided.
+    #: Can be omitted when a single ``frequency`` series is provided.
     labels: Optional[List[str]] = None
 
     #: Custom format options to allow for control over the display of the plot axes.
@@ -203,13 +189,22 @@ class Histogram(Plot):
     y_config: Optional[AxisConfig] = None
 
     def __post_init_post_parse__(self) -> None:
-        if len(self.buckets) > 0 or len(self.frequency) > 0:
-            if len(self.distributions) > 0:
-                raise ValueError(
-                    "Invalid inputs: both 'buckets'/'frequency' and 'distribution' provided. "
-                    "To specify multiple distributions, use only the 'distributions' field.",
-                )
-            _validate_histogram_data(self.buckets, self.frequency)
+        n_buckets = len(self.buckets)
+        if n_buckets < 2:
+            raise ValueError(f"Minimum 2 entries required in 'buckets' series (length: {n_buckets})")
+        buckets_arr = np.array(self.buckets)
+        if not np.all(buckets_arr[1:] > buckets_arr[:-1]):  # validate strictly increasing
+            raise ValueError("Invalid 'buckets' series: series must be strictly increasing")
+
+        frequency_arr = np.array(self.frequency)
+        actual_frequency_shape = np.shape(frequency_arr)
+        if len(actual_frequency_shape) > 1 and self.labels is None:
+            raise ValueError("'labels' are required when multiple 'frequency' series are provided")
+
+        n_labels = len(self.labels or [])
+        expected_frequency_shape = (n_labels, n_buckets - 1) if n_labels > 0 else (n_buckets - 1,)
+        if actual_frequency_shape != expected_frequency_shape:
+            raise ValueError(f"Invalid 'frequency' shape {actual_frequency_shape}: expected {expected_frequency_shape}")
 
     @staticmethod
     def _data_type() -> _PlotType:
@@ -449,18 +444,3 @@ def _maybe_display_name(configuration: Optional[EvaluatorConfiguration]) -> Opti
 def _configuration_description(configuration: Optional[EvaluatorConfiguration]) -> str:
     display_name = _maybe_display_name(configuration)
     return f"(configuration: {display_name})" if display_name is not None else ""
-
-
-def _validate_histogram_data(buckets: NumberSeries, frequency: NumberSeries) -> None:
-    if len(frequency) + 1 != len(buckets):
-        raise ValueError(
-            f"Series 'frequency' (length: {len(frequency)}) should be 1 shorter than "
-            f"series 'buckets' (length: {len(buckets)})",
-        )
-
-    if len(frequency) == 0:
-        raise ValueError("Zero-length series 'frequency' provided")
-
-    for i in range(len(buckets) - 1):
-        if buckets[i] >= buckets[i + 1]:
-            raise ValueError(f"Invalid bucket at index ({i}, {i + 1}): ({buckets[i]}, {buckets[i + 1]})")

--- a/kolena/workflow/evaluator.py
+++ b/kolena/workflow/evaluator.py
@@ -456,6 +456,9 @@ def _validate_histogram_data(buckets: NumberSeries, frequency: NumberSeries) -> 
             f"series 'buckets' (length: {len(buckets)})",
         )
 
+    if len(frequency) == 0:
+        raise ValueError("Zero-length series 'frequency' provided")
+
     for i in range(len(buckets) - 1):
         if buckets[i] >= buckets[i + 1]:
             raise ValueError(f"Invalid bucket at index ({i}, {i + 1}): ({buckets[i]}, {buckets[i + 1]})")

--- a/kolena/workflow/evaluator.py
+++ b/kolena/workflow/evaluator.py
@@ -160,9 +160,10 @@ class CurvePlot(Plot):
 @dataclass(frozen=True, config=ValidatorConfig)
 class Histogram(Plot):
     """
-    A plot visualizing a histogram per test case.
+    A plot visualizing distribution of one or more continuous values, e.g. distribution of an error metric across all
+    samples within a test case.
 
-    Histograms allow for easy visualizations of data distributions.
+    For visualization of discrete values, see :class:`BarPlot`.
     """
 
     title: str

--- a/kolena/workflow/evaluator.py
+++ b/kolena/workflow/evaluator.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import dataclasses
 from abc import ABCMeta
 from abc import abstractmethod
 from typing import Any
@@ -184,17 +183,20 @@ class Histogram(Plot):
     x_label: str
     y_label: str
 
-    #: A Histogram requires intervals to bucket the data.
-    #: For ``n`` buckets, ``n+1`` consecutive bounds must be specified in increasing order.
-    buckets: NumberSeries = dataclasses.field(default_factory=list)
+    #: A Histogram requires intervals to bucket the data. For ``n`` buckets, ``n+1`` consecutive bounds must be
+    #: specified in increasing order.
+    buckets: NumberSeries
 
-    #: For ``n`` buckets, there are ``n`` frequencies that define each bucket's height.
-    #: The ``n``th frequency corresponds to the ``n``th bucket.
-    frequency: NumberSeries = dataclasses.field(default_factory=list)
+    #: For ``n`` buckets, there are ``n`` frequencies corresponding to the height of each bucket. The ``n``th frequency
+    #: corresponds to the ``n``th bucket with bounds (``n``, ``n+1``) in ``buckets``.
+    #:
+    #: To specify multiple distributions for a given test case, multiple frequency series can be provided, corresponding
+    #: e.g. to the distribution for a given class within a test case, with name specified in ``labels``.
+    frequency: Union[NumberSeries, Sequence[NumberSeries]]
 
-    #: Specify multiple distributions for a given test case. When only one distribution is desired, ``buckets`` and
-    #: ``frequency`` can be used directly.
-    distributions: List[HistogramDistribution] = dataclasses.field(default_factory=list)
+    #: Optionally specify a list of labels corresponding to the different series in ``frequency`` when multiple series
+    #: are specified.
+    labels: Optional[List[str]] = None
 
     #: Custom format options to allow for control over the display of the plot axes.
     x_config: Optional[AxisConfig] = None

--- a/tests/unit/workflow/test_plot.py
+++ b/tests/unit/workflow/test_plot.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
@@ -196,25 +197,56 @@ def test__histogram_distribution__validate__invalid(buckets: List[Any], frequenc
         HistogramDistribution(label="a", buckets=buckets, frequency=frequency)
 
 
-def test__histogram__serialize() -> None:
-    assert Histogram(
-        title="test",
-        x_label="x",
-        y_label="y",
-        buckets=[-3, -2, -1, 0, 1, 2, 3],
-        frequency=[0, 1, 2, 1, 4.4, 0.2],
-        y_config=AxisConfig(type="log"),
-    )._to_dict() == {
-        "title": "test",
-        "x_label": "x",
-        "y_label": "y",
-        "buckets": [-3, -2, -1, 0, 1, 2, 3],
-        "frequency": [0, 1, 2, 1, 4.4, 0.2],
-        "distributions": [],
-        "x_config": None,
-        "y_config": {"type": "log"},
-        "data_type": f"{_PlotType._data_category()}/{_PlotType.HISTOGRAM.value}",
-    }
+@pytest.mark.parametrize(
+    "histogram,serialized",
+    [
+        (
+            Histogram(
+                title="test",
+                x_label="x",
+                y_label="y",
+                buckets=[-3, -2, -1, 0, 1, 2, 3],
+                frequency=[0, 1, 2, 1, 4.4, 0.2],
+                y_config=AxisConfig(type="log"),
+            ),
+            {
+                "title": "test",
+                "x_label": "x",
+                "y_label": "y",
+                "buckets": [-3, -2, -1, 0, 1, 2, 3],
+                "frequency": [0, 1, 2, 1, 4.4, 0.2],
+                "distributions": [],
+                "x_config": None,
+                "y_config": {"type": "log"},
+                "data_type": f"{_PlotType._data_category()}/{_PlotType.HISTOGRAM.value}",
+            },
+        ),
+        (
+            Histogram(
+                title="test",
+                x_label="x",
+                y_label="y",
+                distributions=[
+                    HistogramDistribution(label="a", buckets=[1, 2, 3], frequency=[1, 2]),
+                ],
+                y_config=AxisConfig(type="log"),
+            ),
+            {
+                "title": "test",
+                "x_label": "x",
+                "y_label": "y",
+                "buckets": [],
+                "frequency": [],
+                "distributions": [{"label": "a", "buckets": [1, 2, 3], "frequency": [1, 2]}],
+                "x_config": None,
+                "y_config": {"type": "log"},
+                "data_type": f"{_PlotType._data_category()}/{_PlotType.HISTOGRAM.value}",
+            },
+        ),
+    ],
+)
+def test__histogram__serialize(histogram: Histogram, serialized: Dict[str, Any]) -> None:
+    assert histogram._to_dict() == serialized
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR extends the `kolena.workflow.Histogram` API object to support specifying multiple frequency distributions corresponding to e.g. different classes within a test case.