### PR TITLE
TP/FP/FN/TN clean up

### DIFF
--- a/docs/assets/images/metrics-tpfpfntn-dog-classifier.png
+++ b/docs/assets/images/metrics-tpfpfntn-dog-classifier.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9fb5eae07d25bcafdd42ef9c1e00de8c1dae4dfee7dc9ea92bb955b0a2906ee
-size 211552

--- a/docs/metrics/tp-fp-fn-tn.md
+++ b/docs/metrics/tp-fp-fn-tn.md
@@ -21,10 +21,10 @@ Let’s say we’re building a dog classifier that predicts whether an image has
 
 <center>
 
-|                              | Positive Inference (Dog) | Negative Inference (No Dog) |
-|                              | :----------------------: | :-------------------------: |
-| **Positive Sample (Dog)**    | True Positive (TP)       | False Negative (FN)         |
-| **Negative Sample (No Dog)** | False Positive (FP)      | True Negative (TN)          |
+|                                    | Positive Inference (Dog) | Negative Inference (No Dog) |
+|                                    | :----------------------: | :-------------------------: |
+| **Positive Ground Truth (Dog)**    | True Positive (TP)       | False Negative (FN)         |
+| **Negative Ground Truth (No Dog)** | False Positive (FP)      | True Negative (TN)          |
 
 </center>
 

--- a/docs/metrics/tp-fp-fn-tn.md
+++ b/docs/metrics/tp-fp-fn-tn.md
@@ -6,7 +6,7 @@ search:
 # TP / FP / FN / TN
 
 The counts of **true positive** (TP), **false positive** (FP), **false negative** (FN), and **true negative** (TN)
-predictions and ground truths are essential for summarizing model performance. These metrics are the building blocks of
+inferences and ground truths are essential for summarizing model performance. These metrics are the building blocks of
 many other metrics, including accuracy, precision, and recall.
 
 | Metric | | Description |
@@ -16,18 +16,25 @@ many other metrics, including accuracy, precision, and recall.
 | <nobr>False Negative</nobr> | FN | An instance for which predicted value is negative but actual value is positive |
 | True Negative | TN | An instance for which both predicted and actual values are negative |
 
-To compute these metrics, each prediction is compared to a ground truth and categorized into one of the four groups.
+To compute these metrics, each inference is compared to a ground truth and categorized into one of the four groups.
 Let’s say we’re building a dog classifier that predicts whether an image has a dog or not:
 
-![A dog classifier example](../assets/images/metrics-tpfpfntn-dog-classifier.png)
+<center>
+
+|                              | Positive Inference (Dog) | Negative Inference (No Dog) |
+|                              | :----------------------: | :-------------------------: |
+| **Positive Sample (Dog)**    | True Positive (TP)       | False Negative (FN)         |
+| **Negative Sample (No Dog)** | False Positive (FP)      | True Negative (TN)          |
+
+</center>
 
 Images of a dog are **positive** samples, and images without a dog are **negative** samples.
 
-If a classifier predicts that there is a dog on a **positive** sample, that prediction is a **true positive** (TP).
-If that classifier predicts that there isn’t a dog on a positive sample, that prediction is a **false negative** (FN).
+If a classifier predicts that there is a dog on a **positive** sample, that inference is a **true positive** (TP).
+If that classifier predicts that there isn’t a dog on a positive sample, that inference is a **false negative** (FN).
 
-Similarly, if that classifier predicts that there is a dog on a **negative** sample, that prediction is a
-**false positive** (FP). A negative prediction on a negative sample is a **true negative** (TN).
+Similarly, if that classifier predicts that there is a dog on a **negative** sample, that inference is a
+**false positive** (FP). A negative inference on a negative sample is a **true negative** (TN).
 
 ## Implementation Details
 
@@ -49,7 +56,7 @@ In a binary classification task, TP, FN, FP, and TN are implemented as follows:
 | --- | --- | --- |
 | <nobr>`ground_truths`</nobr> | `List[bool]` | Ground truth labels, where `True` indicates a positive sample |
 | `inferences` | <nobr>`List[float]`</nobr> | Predicted confidence scores, where a higher score indicates a higher confidence of the sample being positive |
-| `T` | `float` | Threshold value to compare against the prediction’s confidence score, where `score >= T` is positive |
+| `T` | `float` | Threshold value to compare against the inference’s confidence score, where `score >= T` is positive |
 
 With these inputs, TP / FP/ FN / TN metrics are defined:
 
@@ -100,7 +107,7 @@ these TP / FP / FN / TN metrics is computed for each class. For class `Airplane`
 In a **multi-label** classification task, TP / FP / FN / TN are computed per class, like in multiclass classification.
 
 A sample is considered to be a positive one if the ground truth **includes** the evaluating class; otherwise, it’s a
-negative sample. The same logic can be applied to the predictions, so, for example, if a classifier predicts that this
+negative sample. The same logic can be applied to the inferences, so, for example, if a classifier predicts that this
 sample belongs to class `Airplane` and `Boat`, and the ground truth for the same sample is only class `Airplane`, then
 this sample is considered to be a TP for class `Airplane`, and FP for class `Boat`.
 
@@ -125,16 +132,16 @@ over Union (IoU)](./iou.md) and [Geometry Matching](./geometry-matching.md)).
 
 #### Single-class
 
-Let’s assume that a [matching algorithm](./geometry-matching.md) has already been run on all predictions and that the matched pairs and unmatched
-ground truths and predictions are given. Consider the following variables, adapted from
+Let’s assume that a [matching algorithm](./geometry-matching.md) has already been run on all inferences and that the matched pairs and unmatched
+ground truths and inferences are given. Consider the following variables, adapted from
 [`match_inferences`][kolena.workflow.metrics.match_inferences]:
 
 | Variable | Type | Description |
 | --- | --- | --- |
-| `matched` | <nobr>`List[Tuple[GT, Inf]]`</nobr> | List of **matched** ground truth and prediction bounding box **pairs** |
+| `matched` | <nobr>`List[Tuple[GT, Inf]]`</nobr> | List of **matched** ground truth and inference bounding box **pairs** |
 | `unmatched_gt` | `List[GT]` | List of **unmatched** ground truth bounding boxes |
 | <nobr>`unmatched_inf`</nobr> | `List[Inf]` | List of **unmatched** inference bounding boxes |
-| `T` | `float` | Threshold used to filter valid prediction bounding boxes based on their confidence scores |
+| `T` | `float` | Threshold used to filter valid inference bounding boxes based on their confidence scores |
 
 Then these metrics are defined:
 
@@ -192,8 +199,8 @@ applications is to compute these metrics for each label using the **one-vs-rest*
 as a single-class problem.
 
 Additionally, these four metrics don't take model confidence score into account. All inferences above the confidence
-score threshold are treated the same! For example, when using a confidence score threshold of 0.5, a prediction with a
-confidence score barely above the threshold (e.g. 0.55) is treated the same as a prediction with a very high confidence
-score (e.g. 0.99). In other words, any inference above the confidence threshold is considered as a positive prediction.
+score threshold are treated the same! For example, when using a confidence score threshold of 0.5, an inference with a
+confidence score barely above the threshold (e.g. 0.55) is treated the same as an inference with a very high confidence
+score (e.g. 0.99). In other words, any inference above the confidence threshold is considered as a positive inference.
 To examine performance taking confidence score into account, consider plotting a histogram of the distribution of
 confidence scores.


### PR DESCRIPTION
### Linked issue(s):
[KOL-2578](https://linear.app/kolena/issue/KOL-2578/consistent-capitalization-and-wordings-like-inference-across-metrics)

### What change does this PR introduce and why?
* Replaced the dog classifier image with a table
* Replaced `predictions` to `inferences`.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
