### PR TITLE
Hide Metrics Glossary from nav bar and search

### DIFF
--- a/docs/metrics/averaging-methods.md
+++ b/docs/metrics/averaging-methods.md
@@ -1,5 +1,8 @@
 ---
 subtitle: Macro, Micro, Weighted
+# TODO: remove search exclusion before landing Metrics Glossary
+search:
+  exclude: true
 ---
 
 # Averaging Methods

--- a/docs/metrics/index.md
+++ b/docs/metrics/index.md
@@ -1,5 +1,8 @@
 ---
 icon: kolena/metrics-glossary-16
+# TODO: remove search exclusion before landing Metrics Glossary
+search:
+  exclude: true
 ---
 
 # :kolena-metrics-glossary-20: Metrics Glossary

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,9 +48,10 @@ nav:
               - <code>detection</code>: reference/legacy/built-in/detection.md
               - <code>fr</code>: reference/legacy/built-in/fr.md
               - Base Definitions: reference/legacy/built-in/base.md
-  - Metrics Glossary:
-      - Metrics Glossary: metrics/index.md
-      - Averaging Methods: metrics/averaging-methods.md
+  # TODO: uncomment when landing Metrics Glossary
+  # - Metrics Glossary:
+  #     - Metrics Glossary: metrics/index.md
+  #     - Averaging Methods: metrics/averaging-methods.md
   - Help & FAQ:
     - Help & FAQ: faq/index.md
   - Sign in ↗: https://app.kolena.io


### PR DESCRIPTION
Not ready for today's release. Exclude from nav bar and search results until next week, when more content has landed.