### PR TITLE
Add Datadog RUM to docs.kolena.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
           git config user.email 'bot@kolena.io'
           ./docs/setup_insiders.sh
           poetry run mkdocs gh-deploy --verbose --strict --remote-branch release/docs --config-file mkdocs.insiders.yml
+        env:
+          DD_RUM_CLIENT_TOKEN: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
+          DD_RUM_APPLICATION_ID: ${{ secrets.DD_RUM_APPLICATION_ID }}
 
       - name: Push 'kolena' dist to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,22 @@ on:
   push:
     tags:
       - "*"
+    branches:
+      - gh/rum
 
 jobs:
   release:
     name: Build and publish release of kolena Python package and documentation
     runs-on: ubuntu-latest
     steps:
+      - name: Check vars
+        run: |
+          echo "$DD_RUM_CLIENT_TOKEN, $DD_RUM_APPLICATION_ID"
+          exit 1
+        env:
+          DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
+          DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}
+
       - name: Check out the repo
         uses: actions/checkout@v3
         with:
@@ -56,8 +66,8 @@ jobs:
           ./docs/setup_insiders.sh
           poetry run mkdocs gh-deploy --verbose --strict --remote-branch release/docs --config-file mkdocs.insiders.yml
         env:
-          DD_RUM_CLIENT_TOKEN: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
-          DD_RUM_APPLICATION_ID: ${{ secrets.DD_RUM_APPLICATION_ID }}
+          DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
+          DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}
 
       - name: Push 'kolena' dist to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,22 +4,12 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - gh/rum
 
 jobs:
   release:
     name: Build and publish release of kolena Python package and documentation
     runs-on: ubuntu-latest
     steps:
-      - name: Check vars
-        run: |
-          echo "$DD_RUM_CLIENT_TOKEN, $DD_RUM_APPLICATION_ID"
-          exit 1
-        env:
-          DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
-          DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}
-
       - name: Check out the repo
         uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/docs/assets/images/wordmark-violet.svg" width="400" alt="Kolena" />
+  <img src="https://docs.kolena.io/assets/images/wordmark-violet.svg" width="400" alt="Kolena" />
 </p>
 
 <p align='center'>

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -14,7 +14,7 @@
       applicationId: '32c8b59a-335b-4a60-8320-52cf94822079',
       site: 'datadoghq.com',
       service: 'docs.kolena.io',
-      env: 'production',
+      env: window.location.hostname,
       // Specify a version number to identify the deployed version of your application in Datadog
       // version: '1.0.0',
       sessionSampleRate: 100,

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+{{ super() }}
+<script>
+  (function(h,o,u,n,d) {
+    h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
+    d=o.createElement(u);d.async=1;d.src=n
+    n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v4/datadog-rum.js','DD_RUM')
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
+      clientToken: 'pub77d1be21718df74d03f852860d7f6b7f',
+      applicationId: '32c8b59a-335b-4a60-8320-52cf94822079',
+      site: 'datadoghq.com',
+      service: 'docs.kolena.io',
+      env: 'production',
+      // Specify a version number to identify the deployed version of your application in Datadog
+      // version: '1.0.0',
+      sessionSampleRate: 100,
+      sessionReplaySampleRate: 20,
+      trackUserInteractions: true,
+      trackResources: true,
+      trackLongTasks: true,
+      defaultPrivacyLevel: 'mask-user-input',
+    });
+
+    window.DD_RUM.startSessionReplayRecording();
+  })
+</script>
+{% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block htmltitle %}
+<title>{{ page.title | striptags }} · {{ config.site_name }}</title>
+{% endblock %}
+
 {% block extrahead %}
 {{ super() }}
 <script>
@@ -14,7 +18,7 @@
       applicationId: '32c8b59a-335b-4a60-8320-52cf94822079',
       site: 'datadoghq.com',
       service: 'docs.kolena.io',
-      env: window.location.hostname,
+      env: window.location.hostname === 'docs.kolena.io' ? 'production' : 'development',
       sessionSampleRate: 100,
       sessionReplaySampleRate: 100,
       trackUserInteractions: true,

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -14,8 +14,8 @@
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v4/datadog-rum.js','DD_RUM')
   window.DD_RUM.onReady(function() {
     window.DD_RUM.init({
-      clientToken: 'pub77d1be21718df74d03f852860d7f6b7f',
-      applicationId: '32c8b59a-335b-4a60-8320-52cf94822079',
+      clientToken: '{{ config.extra.dd_rum.client_token }}',
+      applicationId: '{{ config.extra.dd_rum.application_id }}',
       site: 'datadoghq.com',
       service: 'docs.kolena.io',
       env: window.location.hostname === 'docs.kolena.io' ? 'production' : 'development',

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -15,14 +15,11 @@
       site: 'datadoghq.com',
       service: 'docs.kolena.io',
       env: window.location.hostname,
-      // Specify a version number to identify the deployed version of your application in Datadog
-      // version: '1.0.0',
       sessionSampleRate: 100,
-      sessionReplaySampleRate: 20,
+      sessionReplaySampleRate: 100,
       trackUserInteractions: true,
       trackResources: true,
       trackLongTasks: true,
-      defaultPrivacyLevel: 'mask-user-input',
     });
 
     window.DD_RUM.startSessionReplayRecording();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -169,3 +169,6 @@ extra:
     - icon: kolena/logo
       link: https://app.kolena.io
       name: Kolena Platform
+  dd_rum:
+    client_token: !ENV [DD_RUM_CLIENT_TOKEN, blank]
+    application_id: !ENV [DD_RUM_APPLICATION_ID, blank]


### PR DESCRIPTION
Tracking will help us understand docs engagement. Note that this, along with all other common user monitoring tools, will be blocked by ad blockers.

Fixes KOL-2500