### PR TITLE
Publish docs as kolenabot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - gh/docs-publish-bot
 
 jobs:
   release:
@@ -56,10 +54,7 @@ jobs:
           git config user.name 'kolenabot'
           git config user.email 'bot@kolena.io'
           ./docs/setup_insiders.sh
-          poetry run mkdocs gh-deploy --verbose --strict --remote-branch bot/gh-pages --config-file mkdocs.insiders.yml
-
-      - name: Fail
-        run: exit 1
+          poetry run mkdocs gh-deploy --verbose --strict --remote-branch release/gh-pages --config-file mkdocs.insiders.yml
 
       - name: Push 'kolena' dist to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           git config user.name 'kolenabot'
           git config user.email 'bot@kolena.io'
           ./docs/setup_insiders.sh
-          poetry run mkdocs gh-deploy --verbose --strict --remote-branch release/gh-pages --config-file mkdocs.insiders.yml
+          poetry run mkdocs gh-deploy --verbose --strict --remote-branch release/docs --config-file mkdocs.insiders.yml
 
       - name: Push 'kolena' dist to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "*"
+    branches:
+      - gh/docs-publish-bot
 
 jobs:
   release:
@@ -51,8 +53,13 @@ jobs:
 
       - name: Build 'kolena' documentation and push to GitHub Pages
         run: |
+          git config user.name 'kolenabot'
+          git config user.email 'bot@kolena.io'
           ./docs/setup_insiders.sh
-          poetry run mkdocs gh-deploy --verbose --config-file mkdocs.insiders.yml
+          poetry run mkdocs gh-deploy --verbose --strict --remote-branch bot/gh-pages --config-file mkdocs.insiders.yml
+
+      - name: Fail
+        run: exit 1
 
       - name: Push 'kolena' dist to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Publish documentation on release to `release/docs` as user [kolenabot](https://github.com/kolenabot), allowing us to set up author-based branch protections on the `release/docs` branch. Using a custom branch instead of the default `gh-pages` branch also gives us a little added protection in case anybody accidentally runs `mkdocs gh-deploy` as kolenabot.

Fixes KOL-2508