### PR TITLE
enable metrics glossary with cards in the main metrics page

### DIFF
--- a/docs/metrics/accuracy.md
+++ b/docs/metrics/accuracy.md
@@ -1,8 +1,3 @@
----
-search:
-  exclude: true
----
-
 # Accuracy
 
 Accuracy is one of the most well-known metrics in machine learning model evaluation because it is simple to understand

--- a/docs/metrics/averaging-methods.md
+++ b/docs/metrics/averaging-methods.md
@@ -1,8 +1,5 @@
 ---
 subtitle: Macro, Micro, Weighted
-# TODO: remove search exclusion before landing Metrics Glossary
-search:
-  exclude: true
 ---
 
 # Averaging Methods

--- a/docs/metrics/geometry-matching.md
+++ b/docs/metrics/geometry-matching.md
@@ -1,8 +1,3 @@
----
-search:
-  exclude: true
----
-
 # Geometry Matching
 
 Geometry matching is the process of matching inferences to ground truths for computer vision workflows with a

--- a/docs/metrics/index.md
+++ b/docs/metrics/index.md
@@ -19,27 +19,21 @@ biases, and its intended uses.
 
     Accuracy measures how well a model predicts correctly. It's a good metric for assessing model performance in simple
     cases with balanced data.
-</div>
 
-<div class="grid cards" markdown>
 - [Averaging Methods: Macro, Micro, Weighted](averaging-methods.md)
 
     ---
 
     Different averaging methods for aggregating metrics for **multiclass** workflows, such as classification and
     object detection.
-</div>
 
-<div class="grid cards" markdown>
 - [F<sub>1</sub> score](f1-score.md)
 
     ---
 
     F<sub>1</sub> score is a metric that combines two competing metrics, [precision](precision.md) and
     [recall](recall.md) with an equal weight. It symmetrically represents both precision and recall as one metric.
-</div>
 
-<div class="grid cards" markdown>
 - [Geometry Matching](geometry-matching.md)
 
     ---
@@ -48,27 +42,21 @@ biases, and its intended uses.
     localization component. It is a core building block for metrics such as [TP, FP, and FN](tp-fp-fn-tn.md), and any
     metrics built on top of these, like [precision](precision.md), [recall](recall.md), and
     [F<sub>1</sub> score](f1-score.md).
-</div>
 
-<div class="grid cards" markdown>
 - [Intersection over Union (IoU)](iou.md)
 
     ---
 
     IoU measures overlap between two geometries, segmentation masks, sets of labels, or time-series snippets.
     Also known as Jaccard index in classification workflow.
-</div>
 
-<div class="grid cards" markdown>
 - [Precision](precision.md)
 
     ---
 
     Precision measures the proportion of positive inferences from a model that are correct. It is useful when the
     objective is to measure and reduce false positive inferences.
-</div>
 
-<div class="grid cards" markdown>
 - [Recall](recall.md)
 
     ---
@@ -76,9 +64,7 @@ biases, and its intended uses.
     Recall, also known as true positive rate (TPR) and sensitivity, measures the proportion of all positive ground
     truths that a model correctly predicts. It is useful when the objective is to measure and reduce false negative
     ground truths, i.e. model misses.
-</div>
 
-<div class="grid cards" markdown>
 - [TP / FP / FN / TN](tp-fp-fn-tn.md)
 
     ---

--- a/docs/metrics/index.md
+++ b/docs/metrics/index.md
@@ -13,6 +13,15 @@ comparing model performance. In each metrics guide, you can learn about the metr
 biases, and its intended uses.
 
 <div class="grid cards" markdown>
+- [Accuracy](accuracy.md)
+
+    ---
+
+    Accuracy measures how well a model predicts correctly. It's a good metric for assessing model performance in simple
+    cases with balanced data.
+</div>
+
+<div class="grid cards" markdown>
 - [Averaging Methods: Macro, Micro, Weighted](averaging-methods.md)
 
     ---
@@ -22,13 +31,23 @@ biases, and its intended uses.
 </div>
 
 <div class="grid cards" markdown>
+- [F<sub>1</sub> score](f1-score.md)
+
+    ---
+
+    F<sub>1</sub> score is a metric that combines two competing metrics, [precision](precision.md) and
+    [recall](recall.md) with an equal weight. It symmetrically represents both precision and recall as one metric.
+</div>
+
+<div class="grid cards" markdown>
 - [Geometry Matching](geometry-matching.md)
 
     ---
 
     Geometry matching is the process of matching inferences to ground truths for computer vision workflows with a
-    localization component. It is a core building block for metrics such as TP, FP, and FN, and any metrics built on
-    top of these, like precision, recall, and F1 score.
+    localization component. It is a core building block for metrics such as [TP, FP, and FN](tp-fp-fn-tn.md), and any
+    metrics built on top of these, like [precision](precision.md), [recall](recall.md), and
+    [F<sub>1</sub> score](f1-score.md).
 </div>
 
 <div class="grid cards" markdown>
@@ -36,6 +55,35 @@ biases, and its intended uses.
 
     ---
 
-    This metric measures overlap between two geometries, segmentation masks, sets of labels, or time-series snippets.
+    IoU measures overlap between two geometries, segmentation masks, sets of labels, or time-series snippets.
     Also known as Jaccard index in classification workflow.
+</div>
+
+<div class="grid cards" markdown>
+- [Precision](precision.md)
+
+    ---
+
+    Precision measures the proportion of positive inferences from a model that are correct. It is useful when the
+    objective is to measure and reduce false positive inferences.
+</div>
+
+<div class="grid cards" markdown>
+- [Recall](recall.md)
+
+    ---
+
+    Recall, also known as true positive rate (TPR) and sensitivity, measures the proportion of all positive ground
+    truths that a model correctly predicts. It is useful when the objective is to measure and reduce false negative
+    ground truths, i.e. model misses.
+</div>
+
+<div class="grid cards" markdown>
+- [TP / FP / FN / TN](tp-fp-fn-tn.md)
+
+    ---
+
+    The counts of TP, FP, FN and TN ground truths and inferences are essential for summarizing model performance. They
+    are the building blocks of many other metrics, including [accuracy](accuracy.md), [precision](precision.md),
+    and [recall](recall.md).
 </div>

--- a/docs/metrics/index.md
+++ b/docs/metrics/index.md
@@ -27,11 +27,11 @@ biases, and its intended uses.
     Different averaging methods for aggregating metrics for **multiclass** workflows, such as classification and
     object detection.
 
-- [F<sub>1</sub> score](f1-score.md)
+- [F<sub>1</sub>-score](f1-score.md)
 
     ---
 
-    F<sub>1</sub> score is a metric that combines two competing metrics, [precision](precision.md) and
+    F<sub>1</sub>-score is a metric that combines two competing metrics, [precision](precision.md) and
     [recall](recall.md) with an equal weight. It symmetrically represents both precision and recall as one metric.
 
 - [Geometry Matching](geometry-matching.md)
@@ -41,7 +41,7 @@ biases, and its intended uses.
     Geometry matching is the process of matching inferences to ground truths for computer vision workflows with a
     localization component. It is a core building block for metrics such as [TP, FP, and FN](tp-fp-fn-tn.md), and any
     metrics built on top of these, like [precision](precision.md), [recall](recall.md), and
-    [F<sub>1</sub> score](f1-score.md).
+    [F<sub>1</sub>-score](f1-score.md).
 
 - [Intersection over Union (IoU)](iou.md)
 

--- a/docs/metrics/index.md
+++ b/docs/metrics/index.md
@@ -1,8 +1,5 @@
 ---
 icon: kolena/metrics-glossary-16
-# TODO: remove search exclusion before landing Metrics Glossary
-search:
-  exclude: true
 hide:
   - toc
 ---

--- a/docs/metrics/iou.md
+++ b/docs/metrics/iou.md
@@ -1,9 +1,3 @@
----
-# TODO: remove search exclusion before landing Metrics Glossary
-search:
-  exclude: true
----
-
 # Intersection over Union (IoU)
 
 Intersection over Union (IoU) measures the ratio of the intersection and the union between ground truth and inference,

--- a/docs/metrics/precision.md
+++ b/docs/metrics/precision.md
@@ -1,8 +1,3 @@
----
-search:
-  exclude: true
----
-
 # Precision
 
 <div class="grid" markdown>

--- a/docs/metrics/recall.md
+++ b/docs/metrics/recall.md
@@ -1,8 +1,3 @@
----
-search:
-  exclude: true
----
-
 # Recall (TPR, Sensitivity)
 
 <div class="grid" markdown>

--- a/docs/metrics/tp-fp-fn-tn.md
+++ b/docs/metrics/tp-fp-fn-tn.md
@@ -1,8 +1,3 @@
----
-search:
-  exclude: true
----
-
 # TP / FP / FN / TN
 
 The counts of **true positive** (TP), **false positive** (FP), **false negative** (FN), and **true negative** (TN)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,17 +49,16 @@ nav:
               - <code>detection</code>: reference/legacy/built-in/detection.md
               - <code>fr</code>: reference/legacy/built-in/fr.md
               - Base Definitions: reference/legacy/built-in/base.md
-  # TODO: uncomment when landing Metrics Glossary
-  # - Metrics Glossary:
-  #     - Metrics Glossary: metrics/index.md
-  #     - metrics/accuracy.md
-  #     - metrics/averaging-methods.md
-  #     - metrics/geometry-matching.md
-  #     - metrics/f1-score.md
-  #     - metrics/iou.md
-  #     - metrics/precision.md
-  #     - metrics/recall.md
-  #     - metrics/tp-fp-fn-tn.md
+  - Metrics Glossary:
+      - Metrics Glossary: metrics/index.md
+      - metrics/accuracy.md
+      - metrics/averaging-methods.md
+      - metrics/geometry-matching.md
+      - metrics/f1-score.md
+      - metrics/iou.md
+      - metrics/precision.md
+      - metrics/recall.md
+      - metrics/tp-fp-fn-tn.md
   - Help & FAQ:
       - Help & FAQ: faq/index.md
   - Sign in ↗: https://app.kolena.io


### PR DESCRIPTION
### Linked issue(s):
[KOL-2476](https://linear.app/kolena/issue/KOL-2476/migrate-notion-docs-to-markdown-docs)

### What change does this PR introduce and why?
Enables metrics glossary and completed the full list of cards in the main metrics page

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
