### PR TITLE
Support nested aggregate metrics in MetricsTestCase

### DIFF
--- a/kolena/workflow/_validators.py
+++ b/kolena/workflow/_validators.py
@@ -39,7 +39,11 @@ def assert_workflows_match(workflow_expected: str, workflow_provided: str) -> No
         )
 
 
-def validate_data_object_type(data_object_type: Type[DataObject]) -> None:
+def validate_data_object_type(
+    data_object_type: Type[DataObject],
+    supported_field_types: Optional[List[Type]] = None,
+    allow_lists: bool = True,
+) -> None:
     if not issubclass(data_object_type, DataObject):
         raise ValueError(f"'{data_object_type.__name__}' must extend {DataObject.__name__}")
 
@@ -49,18 +53,11 @@ def validate_data_object_type(data_object_type: Type[DataObject]) -> None:
     if fields is None:
         fields = {field.name: field.type for field in dataclasses.fields(data_object_type)}
     for field_name, field_type in fields.items():
-        validate_field(field_name, field_type)
+        validate_field(field_name, field_type, supported_field_types=supported_field_types, allow_lists=allow_lists)
 
 
 def validate_scalar_data_object_type(data_object_type: Type[DataObject]) -> None:
-    if not issubclass(data_object_type, DataObject):
-        raise ValueError(f"'{data_object_type.__name__}' must extend {DataObject.__name__}")
-
-    fields = getattr(data_object_type, "__annotations__", None)
-    if fields is None:
-        fields = {field.name: field.type for field in dataclasses.fields(data_object_type)}
-    for field_name, field_type in fields.items():
-        validate_field(field_name, field_type, supported_field_types=_SCALAR_TYPES, allow_lists=False)
+    validate_data_object_type(data_object_type, supported_field_types=_SCALAR_TYPES, allow_lists=False)
 
 
 def validate_field(

--- a/kolena/workflow/evaluator.py
+++ b/kolena/workflow/evaluator.py
@@ -71,7 +71,7 @@ class MetricsTestCase(DataObject, metaclass=ABCMeta):
     .. code-block:: python
 
         @dataclass(frozen=True)
-        class PerClassMetrics(DataObject):
+        class PerClassMetrics(MetricsTestCase):
             Precision: float
             Recall: float
             F1: float
@@ -430,8 +430,8 @@ def _validate_metrics_test_sample_type(metrics_test_sample_type: Type[MetricsTes
 def _validate_metrics_test_case_type(metrics_test_case_type: Type[DataObject]) -> None:
     validate_data_object_type(
         metrics_test_case_type,
-        supported_field_types=[_SCALAR_TYPES, List[DataObject]],
-        allow_lists=False,
+        supported_field_types=_SCALAR_TYPES,
+        supported_list_types=[MetricsTestCase],
     )
 
 

--- a/kolena/workflow/evaluator.py
+++ b/kolena/workflow/evaluator.py
@@ -38,7 +38,6 @@ from kolena.workflow._datatypes import DataObject
 from kolena.workflow._datatypes import DataType
 from kolena.workflow._datatypes import TypedDataObject
 from kolena.workflow._validators import get_data_object_field_types
-from kolena.workflow._validators import safe_issubclass
 from kolena.workflow._validators import validate_data_object_type
 from kolena.workflow._validators import validate_scalar_data_object_type
 
@@ -441,8 +440,9 @@ def _validate_metrics_test_case_type(metrics_test_case_type: Type[DataObject]) -
             continue
         # expand e.g. List[Union[MetricsA, MetricsB]] into [MetricsA, MetricsB]
         list_arg_types = [t for arg_type in get_args(field_type) for t in get_args(arg_type) or [arg_type]]
-        metrics_arg_types = [arg_type for arg_type in list_arg_types if safe_issubclass(arg_type, MetricsTestCase)]
-        for arg_type in metrics_arg_types:
+        for arg_type in list_arg_types:
+            if arg_type is None:
+                raise ValueError(f"Unsupported optional metrics object in field '{field_name}'")
             try:
                 validate_scalar_data_object_type(arg_type)
             except ValueError:

--- a/kolena/workflow/evaluator.py
+++ b/kolena/workflow/evaluator.py
@@ -32,6 +32,7 @@ from kolena.workflow import Inference
 from kolena.workflow import TestCase
 from kolena.workflow import TestSample
 from kolena.workflow import TestSuite
+from kolena.workflow._datatypes import _SCALAR_TYPES
 from kolena.workflow._datatypes import DataObject
 from kolena.workflow._datatypes import DataType
 from kolena.workflow._datatypes import TypedDataObject
@@ -63,6 +64,26 @@ class MetricsTestCase(DataObject, metaclass=ABCMeta):
 
     Test-case-level metrics are aggregate metrics like Precision, Recall, and F1 score. Any and all aggregate metrics
     that fit a workflow should be defined here.
+
+    ``MetricsTestCase`` supports nesting metrics objects, for e.g. reporting class-level metrics within a test case that
+    contains multiple classes. Example usage:
+
+    .. code-block:: python
+
+        @dataclass(frozen=True)
+        class PerClassMetrics(DataObject):
+            Precision: float
+            Recall: float
+            F1: float
+            AP: float
+
+        @dataclass(frozen=True)
+        class TestCaseMetrics(MetricsTestCase):
+            macro_Precision: float
+            macro_Recall: float
+            macro_F1: float
+            mAP: float
+            PerClass: List[PerClassMetrics]
     """
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -407,7 +428,11 @@ def _validate_metrics_test_sample_type(metrics_test_sample_type: Type[MetricsTes
 
 
 def _validate_metrics_test_case_type(metrics_test_case_type: Type[DataObject]) -> None:
-    validate_scalar_data_object_type(metrics_test_case_type)
+    validate_data_object_type(
+        metrics_test_case_type,
+        supported_field_types=[_SCALAR_TYPES, List[DataObject]],
+        allow_lists=False,
+    )
 
 
 def _validate_metrics_test_suite_type(metrics_test_suite_type: Type[DataObject]) -> None:

--- a/kolena/workflow/evaluator.py
+++ b/kolena/workflow/evaluator.py
@@ -74,6 +74,7 @@ class MetricsTestCase(DataObject, metaclass=ABCMeta):
 
         @dataclass(frozen=True)
         class PerClassMetrics(MetricsTestCase):
+            Class: str
             Precision: float
             Recall: float
             F1: float

--- a/kolena/workflow/ground_truth.py
+++ b/kolena/workflow/ground_truth.py
@@ -19,6 +19,7 @@ from kolena._utils.validators import ValidatorConfig
 from kolena.workflow import Composite
 from kolena.workflow import TestSample
 from kolena.workflow._datatypes import DataObject
+from kolena.workflow._validators import get_data_object_field_types
 from kolena.workflow._validators import safe_issubclass
 from kolena.workflow._validators import validate_data_object_type
 from kolena.workflow._validators import validate_field
@@ -75,7 +76,7 @@ def _validate_ground_truth_type(
     is_composite = issubclass(test_sample_type, Composite)
     composite_fields = _get_composite_fields(test_sample_type) if is_composite else []
 
-    for field_name, field_value in getattr(ground_truth_type, "__annotations__", {}).items():
+    for field_name, field_value in get_data_object_field_types(ground_truth_type).items():
         if field_name in composite_fields and safe_issubclass(field_value, DataObject):
             validate_data_object_type(field_value)
         else:

--- a/kolena/workflow/inference.py
+++ b/kolena/workflow/inference.py
@@ -19,6 +19,7 @@ from kolena._utils.validators import ValidatorConfig
 from kolena.workflow import Composite
 from kolena.workflow import TestSample
 from kolena.workflow._datatypes import DataObject
+from kolena.workflow._validators import get_data_object_field_types
 from kolena.workflow._validators import safe_issubclass
 from kolena.workflow._validators import validate_data_object_type
 from kolena.workflow._validators import validate_field
@@ -74,7 +75,7 @@ def _validate_inference_type(test_sample_type: Type[TestSample], inference_type:
     is_composite = issubclass(test_sample_type, Composite)
     composite_fields = _get_composite_fields(test_sample_type) if is_composite else []
 
-    for field_name, field_value in getattr(inference_type, "__annotations__", {}).items():
+    for field_name, field_value in get_data_object_field_types(inference_type).items():
         if field_name in composite_fields and safe_issubclass(field_value, DataObject):
             validate_data_object_type(field_value)
         else:

--- a/kolena/workflow/test_case.py
+++ b/kolena/workflow/test_case.py
@@ -44,6 +44,7 @@ from kolena.workflow import TestSample
 from kolena.workflow._datatypes import TestCaseEditorDataFrame
 from kolena.workflow._datatypes import TestSampleDataFrame
 from kolena.workflow._validators import assert_workflows_match
+from kolena.workflow.test_sample import _METADATA_KEY
 from kolena.workflow.workflow import Workflow
 
 
@@ -201,7 +202,7 @@ class TestCase(Frozen, WithTelemetry, metaclass=ABCMeta):
             has_metadata = "test_sample_metadata" in df.columns
             for record in df.itertuples():
                 metadata_field = record.test_sample_metadata if has_metadata else {}
-                test_sample = test_sample_type._from_dict({**record.test_sample, "metadata": metadata_field})
+                test_sample = test_sample_type._from_dict({**record.test_sample, _METADATA_KEY: metadata_field})
                 ground_truth = ground_truth_type._from_dict(record.ground_truth)
                 yield test_sample, ground_truth
         log.info(f"loaded test samples in test case '{self.name}' (v{self.version})")

--- a/kolena/workflow/test_sample.py
+++ b/kolena/workflow/test_sample.py
@@ -29,6 +29,7 @@ from pydantic.dataclasses import dataclass
 from kolena._utils.validators import ValidatorConfig
 from kolena.workflow._datatypes import DataType
 from kolena.workflow._datatypes import TypedDataObject
+from kolena.workflow._validators import get_data_object_field_types
 from kolena.workflow._validators import safe_issubclass
 from kolena.workflow._validators import validate_field
 from kolena.workflow._validators import validate_metadata_dict
@@ -242,10 +243,10 @@ def _validate_test_sample_type(test_sample_type: Type[TestSample], recurse: bool
 
     # TODO: this is structurally identical to implementation in validate_ground_truth_type and
     #  validate_metrics_test_sample_type -- share?
-    fields_by_name = copy.copy(getattr(test_sample_type, "__annotations__", {}))
+    fields_by_name = copy.copy(get_data_object_field_types(test_sample_type))
     is_composite = issubclass(test_sample_type, Composite)
     for field_name, field_value in fields_by_name.items():
-        if field_name == "metadata":
+        if field_name == _METADATA_KEY:
             validate_metadata_dict(field_value)
         # check composite test sample, keeping recurse to restrict 1-level composition for now
         elif is_composite and safe_issubclass(field_value, TestSample):
@@ -258,8 +259,8 @@ def _validate_test_sample_type(test_sample_type: Type[TestSample], recurse: bool
 
 def _get_composite_fields(test_sample_type: Type[TestSample]) -> List[str]:
     composite_fields = []
-    for k, v in getattr(test_sample_type, "__annotations__", {}).items():
-        if k != "metadata":
+    for k, v in get_data_object_field_types(test_sample_type).items():
+        if k != _METADATA_KEY:
             if safe_issubclass(v, TestSample):
                 composite_fields.append(k)
 

--- a/tests/unit/workflow/test_evaluator.py
+++ b/tests/unit/workflow/test_evaluator.py
@@ -165,7 +165,7 @@ def test__validate__metrics_test_suite__invalid_nested() -> None:
 
 def test__validate__metrics_test_case__valid_nested() -> None:
     @dataclasses.dataclass(frozen=True)
-    class Nested(DataObject):
+    class Nested(MetricsTestCase):
         a: int
         b: str
         c: float
@@ -182,31 +182,17 @@ def test__validate__metrics_test_case__valid_nested() -> None:
 
 def test__validate__metrics_test_case__invalid_nested() -> None:
     @dataclasses.dataclass(frozen=True)
-    class Nested(DataObject):  # only List[DataObject] is allowed
+    class Nested(MetricsTestCase):
         a: int
 
-    @dataclasses.dataclass(frozen=True)
-    class StructuredTester(DataObject):
-        a: BoundingBox
-        b: Polyline
+    with pytest.raises(ValueError):
 
-    @dataclasses.dataclass(frozen=True)
-    class DictTester(DataObject):
-        a: Dict[str, Any]
-
-    @dataclasses.dataclass(frozen=True)
-    class ListTester(DataObject):
-        a: List[float]
-
-    for NestedType in [StructuredTester, DictTester, ListTester]:
-        with pytest.raises(ValueError):
-
-            @dataclasses.dataclass(frozen=True)
-            class NestedTester(MetricsTestCase):
-                a: NestedType
+        @dataclasses.dataclass(frozen=True)
+        class NestedTester(MetricsTestCase):
+            a: Nested  # only List[MetricsTestCase] is allowed
 
     with pytest.raises(ValueError):
 
         @dataclasses.dataclass(frozen=True)
         class Nested2DListTester(MetricsTestCase):
-            a: List[List[NestedType]]  # only single List[DataObject] is allowed
+            a: List[List[Nested]]  # only single List[MetricsTestCase] is allowed

--- a/tests/unit/workflow/test_evaluator.py
+++ b/tests/unit/workflow/test_evaluator.py
@@ -19,6 +19,7 @@ from typing import Optional
 from typing import Type
 from typing import Union
 
+import pydantic
 import pytest
 
 from kolena.workflow._datatypes import DataObject
@@ -186,7 +187,7 @@ def test__validate__metrics_test_case__valid_nested() -> None:
         f: List[Union[Nested, Nested2]]
 
 
-def test__validate__metrics_test_case__invalid_nested() -> None:
+def test__validate__metrics_test_case__invalid_nested__single() -> None:
     @dataclasses.dataclass(frozen=True)
     class Nested(MetricsTestCase):
         a: int
@@ -197,11 +198,35 @@ def test__validate__metrics_test_case__invalid_nested() -> None:
         class NestedTester(MetricsTestCase):
             a: Nested  # only List[MetricsTestCase] is allowed
 
+
+def test__validate__metrics_test_case__invalid_nested__data_object() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class Nested(DataObject):
+        a: int
+
     with pytest.raises(ValueError):
 
         @dataclasses.dataclass(frozen=True)
+        class NestedTester(MetricsTestCase):
+            a: List[Nested]  # only List[MetricsTestCase] is allowed
+
+
+def test__validate__metrics_test_case__invalid_nested__list_list() -> None:
+    @pydantic.dataclasses.dataclass(frozen=True)
+    class Nested(MetricsTestCase):
+        a: int
+
+    with pytest.raises(ValueError):
+
+        @pydantic.dataclasses.dataclass(frozen=True)
         class Nested2DListTester(MetricsTestCase):
             a: List[List[Nested]]  # only single List[MetricsTestCase] is allowed
+
+
+def test__validate__metrics_test_case__invalid_nested__doubly_nested() -> None:
+    @pydantic.dataclasses.dataclass(frozen=True)
+    class Nested(MetricsTestCase):
+        a: int
 
     @dataclasses.dataclass(frozen=True)
     class NestedNested(MetricsTestCase):

--- a/tests/unit/workflow/test_evaluator.py
+++ b/tests/unit/workflow/test_evaluator.py
@@ -150,6 +150,8 @@ def test__validate__metrics_test_case_and_test_suite__invalid(base: Type[DataObj
         class ListTester(base):
             a: List[float]
 
+
+def test__validate__metrics_test_suite__invalid_nested() -> None:
     @dataclasses.dataclass(frozen=True)
     class Nested(DataObject):
         a: int
@@ -157,5 +159,54 @@ def test__validate__metrics_test_case_and_test_suite__invalid(base: Type[DataObj
     with pytest.raises(ValueError):
 
         @dataclasses.dataclass(frozen=True)
-        class NestedTester(base):
+        class NestedTester(MetricsTestSuite):
             a: Nested
+
+
+def test__validate__metrics_test_case__valid_nested() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class Nested(DataObject):
+        a: int
+        b: str
+        c: float
+        d: Optional[str]
+        e: Union[int, str, float]
+
+    @dataclasses.dataclass(frozen=True)
+    class NestedTester(MetricsTestCase):
+        a: int
+        b: float
+        c: List[Nested]
+        d: List[Nested]
+
+
+def test__validate__metrics_test_case__invalid_nested() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class Nested(DataObject):  # only List[DataObject] is allowed
+        a: int
+
+    @dataclasses.dataclass(frozen=True)
+    class StructuredTester(DataObject):
+        a: BoundingBox
+        b: Polyline
+
+    @dataclasses.dataclass(frozen=True)
+    class DictTester(DataObject):
+        a: Dict[str, Any]
+
+    @dataclasses.dataclass(frozen=True)
+    class ListTester(DataObject):
+        a: List[float]
+
+    for NestedType in [StructuredTester, DictTester, ListTester]:
+        with pytest.raises(ValueError):
+
+            @dataclasses.dataclass(frozen=True)
+            class NestedTester(MetricsTestCase):
+                a: NestedType
+
+    with pytest.raises(ValueError):
+
+        @dataclasses.dataclass(frozen=True)
+        class Nested2DListTester(MetricsTestCase):
+            a: List[List[NestedType]]  # only single List[DataObject] is allowed

--- a/tests/unit/workflow/test_evaluator.py
+++ b/tests/unit/workflow/test_evaluator.py
@@ -173,11 +173,17 @@ def test__validate__metrics_test_case__valid_nested() -> None:
         e: Union[int, str, float]
 
     @dataclasses.dataclass(frozen=True)
+    class Nested2(MetricsTestCase):
+        a: int
+
+    @dataclasses.dataclass(frozen=True)
     class NestedTester(MetricsTestCase):
         a: int
         b: float
         c: List[Nested]
-        d: List[Nested]
+        d: Optional[List[Nested]]
+        e: Union[List[Nested], List[Nested2]]
+        f: List[Union[Nested, Nested2]]
 
 
 def test__validate__metrics_test_case__invalid_nested() -> None:
@@ -196,3 +202,13 @@ def test__validate__metrics_test_case__invalid_nested() -> None:
         @dataclasses.dataclass(frozen=True)
         class Nested2DListTester(MetricsTestCase):
             a: List[List[Nested]]  # only single List[MetricsTestCase] is allowed
+
+    @dataclasses.dataclass(frozen=True)
+    class NestedNested(MetricsTestCase):
+        a: List[Nested]
+
+    with pytest.raises(ValueError):
+
+        @dataclasses.dataclass(frozen=True)
+        class Nested2DTester(MetricsTestCase):
+            a: List[NestedNested]  # only one layer of nesting allowed

--- a/tests/unit/workflow/test_evaluator.py
+++ b/tests/unit/workflow/test_evaluator.py
@@ -164,15 +164,16 @@ def test__validate__metrics_test_suite__invalid_nested() -> None:
             a: Nested
 
 
-def test__validate__metrics_test_case__valid_nested() -> None:
-    @dataclasses.dataclass(frozen=True)
-    class Nested(MetricsTestCase):
-        a: int
-        b: str
-        c: float
-        d: Optional[str]
-        e: Union[int, str, float]
+@dataclasses.dataclass(frozen=True)
+class Nested(MetricsTestCase):
+    a: int
+    b: str
+    c: float
+    d: Optional[str]
+    e: Union[int, str, float]
 
+
+def test__validate__metrics_test_case__valid_nested() -> None:
     @dataclasses.dataclass(frozen=True)
     class Nested2(MetricsTestCase):
         a: int
@@ -188,10 +189,6 @@ def test__validate__metrics_test_case__valid_nested() -> None:
 
 
 def test__validate__metrics_test_case__invalid_nested__single() -> None:
-    @dataclasses.dataclass(frozen=True)
-    class Nested(MetricsTestCase):
-        a: int
-
     with pytest.raises(ValueError):
 
         @dataclasses.dataclass(frozen=True)
@@ -201,7 +198,7 @@ def test__validate__metrics_test_case__invalid_nested__single() -> None:
 
 def test__validate__metrics_test_case__invalid_nested__data_object() -> None:
     @dataclasses.dataclass(frozen=True)
-    class Nested(DataObject):
+    class Nested(DataObject):  # note base class
         a: int
 
     with pytest.raises(ValueError):
@@ -211,11 +208,15 @@ def test__validate__metrics_test_case__invalid_nested__data_object() -> None:
             a: List[Nested]  # only List[MetricsTestCase] is allowed
 
 
-def test__validate__metrics_test_case__invalid_nested__list_list() -> None:
-    @pydantic.dataclasses.dataclass(frozen=True)
-    class Nested(MetricsTestCase):
-        a: int
+def test__validate__metrics_test_case__invalid_nested__optional() -> None:
+    with pytest.raises(ValueError):
 
+        @pydantic.dataclasses.dataclass(frozen=True)
+        class Nested2DListTester(MetricsTestCase):
+            a: Optional[Nested]  # only single List[MetricsTestCase] is allowed
+
+
+def test__validate__metrics_test_case__invalid_nested__list_list() -> None:
     with pytest.raises(ValueError):
 
         @pydantic.dataclasses.dataclass(frozen=True)
@@ -223,11 +224,15 @@ def test__validate__metrics_test_case__invalid_nested__list_list() -> None:
             a: List[List[Nested]]  # only single List[MetricsTestCase] is allowed
 
 
-def test__validate__metrics_test_case__invalid_nested__doubly_nested() -> None:
-    @pydantic.dataclasses.dataclass(frozen=True)
-    class Nested(MetricsTestCase):
-        a: int
+def test__validate__metrics_test_case__invalid_nested__list_optional() -> None:
+    with pytest.raises(ValueError):
 
+        @pydantic.dataclasses.dataclass(frozen=True)
+        class Nested2DListTester(MetricsTestCase):
+            a: List[Optional[Nested]]
+
+
+def test__validate__metrics_test_case__invalid_nested__doubly_nested() -> None:
     @dataclasses.dataclass(frozen=True)
     class NestedNested(MetricsTestCase):
         a: List[Nested]


### PR DESCRIPTION
Add the ability to nest `List[MetricsTestCase]` inside a `MetricsTestCase` object, supporting e.g. per-class metrics reported for multiple classes within a test case.

Fixes KOL-2408