### PR TITLE
Properly report number of inferences uploaded

### DIFF
--- a/kolena/detection/_internal/test_run.py
+++ b/kolena/detection/_internal/test_run.py
@@ -233,9 +233,9 @@ class BaseTestRun(ABC, Frozen, WithTelemetry):
         )
         df_chunk_serializable = df_chunk.as_serializable()
         upload_data_frame_chunk(df_chunk_serializable, load_uuid=self._upload_uuid)
+        log.success(f"uploaded {self._n_inferences} inferences for test run")
         self._n_inferences = 0
         self._inferences = OrderedDict()
-        log.success(f"uploaded {self._n_inferences} inferences for test run")
 
     def _finalize_upload(self) -> None:
         if self._upload_uuid is None:


### PR DESCRIPTION
### Linked issue(s):
None

### What change does this PR introduce and why?
We were previously reporting the number of inferences after the count was reset, which meant that it was always logged as 0 inferences.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
