### PR TITLE
Fix docs.kolena.io swipe navigation

### DIFF
--- a/docs/assets/css/theme.css
+++ b/docs/assets/css/theme.css
@@ -1,5 +1,5 @@
 html {
-  overscroll-behavior: none;
+  overscroll-behavior-y: none;
 }
 
 .md-typeset h5 {


### PR DESCRIPTION
Broken by overzealous `overscroll-behavior` disabling.

Fixes KOL-2522