### PR TITLE
Tutorial documentation (Part 3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,10 @@ have LFS installed in your environment and run the following command:
 ```shell
 git lfs install
 ```
+
+### Links
+
+Use relative paths, e.g. `../path-to-file.md`, to link to other pages within the documentation. Relative links that
+include the `.md` file extension are checked during build, and broken links will cause builds to fail. This verification
+is not provided for absolute or external links. When linking to an index page, reference it explicitly, e.g.
+`path/to/index.md`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://app.kolena.io/api/developer/docs/html/_static/wordmark-purple.svg" width="400" alt="Kolena" />
+  <img src="/docs/assets/images/wordmark-violet.svg" width="400" alt="Kolena" />
 </p>
 
 <p align='center'>

--- a/docs/advanced-usage/index.md
+++ b/docs/advanced-usage/index.md
@@ -6,8 +6,10 @@ hide:
 
 # :kolena-rocket-20: Advanced Usage
 
+This section contains tutorial documentation for advanced features available in Kolena.
+
 <div class="grid cards" markdown>
-- :octicons-container-24: [Packaging for Automated Evaluation](packaging-for-automated-evaluation)
+- [:octicons-container-24: Packaging for Automated Evaluation](packaging-for-automated-evaluation)
 
     ---
 

--- a/docs/advanced-usage/index.md
+++ b/docs/advanced-usage/index.md
@@ -9,10 +9,10 @@ hide:
 This section contains tutorial documentation for advanced features available in Kolena.
 
 <div class="grid cards" markdown>
-- [:octicons-container-24: Packaging for Automated Evaluation](packaging-for-automated-evaluation)
+- [:octicons-container-24: Packaging for Automated Evaluation](packaging-for-automated-evaluation.md)
 
     ---
 
-    Package [metrics evaluation logic](/reference/workflow/evaluator) in a Docker container image to dynamically compute
-    metrics on relevant subsets of your test data.
+    Package [metrics evaluation logic](../reference/workflow/evaluator.md) in a Docker container image to dynamically
+    compute metrics on relevant subsets of your test data.
 </div>

--- a/docs/advanced-usage/packaging-for-automated-evaluation.md
+++ b/docs/advanced-usage/packaging-for-automated-evaluation.md
@@ -17,7 +17,7 @@ it for metrics computation on the Kolena platform.
 
 ## Build Evaluator Docker Image
 
-We will use the keypoint detection workflow we've built in the [Building a Workflow](/building-a-workflow) guide
+We will use the keypoint detection workflow we've built in the [Building a Workflow](../building-a-workflow.md) guide
 to illustrate the process. Here is the project structure:
 
 ```
@@ -38,7 +38,7 @@ to illustrate the process. Here is the project structure:
 The `keypoint_detection` directory is where our workflow is defined, with evaluator logic in `evaluator.py` and
 workflow data objects in `workflow.py`. The `main.py` will be the entry point where `test` is executed.
 
-From the [workflow building guide](/building-a-workflow#step-4-running-tests), we know that metrics evaluation
+From the [workflow building guide](../building-a-workflow.md#step-4-running-tests), we know that metrics evaluation
 using [`test`][kolena.workflow.test] involves a `model`, a `test_suite`, an `evaluator`, and optional `configurations`:
 
 ```python
@@ -131,7 +131,7 @@ docker build \
 
 This build process installs the `kolena` package, and as such needs the `KOLENA_TOKEN` environment variable to be
 populated with your Kolena API key.
-Follow the [`kolena` Python client](/installing-kolena#initialization) guide to obtain an API key if you have not
+Follow the [`kolena` Python client](../installing-kolena.md#initialization) guide to obtain an API key if you have not
 done so.
 
 ```shell

--- a/docs/assets/images/test-case-diff-dark.png
+++ b/docs/assets/images/test-case-diff-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3face726217a771b9ea2a36da5fcb1834575fa6ffff31c73fce4b9af5a55fd8
+size 48879

--- a/docs/assets/images/test-case-diff-light.png
+++ b/docs/assets/images/test-case-diff-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2e7f4996398f5f7b0347dce7e957bff3c61b5c53d63d858f8386f7e1c010b25
+size 49762

--- a/docs/assets/images/test-case-diff.png
+++ b/docs/assets/images/test-case-diff.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93dffd0a7704b1d9fbdee141b66a42971847daa6cc55a34c543865f18699980e
+size 54192

--- a/docs/assets/images/test-case-diff.png
+++ b/docs/assets/images/test-case-diff.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93dffd0a7704b1d9fbdee141b66a42971847daa6cc55a34c543865f18699980e
-size 54192

--- a/docs/assets/images/wordmark-violet.svg
+++ b/docs/assets/images/wordmark-violet.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cb9ea8b9e10bfb3beac7a34b9d7e001eb447c5a9e9ffbde7145dd2048978676
+size 2555

--- a/docs/assets/images/wordmark-white.svg
+++ b/docs/assets/images/wordmark-white.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a339d17ebcfa5149fb2f7893cc3d50e7a6eb1ed4240fe37bb67c11b2cd4d76c6
+size 3373

--- a/docs/building-a-workflow.md
+++ b/docs/building-a-workflow.md
@@ -4,14 +4,14 @@ icon: kolena/cube-16
 
 # :kolena-cube-20: Building a Workflow
 
-In this quickstart tutorial we'll learn how to use the [`kolena.workflow`](reference/workflow) workflow builder
+In this quickstart tutorial we'll learn how to use the [`kolena.workflow`](reference/workflow/index.md) workflow builder
 definitions to test a [Keypoint Detection](https://keras.io/examples/vision/keypoint_detection/) model on the
 [300-W](https://ibug.doc.ic.ac.uk/resources/300-W/) facial keypoint dataset. This demonstration will show us how we can
 build a workflow to test any arbitrary ML problem on Kolena.
 
 ### Getting Started
 
-With the `kolena` Python client [installed](/installing-kolena#installation),
+With the `kolena` Python client [installed](installing-kolena.md#installation),
 first let's initialize a client session:
 
 ```python
@@ -147,7 +147,7 @@ class TestSampleMetrics(MetricsTestSample):
 #### Test Case Metrics
 
 Test Case metrics are aggregate metrics computed across a population. All of your standard evaluation metrics should
-go here — things like accuracy, precision, recall, or any other aggregate metrics that apply to your problem.
+go here — things like accuracy, precision, recall, or any other aggregate metrics that apply to your problem.
 
 For keypoints, we care about the **mean NME** and **alignment failure rate** across the different test samples in a test
 case:
@@ -196,7 +196,7 @@ test_case = TestCase(f"{DATASET} :: basic", test_samples=ts_with_gt)
 !!! note "Note: Creating test cases"
     In this tutorial we created only a single simple test case, but more advanced test cases can be generated in a
     variety of fast and scalable ways, either programmatically with the `kolena` Python client or visually in the
-    [Studio](https://app.kolena.io/redirect/studio).
+    [:kolena-studio-16: Studio](https://app.kolena.io/redirect/studio).
 
 <!-- See [Creating Test Cases](../testing-with-kolena/creating-tests.md#creating-test-cases) for details. -->
 
@@ -270,8 +270,8 @@ def evaluate_keypoint_detection(
 
 #### Running tests
 
-To test our models, we can define an `infer` function that maps the `TestSample` object we defined above into an
-`Inference`:
+To test our models, we can define an [`infer`][kolena.workflow.Model.infer] function that maps the `TestSample` object
+we defined above into an `Inference`:
 
 ```python
 from random import randint
@@ -311,5 +311,5 @@ detection model as an example. We created new tests, tested our models on Kolena
 evaluation to fit our exact expectations.
 
 This tutorial just scratches the surface of what's possible with Kolena and covered a fraction of the
-`kolena` API — now that we're up and running, we can think about ways to create more detailed tests, improve
+`kolena` API — now that we're up and running, we can think about ways to create more detailed tests, improve
 existing tests, and dive deep into model behaviors.

--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -7,9 +7,9 @@ hide:
 # :kolena-flag-20: Core Concepts
 
 In this section, we'll get acquainted with the core concepts on Kolena, and learn in-depth about the various features
-offered. For a brief introduction, see the [Quickstart Guide](/quickstart) or the
-[Building a Workflow](/building-a-workflow) tutorial. For code-level API documentation, see the
-[API Reference Documentation](/reference/workflow) for the `kolena` Python client.
+offered. For a brief introduction, see the [Quickstart Guide](../quickstart.md) or the
+[Building a Workflow](../building-a-workflow.md) tutorial. For code-level API documentation, see the
+[API Reference Documentation](../reference/workflow) for the `kolena` Python client.
 
 <div class="grid cards" markdown>
 - [:kolena-workflow-16: Workflow](workflow)
@@ -33,6 +33,6 @@ offered. For a brief introduction, see the [Quickstart Guide](/quickstart) or th
 
     ---
 
-    In Kolena, a model is a deterministic transformation from [test samples](/core-concepts/workflow#test-sample) to
-    [inferences](/core-concepts/workflow#inference).
+    In Kolena, a model is a deterministic transformation from [test samples](workflow.md#test-sample) to
+    [inferences](workflow.md#inference).
 </div>

--- a/docs/core-concepts/model.md
+++ b/docs/core-concepts/model.md
@@ -4,8 +4,8 @@ icon: kolena/model-16
 
 # :kolena-model-20: Model
 
-In Kolena, a model is a deterministic transformation from [test samples](/core-concepts/workflow#test-sample) to
-[inferences](/core-concepts/workflow#inference).
+In Kolena, a model is a deterministic transformation from [test samples](workflow.md#test-sample) to
+[inferences](workflow.md#inference).
 
 Kolena only stores metadata associated with your model in its model registry at
 [app.kolena.io/~/models](https://app.kolena.io/redirect/models). Models themselves — their code or their weights — are
@@ -18,7 +18,7 @@ and architecture. It's possible to test any sort of model, from deep learning to
 
 The [`Model`][kolena.workflow.Model] class is used to programmatically create models for testing. Rather than importing
 the class from `kolena.workflow` directly, use the `Model` definition returned from
-[`define_workflow`](/core-concepts/workflow#defining-a-workflow) bound to the test sample and inference types for your
+[`define_workflow`](workflow.md#defining-a-workflow) bound to the test sample and inference types for your
 workflow:
 
 ```python

--- a/docs/core-concepts/test-suite.md
+++ b/docs/core-concepts/test-suite.md
@@ -6,8 +6,8 @@ icon: kolena/test-suite-16
 
 Test cases and test suites are used to organize test data in Kolena.
 
-A **test case** is a collection of [test samples](/core-concepts/workflow#test-sample) and their associated
-[ground truths](/core-concepts/workflow#ground-truth). Test cases can be thought of as benchmark datasets, or slices of
+A **test case** is a collection of [test samples](workflow.md#test-sample) and their associated
+[ground truths](workflow.md#ground-truth). Test cases can be thought of as benchmark datasets, or slices of
 a benchmark dataset.
 
 A **test suite** is a collection of test cases. Models are tested on test suites.
@@ -16,7 +16,7 @@ A **test suite** is a collection of test cases. Models are tested on test suites
 
 The [`TestCase`][kolena.workflow.TestCase] and [`TestSuite`][kolena.workflow.TestSuite] classes are used to
 programmatically create test cases and test suites. Rather than importing these classes from `kolena.workflow` directly,
-Use the definitions returned from [`define_workflow`](/core-concepts/workflow#defining-a-workflow) bound to the test
+Use the definitions returned from [`define_workflow`](workflow.md#defining-a-workflow) bound to the test
 sample and ground truth types for your workflow:
 
 ```python

--- a/docs/core-concepts/workflow.md
+++ b/docs/core-concepts/workflow.md
@@ -16,12 +16,13 @@ Examples of workflows include:
 - [:kolena-video-20: Video Retrieval](https://paperswithcode.com/task/video-retrieval) using text queries on a corpus of videos
 </div>
 
-With the [`kolena.workflow`](/reference/workflow) client module, any arbitrary ML problem can be defined as a workflow
-and tested on Kolena.
+With the [`kolena.workflow`](../reference/workflow/index.md) client module, any arbitrary ML problem can be defined as a
+workflow and tested on Kolena.
 
 There are three main components of a workflow:
 
 !!! info inline end
+
     These three types can be thought of as the data model, or the schema, of a workflow.
 
 1. [**Test Sample**](#test-sample): the inputs to a model, e.g. image, video, document
@@ -39,7 +40,7 @@ computer vision models would have a [video][kolena.workflow.Video] test sample t
 [image pairs][kolena.workflow.Composite]. For natural language processing models, the test sample may be a
 [document][kolena.workflow.Document] or [text snippet][kolena.workflow.Text].
 
-When [building a workflow](building-a-workflow), you can [extend](/reference/workflow/test-sample) and
+When [building a workflow](../building-a-workflow.md), you can [extend](../reference/workflow/test-sample.md) and
 [compose][kolena.workflow.Composite] these base test sample types as necessary, or use the base types directly if no
 customization is required.
 
@@ -63,9 +64,9 @@ class MyDocument(Document):
 
 !!! tip "Use `pydantic` dataclasses"
 
-    When building a workflow, object definitions can us [standard library `dataclasses`][dataclasses] or [Pydantic
-    `dataclasses`](https://docs.pydantic.dev/latest/usage/dataclasses/). Pydantic brings helpful runtime type validation
-    and coercion and can be used as a drop-in replacement for standard library `dataclasses`.
+    When building a workflow, object definitions can us [standard library `dataclasses`][dataclasses] or
+    [Pydantic `dataclasses`](https://docs.pydantic.dev/latest/usage/dataclasses/). Pydantic brings helpful runtime type
+    validation and coercion and can be used as a drop-in replacement for standard library `dataclasses`.
 
 ### Composite Test Samples
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,16 +4,17 @@ hide:
   - toc
 ---
 
-<p align="center">
-  <img src="https://app.kolena.io/api/developer/docs/html/_static/wordmark-purple.svg" width="400" alt="Kolena" />
-</p>
+<figure markdown>
+  ![Kolena](assets/images/wordmark-violet.svg#only-light){ width="400" }
+  ![Kolena](assets/images/wordmark-white.svg#only-dark){ width="400" }
+</figure>
 
 <p align='center'>
   <a href="https://pypi.python.org/pypi/kolena"><img src="https://img.shields.io/pypi/v/kolena" /></a>
   <a href="https://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/pypi/l/kolena" /></a>
   <a href="https://github.com/kolenaIO/kolena/actions"><img src="https://img.shields.io/github/checks-status/kolenaIO/kolena/trunk" /></a>
   <a href="https://codecov.io/gh/kolenaIO/kolena" ><img src="https://codecov.io/gh/kolenaIO/kolena/branch/trunk/graph/badge.svg?token=8WOY5I8SF1"/></a>
-  <a href="https://docs.kolena.io"><img src="https://img.shields.io/badge/resource-docs-6434c1" /></a>
+  <a href="https://github.com/kolenaIO/kolena"><img src="https://img.shields.io/badge/resource-repo-6434c1" /></a>
 </p>
 
 ---
@@ -26,5 +27,101 @@ model behaviors and take the mystery out of model development. Kolena helps you:
 - Meaningfully communicate model capabilities
 - Automate model testing and deployment workflows
 
-This `kolena` package contains the Python client library for programmatic interaction with the Kolena ML testing
-platform.
+Kolena organizes your test data, stores and visualizes your model evaluations, and provides tooling to craft better
+tests. You interface with it through the web at [app.kolena.io](https://app.kolena.io) and programmatically via the
+[`kolena`](installing-kolena.md) Python client.
+
+
+
+## Why Kolena?
+
+!!! tip inline "TL;DR"
+
+    Kolena helps you test your ML models more effectively.
+
+    **Jump right in with the [:kolena-flame-16: Quickstart](quickstart.md) guide**.
+
+Current ML evaluation techniques are falling short. Engineers run inference on arbitrarily split benchmark datasets,
+spend weeks staring at error graphs to evaluate their models, and ultimately produce a global metric that fails to
+capture the true behavior of the model.
+
+Models exhibit highly variable performance across different subsets of a domain. A global metric gives you a high-level
+picture of performance but doesn't tell you what you really want to know: _what sort of behavior can I expect from my model in production?_
+
+To answer this question you need a higher-resolution picture of model performance. Not "how well does my model perform
+on class X," but "in what scenarios does my model perform well for class X?"
+
+![Looking at global metric, Model A seems far inferior to Model B.](assets/images/test-case-diff-light.png#only-light)
+![Looking at global metric, Model A seems far inferior to Model B.](assets/images/test-case-diff-dark.png#only-dark)
+
+In the above example, looking only at global metric (e.g. F1 score), we'd almost certainly choose to deploy Model B.
+
+But what if the "High Blur" scenario isn't important for our product? Most of Model A's failures are from that
+scenario, and it outperforms Model B in more important scenarios like "Front View." Meanwhile, Model B's
+underperformance in "Front View," a highly important scenario, is masked by improved performance in
+the unimportant "High Blur" scenario.
+
+!!! tip "Test data is more important than training data!"
+
+    Everything you know about a new model's behavior is learned from your tests.
+
+    Fine-grained tests teach you what you need to learn before a model hits production.
+
+Now... why Kolena? Two reasons:
+
+1. **Managing fine-grained tests is a tedious data engineering task**, especially under changing data circumstances as
+   your dataset grows and your understanding of your domain develops
+2. **Creating fine-grained tests is labor-intensive** and typically involves manual annotation of countless images, a
+   costly and time-consuming process
+
+We built Kolena to solve these two problems.
+
+## Read More
+
+- Best Practices for ML Model Testing ([Kolena Blog](https://www.kolena.io/blog/best-practices-for-ml-model-testing))
+- Hidden Stratification Causes Clinically Meaningful Failures in Machine Learning for Medical Imaging ([arXiv:1909.12475](https://arxiv.org/abs/1909.12475))
+- No Subclass Left Behind: Fine-Grained Robustness in Coarse-Grained Classification Problems ([arXiv:2011.12945](https://arxiv.org/abs/2011.12945))
+
+---
+
+# :kolena-layers-20: Developer Guide
+
+Learn how to use Kolena to test your models effectively:
+
+<div class="grid cards" markdown>
+- [:kolena-flame-16: Quickstart](quickstart.md)
+
+    ---
+
+    Run through an example using Kolena to set up rigorous and repeatable model testing in minutes.
+
+- [:kolena-developer-16: Installing `kolena`](installing-kolena.md)
+
+    ---
+
+    Install and initialize the `kolena` Python package, the programmatic interface to Kolena.
+
+- [:kolena-cube-16: Building a Workflow](building-a-workflow.md)
+
+    ---
+
+    Learn how to use `kolena.workflow` to test any arbitrary ML problem on Kolena.
+
+- [:kolena-flag-16: Core Concepts](core-concepts/index.md)
+
+    ---
+
+    Core concepts for testing in Kolena.
+
+- [:kolena-rocket-16: Advanced Usage](advanced-usage/index.md)
+
+    ---
+
+    Tutorial documentation for advanced features available in Kolena.
+
+- [:kolena-manual-16: API Reference](reference/index.md)
+
+    ---
+
+    Developer-focused detailed API reference documentation for `kolena`.
+</div>

--- a/docs/installing-kolena.md
+++ b/docs/installing-kolena.md
@@ -70,6 +70,7 @@ By default, sessions have static scope and persist until the interpreter is exit
 Additional logging can be configured by specifying `initialize(..., verbose=True)`.
 
 !!! tip "Tip: `logging`"
+
     Integrate `kolena` into your existing logging system by filtering for events from the `"kolena"` logger. All log
     messages are emitted as both Python standard library [`logging`][logging] events as well as stdout/stderr messages.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,9 @@ icon: kolena/flame-16
 
 # :kolena-flame-20: Quickstart
 
-Install Kolena to set up rigorous and repeatable model testing in minutes. In this quickstart guide, we'll use the
+Install Kolena to set up rigorous and repeatable model testing in minutes.
+
+In this quickstart guide, we'll use the
 [`age_estimation`](https://github.com/kolenaIO/kolena/tree/trunk/examples/age_estimation) example integration to
 demonstrate the how to curate test data and test models in Kolena.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -73,8 +73,8 @@ cd kolena/examples/age_estimation
 poetry update && poetry install
 ```
 
-Now we're up and running and can start [creating test suites](#creating-test-suites) and
-[testing models](#testing-models).
+Now we're up and running and can start [creating test suites](#create-test-suites) and
+[testing models](#test-a-model).
 
 ## Create Test Suites
 

--- a/docs/reference/legacy/built-in/classification.md
+++ b/docs/reference/legacy/built-in/classification.md
@@ -12,7 +12,7 @@ search:
 
     Please see `kolena.workflow` for customizable and extensible definitions to use for all new projects.
 
-!["Dog" classification example from the Dogs vs. Cats dataset.](/assets/images/classification-dog.jpg)
+!["Dog" classification example from the Dogs vs. Cats dataset.](../../../assets/images/classification-dog.jpg)
 
 `kolena.classification` supports the following types of classification models:
 

--- a/docs/reference/legacy/built-in/detection.md
+++ b/docs/reference/legacy/built-in/detection.md
@@ -12,7 +12,7 @@ search:
 
     Please see `kolena.workflow` for customizable and extensible definitions to use for all new projects.
 
-![Object detection example from the Common Objects in Context (COCO) dataset.](/assets/images/detection-airplane.jpg)
+![Object detection example from the Common Objects in Context (COCO) dataset.](../../../assets/images/detection-airplane.jpg)
 
 Object detection models attempt to localize and classify objects in an image. Kolena supports single-class and
 multi-class object detection models identifying objects with rectangular (object detection) and arbitrary (instance

--- a/docs/reference/legacy/built-in/fr.md
+++ b/docs/reference/legacy/built-in/fr.md
@@ -12,7 +12,7 @@ search:
 
     Please see `kolena.workflow` for customizable and extensible definitions to use for all new projects.
 
-![Example Face Recognition (1:1) image pair from the Labeled Faces in the Wild dataset.](/assets/images/face-recognition.jpg)
+![Example Face Recognition (1:1) image pair from the Labeled Faces in the Wild dataset.](../../../assets/images/face-recognition.jpg)
 
 Face Recognition (1:1) workflow is built to test models answering the question: _do these two images depict the same
 person_? The terminology and methodology are adapted from the [NIST FRVT 1:1](https://pages.nist.gov/frvt/html/frvt11.html)

--- a/docs/reference/legacy/index.md
+++ b/docs/reference/legacy/index.md
@@ -18,7 +18,7 @@ hide:
 <div class="grid cards" markdown>
 - :kolena-classification-20: [`kolena.classification`](built-in/classification)
 
-    !["Dog" classification example from the Dogs vs. Cats dataset.](/assets/images/classification-dog.jpg)
+    !["Dog" classification example from the Dogs vs. Cats dataset.](../../assets/images/classification-dog.jpg)
 
     ---
 
@@ -26,7 +26,7 @@ hide:
 
 - :kolena-detection-20: [`kolena.detection`](built-in/detection)
 
-    ![Object detection example from the Common Objects in Context (COCO) dataset.](/assets/images/detection-airplane.jpg)
+    ![Object detection example from the Common Objects in Context (COCO) dataset.](../../assets/images/detection-airplane.jpg)
 
     ---
 
@@ -34,7 +34,7 @@ hide:
 
 - :kolena-fr-20: [`kolena.fr`](built-in/fr)
 
-    ![Example Face Recognition (1:1) image pair from the Labeled Faces in the Wild dataset.](/assets/images/face-recognition.jpg)
+    ![Example Face Recognition (1:1) image pair from the Labeled Faces in the Wild dataset.](../../assets/images/face-recognition.jpg)
 
     ---
 

--- a/docs/reference/workflow/index.md
+++ b/docs/reference/workflow/index.md
@@ -6,14 +6,16 @@ hide:
 
 # :kolena-cube-20: `kolena.workflow`
 
-`kolena.workflow` contains the definitions to build a workflow:
+`kolena.workflow` contains the definitions to build a [workflow](../../core-concepts/workflow.md):
 
-!!! info inline end
-    The [`TestSample`][kolena.workflow.TestSample], [`GroundTruth`][kolena.workflow.GroundTruth], and
-    [`Inference`][kolena.workflow.Inference] can be thought of as the data model, or schema, for a
-    [workflow](/core-concepts/workflow).
+!!! info inline end "Defining a workflow"
 
-1. Design data types, including any [`annotations`](annotation) or [`assets`](asset):
+    [`TestSample`][kolena.workflow.TestSample], [`GroundTruth`][kolena.workflow.GroundTruth], and
+    [`Inference`][kolena.workflow.Inference] can be thought of as the data model, or schema, for a workflow.
+
+    See the [workflow](../../core-concepts/workflow.md) developer guide for more information.
+
+1. Design data types, including any [`annotations`](annotation.md) or [`assets`](asset.md):
 
     - [`TestSample`][kolena.workflow.TestSample]: model inputs, e.g. images, videos, documents
     - [`GroundTruth`][kolena.workflow.GroundTruth]: expected model outputs
@@ -22,6 +24,11 @@ hide:
 2. Define metrics and how they are computed:
 
     - [`Evaluator`][kolena.workflow.Evaluator]: metrics computation engine
+
+!!! info inline end "Managing Tests"
+
+    See the [test case and test suite](../../core-concepts/test-suite.md) developer guide for an introduction to the
+    test case and test suite concept.
 
 3. Create tests:
 


### PR DESCRIPTION
This PR follows up on #72, #74, and #75 to finish up the initial tutorial documentation port. Starting from this afternoon's release, the documentation built out of `./docs` in this repo will replace the GitBook content at docs.kolena.io and the API Reference documentation built via Sphinx.

Fixes KOL-2498