### PR TITLE
Use legacy/xunit1 format for circleci

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -136,8 +136,8 @@ jobs:
               TESTFILES=$(find tests/integration/$TEST_GROUP -name "test_*.py" |
                 circleci tests split --split-by=timings --timings-type=filename)
             fi
-            poetry run pytest -vv --durations=0 --cov=kolena --cov-branch --junitxml=test-results/result.xml \
-              $TESTFILES
+            poetry run pytest -vv --durations=0 --cov=kolena --cov-branch -o junit_family=legacy \
+              --junitxml=test-results/result.xml $TESTFILES
       - when:
           # Generate coverage only from one python version
           condition:


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?

https://circleci.com/docs/troubleshoot-test-splitting/#are-you-setting-the-junit-family-in-your-pytest-ini

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
