### PR TITLE
Add meta tags to social card layout

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -86,10 +86,13 @@ jobs:
       - restore_cache:
           key: ci-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
       - run:
-          name: Install system-level build dependencies
+          name: Install system-level build and checkout dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install -y libcairo2-dev
+            sudo apt-get install -y libcairo2-dev git-lfs
+      - run:
+          name: Checkout LFS blobs
+          command: git lfs pull
       - run:
           name: Build documentation without 'insiders' packages
           command: poetry run mkdocs build

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -86,7 +86,7 @@ jobs:
       - restore_cache:
           key: ci-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
       - run:
-          name: Install system-level build and checkout dependencies
+          name: Install system-level dependencies
           command: |
             sudo apt-get update
             sudo apt-get install -y libcairo2-dev git-lfs

--- a/docs/layouts/custom.yml
+++ b/docs/layouts/custom.yml
@@ -1,3 +1,24 @@
+definitions:
+  - &page_title_with_site_name "{{ page.title }} - {{ config.site_name }}"
+  - &page_description "{{ config.site_description }}"
+
+tags:
+  # Open Graph
+  og:type: website
+  og:title: *page_title_with_site_name
+  og:description: *page_description
+  og:image: "{{ image.url }}"
+  og:image:type: "{{ image.type }}"
+  og:image:width: "{{ image.width }}"
+  og:image:height: "{{ image.height }}"
+  og:url: "{{ page.canonical_url }}"
+
+  # Twitter
+  twitter:card: summary_large_image
+  twitter.title: *page_title_with_site_name
+  twitter:description: *page_description
+  twitter:image: "{{ image.url }}"
+
 size: { width: 1200, height: 630 }
 layers:
   - background:
@@ -36,7 +57,7 @@ layers:
   - size: { width: 832, height: 66 }
     offset: { x: 64, y: 512 }
     typography:
-      content: "{{ config.site_description }}"
+      content: *page_description
       align: start
       color: white
       line: { amount: 2, height: 1.5 }

--- a/docs/layouts/custom.yml
+++ b/docs/layouts/custom.yml
@@ -14,7 +14,7 @@ tags:  # adapted from mkdocs-material-insiders layouts/default.yml
   og:image:height: "{{ image.height }}"
   og:url: "{{ page.canonical_url }}"
   twitter:card: summary_large_image
-  twitter.title: *page_title_with_site_name
+  twitter:title: *page_title_with_site_name
   twitter:description: *page_description
   twitter:image: "{{ image.url }}"
 

--- a/docs/layouts/custom.yml
+++ b/docs/layouts/custom.yml
@@ -1,9 +1,10 @@
 definitions:
   - &page_title_with_site_name "{{ page.title }} - {{ config.site_name }}"
   - &page_description "{{ config.site_description }}"
+  - &font_family "DM Sans"
+  - &color "white"
 
-tags:
-  # Open Graph
+tags:  # adapted from mkdocs-material-insiders layouts/default.yml
   og:type: website
   og:title: *page_title_with_site_name
   og:description: *page_description
@@ -12,8 +13,6 @@ tags:
   og:image:width: "{{ image.width }}"
   og:image:height: "{{ image.height }}"
   og:url: "{{ page.canonical_url }}"
-
-  # Twitter
   twitter:card: summary_large_image
   twitter.title: *page_title_with_site_name
   twitter:description: *page_description
@@ -40,8 +39,8 @@ layers:
     offset: { x: 64, y: 64 }
     typography:
       content: "{{ config.site_name }}"
-      color: white
-      font: { family: DM Sans, style: Bold }
+      color: *color
+      font: { family: *font_family, style: Bold }
 
   # Page title
   - size: { width: 832, height: 310 }
@@ -49,9 +48,9 @@ layers:
     typography:
       content: "{{ page.title | striptags }}"  # strip out any HTML tags, e.g. <code>
       align: start
-      color: white
+      color: *color
       line: { amount: 3, height: 1.25 }
-      font: { family: DM Sans, style: Bold }
+      font: { family: *font_family, style: Bold }
 
   # Page description
   - size: { width: 832, height: 66 }
@@ -59,6 +58,6 @@ layers:
     typography:
       content: *page_description
       align: start
-      color: white
+      color: *color
       line: { amount: 2, height: 1.5 }
       font: { family: Inter, style: Regular }


### PR DESCRIPTION
#78 updated the social cards to use a custom layout, but neglected to port the meta tags to this new layout (custom social cards is an [experimental feature](https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards/#customization) and its documentation could use fleshing out). This PR fixes that and should unbreak social cards once released.

Fixes KOL-2503