### PR TITLE
Remove 'experimental.new-installer' from CI

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -157,7 +157,7 @@ jobs:
                 command: circleci-agent step halt
       - checkout
       - restore_cache:
-          key: ci-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
+          key: ci-cache-<< parameters.python-version >><< parameters.extras >>-{{ checksum "pyproject.toml" }}
       - run:
           name: Run << parameters.pytest-group >> integration tests
           command: |
@@ -221,41 +221,39 @@ workflows:
   ci:
     jobs:
       - ci-base:
-          name: ci-base-<< matrix.python-version >>-<< matrix.extras >>
+          name: ci-base-<< matrix.python-version >><< matrix.extras >>
           matrix:
             parameters:
               python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
-              extras: ["", "metrics"]
+              extras: ["", "-metrics"]
       - unit-test:
-          name: unit-test-<< matrix.python-version >>-<< matrix.extras >>
+          name: unit-test-<< matrix.python-version >><< matrix.extras >>
           matrix:
             parameters:
               python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
-              extras: ["", "metrics"]
+              extras: ["", "-metrics"]
           requires:
-            - ci-base-<< matrix.python-version >>-<< matrix.extras >>
+            - ci-base-<< matrix.python-version >><< matrix.extras >>
       - integration-test:
-          name: integration-test-<< matrix.pytest-group >>-<< matrix.python-version >>-<< matrix.extras >>
+          name: integration-test-<< matrix.pytest-group >>-<< matrix.python-version >>
           matrix:
             parameters:
               python-version: [ "3.9" ]
               pytest-group: [ detection, fr, classification, workflow ]
-              extras: [""]
           enabled: true
           parallelism: 4
           requires:
-            - ci-base-<< matrix.python-version >>-<< matrix.extras >>
+            - ci-base-<< matrix.python-version >>
       - integration-test:
           name: integration-test-misc-<< matrix.python-version >>-<< matrix.extras >>
           matrix:
             parameters:
               python-version: [ "3.9" ]
-              extras: [""]
           pytest-group: misc
           enabled: << pipeline.parameters.all >>
           parallelism: 1
           requires:
-            - ci-base-<< matrix.python-version >>-<< matrix.extras >>
+            - ci-base-<< matrix.python-version >>
   example:
     when:
       or: [ << pipeline.parameters.workflow >>, << pipeline.parameters.all >>, << pipeline.parameters.example >> ]

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -245,7 +245,7 @@ workflows:
           requires:
             - ci-base-<< matrix.python-version >>
       - integration-test:
-          name: integration-test-misc-<< matrix.python-version >>-<< matrix.extras >>
+          name: integration-test-misc-<< matrix.python-version >>
           matrix:
             parameters:
               python-version: [ "3.9" ]

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: ci-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
+          key: ci-cache-<< parameters.python-version >><< parameters.extras >>-{{ checksum "pyproject.toml" }}
       - run: poetry run python3 -c 'import kolena'
       # TODO: fix underlying mypy issues with Python>3.9 rather than skipping
       - when:
@@ -105,7 +105,7 @@ jobs:
                   poetry run pytest -m 'not metrics' -vv --cov=kolena --cov-branch tests/unit
       - when:
           condition:
-            equal: [ "metrics", << parameters.extras >> ]
+            equal: [ "-metrics", << parameters.extras >> ]
           steps:
             - run:
                 name: Run metrics unit tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -206,7 +206,6 @@ jobs:
       - checkout:
           path: ~/project
       - run: |
-          poetry config experimental.new-installer false
           poetry config installer.max-workers 10
           poetry install --no-ansi
       - run:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -51,7 +51,6 @@ jobs:
             - run:
                 name: Install Dependencies
                 command: |
-                  poetry config experimental.new-installer false
                   poetry config installer.max-workers 10
                   poetry install --no-ansi
       - when:
@@ -61,7 +60,6 @@ jobs:
             - run:
                 name: Install Dependencies
                 command: |
-                  poetry config experimental.new-installer false
                   poetry config installer.max-workers 10
                   poetry install --all-extras --no-ansi
       - save_cache:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: &ci-base-cache ci-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
+          key: &ci-base-cache ci-cache-<< parameters.python-version >><< parameters.extras >>-{{ checksum "pyproject.toml" }}
       - when:
           condition:
             equal: [ "", << parameters.extras >> ]
@@ -55,7 +55,7 @@ jobs:
                   poetry install --no-ansi
       - when:
           condition:
-            equal: [ "metrics", << parameters.extras >> ]
+            equal: [ "-metrics", << parameters.extras >> ]
           steps:
             - run:
                 name: Install Dependencies

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: &ci-base-cache ci-cache-<< parameters.python-version >><< parameters.extras >>-{{ checksum "pyproject.toml" }}
+          key: &ci-base-cache ci-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
       - when:
           condition:
             equal: [ "", << parameters.extras >> ]
@@ -55,7 +55,7 @@ jobs:
                   poetry install --no-ansi
       - when:
           condition:
-            equal: [ "-metrics", << parameters.extras >> ]
+            equal: [ "metrics", << parameters.extras >> ]
           steps:
             - run:
                 name: Install Dependencies
@@ -84,7 +84,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: ci-cache-<< parameters.python-version >><< parameters.extras >>-{{ checksum "pyproject.toml" }}
+          key: ci-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
       - run: poetry run python3 -c 'import kolena'
       # TODO: fix underlying mypy issues with Python>3.9 rather than skipping
       - when:
@@ -105,7 +105,7 @@ jobs:
                   poetry run pytest -m 'not metrics' -vv --cov=kolena --cov-branch tests/unit
       - when:
           condition:
-            equal: [ "-metrics", << parameters.extras >> ]
+            equal: [ "metrics", << parameters.extras >> ]
           steps:
             - run:
                 name: Run metrics unit tests
@@ -157,7 +157,7 @@ jobs:
                 command: circleci-agent step halt
       - checkout
       - restore_cache:
-          key: ci-cache-<< parameters.python-version >><< parameters.extras >>-{{ checksum "pyproject.toml" }}
+          key: ci-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
       - run:
           name: Run << parameters.pytest-group >> integration tests
           command: |
@@ -221,39 +221,41 @@ workflows:
   ci:
     jobs:
       - ci-base:
-          name: ci-base-<< matrix.python-version >><< matrix.extras >>
+          name: ci-base-<< matrix.python-version >>-<< matrix.extras >>
           matrix:
             parameters:
               python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
-              extras: ["", "-metrics"]
+              extras: ["", "metrics"]
       - unit-test:
-          name: unit-test-<< matrix.python-version >><< matrix.extras >>
+          name: unit-test-<< matrix.python-version >>-<< matrix.extras >>
           matrix:
             parameters:
               python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
-              extras: ["", "-metrics"]
+              extras: ["", "metrics"]
           requires:
-            - ci-base-<< matrix.python-version >><< matrix.extras >>
+            - ci-base-<< matrix.python-version >>-<< matrix.extras >>
       - integration-test:
-          name: integration-test-<< matrix.pytest-group >>-<< matrix.python-version >>
+          name: integration-test-<< matrix.pytest-group >>-<< matrix.python-version >>-<< matrix.extras >>
           matrix:
             parameters:
               python-version: [ "3.9" ]
               pytest-group: [ detection, fr, classification, workflow ]
+              extras: [""]
           enabled: true
           parallelism: 4
           requires:
-            - ci-base-<< matrix.python-version >>
+            - ci-base-<< matrix.python-version >>-<< matrix.extras >>
       - integration-test:
-          name: integration-test-misc-<< matrix.python-version >>
+          name: integration-test-misc-<< matrix.python-version >>-<< matrix.extras >>
           matrix:
             parameters:
               python-version: [ "3.9" ]
+              extras: [""]
           pytest-group: misc
           enabled: << pipeline.parameters.all >>
           parallelism: 1
           requires:
-            - ci-base-<< matrix.python-version >>
+            - ci-base-<< matrix.python-version >>-<< matrix.extras >>
   example:
     when:
       or: [ << pipeline.parameters.workflow >>, << pipeline.parameters.all >>, << pipeline.parameters.example >> ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-diff
 <p align="center">
   <img src="https://app.kolena.io/api/developer/docs/html/_static/wordmark-purple.svg" width="400" alt="Kolena" />
 </p>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+diff
 <p align="center">
   <img src="https://app.kolena.io/api/developer/docs/html/_static/wordmark-purple.svg" width="400" alt="Kolena" />
 </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ termcolor = "^1.1.0"
 pyarrow = ">=8"
 typing-extensions = { version = "^4.5.0", python = "< 3.8" }
 click = "^8.1.3"
-
 scikit-learn = [
     { version = ">=1.0.0,<1.0.3", python = ">=3.7.1,<3.8",  optional = true },
     { version = ">=1.2.0", python = ">=3.8",  optional = true },


### PR DESCRIPTION
Seems that this `experimental.new-installer` option was deprecated in Poetry 1.4 and dropped from the [Poetry 1.5](https://python-poetry.org/blog/announcing-poetry-1.5.0/) version that now ships with the `cimg/python` container image. This PR removes it to bring CI green again — better to keep with the times than pin to an older Poetry version.