### PR TITLE
Metrics Glossary: Consistent wordings 

### DIFF
--- a/docs/metrics/accuracy.md
+++ b/docs/metrics/accuracy.md
@@ -6,7 +6,7 @@ and straightforward to calculate.
 Accuracy measures how often a model correctly predicts something (ranging from 0 to 1, with 1 being perfect
 inferences). It reports the ratio of the number of correct inferences to the total number of inferences,
 making it a good metric for assessing model performance in simple cases with balanced data. However, accuracy is much
-less meaningful with unbalanced datasets (e.g. far more negative samples than positive samples) and should be used with
+less meaningful with unbalanced datasets (e.g. far more negative ground truths than positive ground truths) and should be used with
 caution.
 
 ## Implementation Details
@@ -24,7 +24,7 @@ $$
 
 ### Examples
 
-Perfect inferences across 20 samples:
+Perfect inferences:
 
 <div class="grid" markdown>
 | Metric | Value |
@@ -42,7 +42,7 @@ $$
 $$
 </div>
 
-Partially correct inferences across 20 samples:
+Partially correct inferences:
 
 <div class="grid" markdown>
 | Metric | Value |
@@ -60,7 +60,7 @@ $$
 $$
 </div>
 
-Highly imbalanced data, with 99 negative samples and 10 positive samples, with _no_ positive inferences:
+Highly imbalanced data, with 990 negative ground truths and 10 positive ground truths, with _no_ positive inferences:
 
 <div class="grid" markdown>
 | Metric | Value |
@@ -91,13 +91,13 @@ While accuracy generally describes a classifier’s performance, it is important
 especially when [the data is imbalanced](https://stephenallwright.com/imbalanced-data/).
 
 For example, let’s say there
-are a total of 500 samples, with 450 belonging to the positive class and 50 to the negative. If the model correctly
-predicts all the positive samples but misses all the negative ones, its accuracy is `450 / 500 = 0.9`. An accuracy score
-of 90% indicates a pretty good model — but is a model that fails 100% of the time on negative samples useful? Using the
+are a total of 500 ground truths, with 450 belonging to the positive class and 50 to the negative. If the model correctly
+predicts all the positive ground truths but misses all the negative ones, its accuracy is `450 / 500 = 0.9`. An accuracy score
+of 90% indicates a pretty good model — but is a model that fails 100% of the time on negative ground truths useful? Using the
 accuracy metric alone can hide a model’s true performance, so we recommend other metrics that are better suited for
 imbalanced data, such as:
 
 - [Balanced accuracy](https://stephenallwright.com/balanced-accuracy/)
-- Precision
-- Recall
-- F1 score
+- [Precision](./precision.md)
+- [Recall](./recall.md)
+- [F<sub>1</sub>-score](./f1-score.md)

--- a/docs/metrics/accuracy.md
+++ b/docs/metrics/accuracy.md
@@ -14,7 +14,7 @@ caution.
 Accuracy is generally used to evaluate classification models. Aside from classification, accuracy is also often
 used to evaluate semantic segmentation models by measuring the percent of correctly classified pixels in an image.
 
-In a classification task, accuracy is the ratio of the number of correct inferences to the total number of inferences.
+In a classification workflow, accuracy is the ratio of the number of correct inferences to the total number of inferences.
 
 With [TP / FP / FN / TN counts](./tp-fp-fn-tn.md) computed, accuracy is defined:
 

--- a/docs/metrics/accuracy.md
+++ b/docs/metrics/accuracy.md
@@ -6,7 +6,7 @@ and straightforward to calculate.
 Accuracy measures how often a model correctly predicts something (ranging from 0 to 1, with 1 being perfect
 inferences). It reports the ratio of the number of correct inferences to the total number of inferences,
 making it a good metric for assessing model performance in simple cases with balanced data. However, accuracy is much
-less meaningful with unbalanced datasets (e.g. far more negative ground truths than positive ground truths) and should be used with
+less meaningful with imbalanced datasets (e.g. far more negative ground truths than positive ground truths) and should be used with
 caution.
 
 ## Implementation Details

--- a/docs/metrics/averaging-methods.md
+++ b/docs/metrics/averaging-methods.md
@@ -4,9 +4,10 @@ subtitle: Macro, Micro, Weighted
 
 # Averaging Methods
 
-For multiclass workflows like classification or object detection, metrics such as precision, recall, and F1-score are
-computed **per class**. To compute a single value that represents model performance across all classes, these per-class
-scores need to be aggregated. There are a few different averaging methods for doing this, most notably:
+For multiclass workflows like classification or object detection, metrics such as [precision](./precision.md),
+[recall](./recall.md), and [F<sub>1</sub>-score](./f1-score.md) are computed **per class**. To compute a single value that represents model performance across all
+classes, these per-class scores need to be aggregated. There are a few different averaging methods for doing this, most
+notably:
 
 - [**Macro**](#macro-average): unweighted mean of all per-class scores
 - [**Micro**](#micro-average): global average of per-sample TP, FP, FN scores
@@ -31,7 +32,7 @@ Let’s consider the following multiclass classification metrics, computed acros
 
 $$
 \begin{align}
-\text{F1}_\text{macro} &= \frac{\text{F1}_\texttt{Airplane} + \text{F1}_\texttt{Boat} + \text{F1}_\texttt{Car}}{3} \\[1em]
+\text{F}_{1 \, \text{macro}} &= \frac{\text{F}_{1 \, \texttt{Airplane}} + \text{F}_{1 \, \texttt{Boat}} + \text{F}_{1 \, \texttt{Car}}}{3} \\[1em]
 &= \frac{0.67 + 0.4 + 0.67}{3} \\[1em]
 &= 0.58
 \end{align}
@@ -39,8 +40,8 @@ $$
 
 ### Micro Average
 
-In contrast to macro, **micro average** computes a **global** average by counting the sums of true positive (TP), false
-negative (FN) and false positive (FP).
+In contrast to macro, **micro average** computes a **global** average by counting the sums of [true positive (TP), false
+negative (FN) and false positive (FP)](./tp-fp-fn-tn.md).
 
 **Micro precision** and **micro recall** are computed with the standard precision and recall formulas, using the total
 TP/FP/FN counts across all classes:
@@ -63,25 +64,25 @@ $$
 $$
 </div>
 
-What about **micro F1**? Plug the micro-averaged values for precision and recall into the standard formula for F1 score:
+What about **micro F<sub>1</sub>**? Plug the micro-averaged values for precision and recall into the standard formula for F<sub>1</sub>-score:
 
 $$
 \begin{align}
-\text{F1}_\text{micro} &= 2 \times \frac{\text{Precision}_\text{micro} \times \text{Recall}_\text{micro}}{\text{Precision}_\text{micro} + \text{Recall}_\text{micro}} \\[1em]
+\text{F}_{1 \, \text{micro}} &= 2 \times \frac{\text{Precision}_\text{micro} \times \text{Recall}_\text{micro}}{\text{Precision}_\text{micro} + \text{Recall}_\text{micro}} \\[1em]
 &= 2 \times \frac{0.6 \times 0.6}{0.6 + 0.6} \\[1em]
 &= 0.6
 \end{align}
 $$
 
 
-Note that precision, recall, and F1-score all have the same value: $0.6$. This is because micro-averaging essentially
+Note that precision, recall, and F<sub>1</sub>-score all have the same value: $0.6$. This is because micro-averaging essentially
 computes the proportion of correctly classified instances out of all instances, which is the definition of overall
 **accuracy**.
 
-In the multi-class classification cases where each sample has a single label, we get the following:
+In the multiclass classification cases where each sample has a single label, we get the following:
 
 $$
-\text{F1}_\text{micro} = \text{Precision}_\text{micro} = \text{Recall}_\text{micro} = \text{Accuracy}
+\text{F}_{1 \, \text{micro}} = \text{Precision}_\text{micro} = \text{Recall}_\text{micro} = \text{Accuracy}
 $$
 
 ### Weighted Average
@@ -95,9 +96,9 @@ class’s support relative to the sum of all support values:
 
 $$
 \begin{align}
-\text{F1}_\text{weighted} &= \left( \text{F1}_\texttt{Airplane} \times \tfrac{\text{#}\ \texttt{Airplane}}{\text{# Total}} \right)
-+ \left( \text{F1}_\texttt{Boat} \times \tfrac{\text{#}\ \texttt{Boat}}{\text{# Total}} \right)
-+ \left( \text{F1}_\texttt{Car} \times \tfrac{\text{#}\ \texttt{Car}}{\text{# Total}} \right) \\[1em]
+\text{F}_{1 \, \text{weighted}} &= \left( \text{F}_{1 \, \texttt{Airplane}} \times \tfrac{\text{#}\ \texttt{Airplane}}{\text{# Total}} \right)
++ \left( \text{F}_{1 \, \texttt{Boat}} \times \tfrac{\text{#}\ \texttt{Boat}}{\text{# Total}} \right)
++ \left( \text{F}_{1 \, \texttt{Car}} \times \tfrac{\text{#}\ \texttt{Car}}{\text{# Total}} \right) \\[1em]
 &= \left( 0.67 \times \tfrac{3}{10} \right) + \left( 0.4 \times \tfrac{1}{10} \right) + \left( 0.67 \times \tfrac{6}{10} \right) \\[1em]
 &= 0.64
 \end{align}

--- a/docs/metrics/geometry-matching.md
+++ b/docs/metrics/geometry-matching.md
@@ -2,8 +2,8 @@
 
 Geometry matching is the process of matching inferences to ground truths for computer vision workflows with a
 localization component, such as 2D and 3D object detection and instance segmentation. It is a building block for metrics
-like true positive/false positive/false negative counts and any metrics derived from these, such as precision and
-recall.
+like [TP / FP / FN counts](./tp-fp-fn-tn.md) and any metrics derived from these, such as [precision](./precision.md) and
+[recall](./recall.md).
 
 While it may sound simple, geometry matching is surprisingly challenging and full of edge cases! In this guide, we'll
 focus on 2D object detection—specifically 2D bounding box matching—to learn about geometry matching algorithms.
@@ -267,7 +267,7 @@ Another behavior to note here is that it is possible to get different matching r
 **order** when there are multiple ground truths overlapping with an inference with the equal IoU or depending on the
 **inference order** when there are multiple inferences overlapping with a ground truth with the equal confidence score.
 
-??? example "Example: Different Matching Results when Ground Truth Order Changes"
+??? example "Example: Different Matching Results When Ground Truth Order Changes"
 
 	![An example of ground truth ordering](../assets/images/metrics-matcher-gt-order.png)
 

--- a/docs/metrics/index.md
+++ b/docs/metrics/index.md
@@ -57,7 +57,7 @@ biases, and its intended uses.
     Precision measures the proportion of positive inferences from a model that are correct. It is useful when the
     objective is to measure and reduce false positive inferences.
 
-- [Recall](recall.md)
+- [Recall (TPR, Sensitivity)](recall.md)
 
     ---
 

--- a/docs/metrics/iou.md
+++ b/docs/metrics/iou.md
@@ -123,7 +123,7 @@ $$
 ### Segmentation Mask
 
 A [segmentation mask][kolena.workflow.annotation.SegmentationMask] is a 2D image where each pixel is a class label
-commonly used in semantic segmentation tasks. The inference shape matches the ground truth shape (width and height),
+commonly used in semantic segmentation workflow. The inference shape matches the ground truth shape (width and height),
 with a channel depth equivalent to the number of class labels to be predicted. Each channel is a binary mask that
 labels areas where a specific class is present:
 
@@ -170,7 +170,7 @@ $$
 
 ### Set of Labels
 
-The set of labels used in multi-label classification tasks is often a
+The set of labels used in multi-label classification workflow is often a
 [binarized](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.label_binarize.html) list with a
 number of label elements, for example, let’s say there are three classes, `Airplane`, `Boat`, and `Car`, and a sample
 is labeled as `Boat` and `Car`. The binary set of labels would then be $[0, 1, 1]$, where each element represents each

--- a/docs/metrics/iou.md
+++ b/docs/metrics/iou.md
@@ -187,7 +187,7 @@ $$
 The IoU for multi-label classification is defined per class. This technique, also known as one-vs-the-rest (OvR),
 evaluates each class as a binary classification problem. Per-class IoU values can then be aggregated using different
 [averaging methods](./averaging-methods.md). The popular choice for this workflow is **macro**, so let’s take a look at
-examples of different averaged IoU/Jaccard index metrics for multi-class multi-label classification:
+examples of different averaged IoU/Jaccard index metrics for multiclass multi-label classification:
 
 **Example: macro IoU of ground truth and inference label sets: `Airplane`, `Boat`, `Car`**
 

--- a/docs/metrics/precision.md
+++ b/docs/metrics/precision.md
@@ -5,7 +5,7 @@
 Precision measures the proportion of positive inferences from a model that are correct, ranging from 0 to 1 (where
 1 is best).
 
-As shown in this diagram, precision is the fraction all inferences that are correct:
+As shown in this diagram, precision is the fraction of all inferences that are correct:
 
 $$\text{Precision} = \frac{\text{TP}}{\text{TP} + \text{FP}}$$
 

--- a/docs/metrics/precision.md
+++ b/docs/metrics/precision.md
@@ -35,7 +35,7 @@ Precision is used across a wide range of workflows, including classification, ob
 semantic segmentation, and information retrieval. It is especially useful when the objective is to measure and reduce
 **false positive** inferences.
 
-For most tasks, precision is the ratio of the number of correct positive inferences to
+For most workflows, precision is the ratio of the number of correct positive inferences to
 the total number of positive inferences:
 
 $$\text{Precision} = \frac{\text{# True Positives}}{\text{# True Positives} + \text{# False Positives}}$$

--- a/docs/metrics/precision.md
+++ b/docs/metrics/precision.md
@@ -95,7 +95,7 @@ $$
 
 ### Multiple Classes
 
-So far, we have only looked at **binary** classification/object detection cases, but in **multi-class** or
+So far, we have only looked at **binary** classification/object detection cases, but in **multiclass** or
 **multi-label** cases, precision is computed per class. In the [TP / FP / FN / TN](./tp-fp-fn-tn.md) guide,
 we went over multiple-class cases and how these metrics are computed. Once you have these four metrics computed per
 class, you can compute precision for each class by treating each as a single-class problem.
@@ -112,5 +112,5 @@ As seen in its formula, precision only takes **positive** inferences (TP and FP)
 (TN and FN) are not considered. Thus, precision only provides one half of the picture, and should always be used in
 tandem with [recall](./recall.md): recall penalizes false negatives (FN), whereas precision does not.
 
-For a single metric that takes both precision and recall into account, use F1 score, which is the harmonic mean between
+For a single metric that takes both precision and recall into account, use F<sub>1</sub>-score, which is the harmonic mean between
 precision and recall.

--- a/docs/metrics/recall.md
+++ b/docs/metrics/recall.md
@@ -97,7 +97,7 @@ $$
 
 ### Multiple Classes
 
-So far, we have only looked at **binary** classification/object detection cases, but in **multi-class** or
+So far, we have only looked at **binary** classification/object detection cases, but in **multiclass** or
 **multi-label** cases, recall is computed per class. In the [TP / FP / FN / TN](./tp-fp-fn-tn.md) guide,
 we went over multiple-class cases and how these metrics are computed. Once you have these four metrics computed per
 class, you can compute recall for each class by treating each as a single-class problem.
@@ -114,5 +114,5 @@ As seen in its formula, recall only takes **positive** ground truths (TP and FN)
 (TN and FP) are not considered. Thus, recall only provides one half of the picture, and should always be used in
 tandem with [precision](./precision.md): precision penalizes false positives (FP), whereas recall does not.
 
-For a single metric that takes both precision and recall into account, use F1 score, which is the harmonic mean between
+For a single metric that takes both precision and recall into account, use F<sub>1</sub>-score, which is the harmonic mean between
 precision and recall.

--- a/docs/metrics/recall.md
+++ b/docs/metrics/recall.md
@@ -5,7 +5,7 @@
 Recall, also known as **true positive rate** (TPR) and **sensitivity**, measures the proportion of all positive
 ground truths that a model correctly predicts, ranging from 0 to 1 (where 1 is best).
 
-As shown in this diagram, recall is the fraction all positive ground truths that are correctly predicted:
+As shown in this diagram, recall is the fraction of all positive ground truths that are correctly predicted:
 
 $$\text{Recall} = \frac{\text{TP}}{\text{TP} + \text{FN}}$$
 

--- a/docs/metrics/tp-fp-fn-tn.md
+++ b/docs/metrics/tp-fp-fn-tn.md
@@ -41,11 +41,11 @@ cases to be aware of for binary and multiclass problems as well as object detect
 
 ### Classification
 
-There are three types of classification tasks: **binary**, **multiclass,** and **multi-label**.
+There are three types of classification workflows: **binary**, **multiclass,** and **multi-label**.
 
 #### Binary
 
-In a binary classification task, TP, FN, FP, and TN are implemented as follows:
+In binary classification workflow, TP, FN, FP, and TN are implemented as follows:
 
 | Variable | Type | Description |
 | --- | --- | --- |
@@ -82,9 +82,9 @@ TN = sum(not gt and inf <  T for gt, inf in zip(ground_truths, inferences))
 
 #### Multiclass
 
-TP / FP / FN / TN metrics are computed a little differently in **multiclass** classification tasks.
+TP / FP / FN / TN metrics are computed a little differently in a **multiclass** classification workflow.
 
-For multiclass classification tasks, these four metrics are defined **per class**. This technique,
+For a multiclass classification workflow, these four metrics are defined **per class**. This technique,
 also known as **one-vs-rest** (OvR), essentially evaluates each class as a binary classification problem.
 
 Consider a classification problem where a given image belongs to either the `Airplane`, `Boat`, or `Car` class. Each of
@@ -99,18 +99,18 @@ these TP / FP / FN / TN metrics is computed for each class. For class `Airplane`
 
 #### Multi-label
 
-In a **multi-label** classification task, TP / FP / FN / TN are computed per class, like in multiclass classification.
+In a **multi-label** classification workflow, TP / FP / FN / TN are computed per class, like in multiclass classification.
 
 A sample is considered to be a positive one if the ground truth **includes** the evaluating class; otherwise, it’s a
 negative sample. The same logic can be applied to the inferences, so, for example, if a classifier predicts that this
 sample belongs to class `Airplane` and `Boat`, and the ground truth for the same sample is only class `Airplane`, then
 this sample is considered to be a TP for class `Airplane`, and FP for class `Boat`.
 
-Multi-label classification tasks can alternately be thought of as a collection of binary classification tasks.
+Multi-label classification workflow can alternately be thought of as a collection of binary classification workflows.
 
 ### Object Detection
 
-There are some differences in how these four metrics work for a detection task compared to a classification task.
+There are some differences in how these four metrics work for a detection workflow compared to a classification workflow.
 Rather than being computed at the sample level (e.g. per image), they're computed at the instance level (i.e. per object)
 for instances that the model is detecting. When given an image with multiple objects, each inference and each ground truth
 is assigned to one group, and the definitions of the terms are slightly altered:
@@ -120,9 +120,9 @@ is assigned to one group, and the definitions of the terms are slightly altered:
 | True Positive | TP | Inference that is matched with a ground truth and has a confidence score $\geq$ threshold |
 | False Positive | FP | Inference that is not matched with a ground truth and has a confidence score $\geq$ threshold |
 | <nobr>False Negative</nobr> | FN | Ground truth that is not matched with an inference or that is matched with an inference that has a confidence score $<$ threshold |
-| True Negative | TN | <p>:kolena-warning-sign-16: **Poorly defined for object detection!** :kolena-warning-sign-16:</p><p>In object detection tasks, a true negative is any non-object that isn't detected as an object. This isn't well defined and as such true negative isn't a commonly used metric in object detection.</p><div>Occasionally, for object detection tasks "true negative" is used to refer to any image that does not have any true positive or false positive inferences.</div> |
+| True Negative | TN | <p>:kolena-warning-sign-16: **Poorly defined for object detection!** :kolena-warning-sign-16:</p><p>In object detection workflow, a true negative is any non-object that isn't detected as an object. This isn't well defined and as such true negative isn't a commonly used metric in object detection.</p><div>Occasionally, for object detection workflow "true negative" is used to refer to any image that does not have any true positive or false positive inferences.</div> |
 
-In an object detection task, checking for detection correctness requires a couple of other metrics (e.g., [Intersection
+In object detection workflow, checking for detection correctness requires a couple of other metrics (e.g., [Intersection
 over Union (IoU)](./iou.md) and [Geometry Matching](./geometry-matching.md)).
 
 #### Single-class
@@ -161,7 +161,7 @@ FP = len([inf.score >= T for inf in unmatched_inf])
 
 #### Multiclass
 
-Like classification, multiclass object detection tasks compute TP / FP / FN per class.
+Like classification, multiclass object detection workflow compute TP / FP / FN per class.
 
 ??? example "Example: Multiclass Object Detection"
 

--- a/docs/metrics/tp-fp-fn-tn.md
+++ b/docs/metrics/tp-fp-fn-tn.md
@@ -1,7 +1,7 @@
 # TP / FP / FN / TN
 
 The counts of **true positive** (TP), **false positive** (FP), **false negative** (FN), and **true negative** (TN)
-inferences and ground truths are essential for summarizing model performance. These metrics are the building blocks of
+ground truths and inferences are essential for summarizing model performance. These metrics are the building blocks of
 many other metrics, including [accuracy](./accuracy.md), [precision](./precision.md), and [recall](./recall.md).
 
 | Metric | | Description |

--- a/docs/metrics/tp-fp-fn-tn.md
+++ b/docs/metrics/tp-fp-fn-tn.md
@@ -2,7 +2,7 @@
 
 The counts of **true positive** (TP), **false positive** (FP), **false negative** (FN), and **true negative** (TN)
 inferences and ground truths are essential for summarizing model performance. These metrics are the building blocks of
-many other metrics, including accuracy, precision, and recall.
+many other metrics, including [accuracy](./accuracy.md), [precision](./precision.md), and [recall](./recall.md).
 
 | Metric | | Description |
 | --- | --- | --- |
@@ -41,7 +41,7 @@ cases to be aware of for binary and multiclass problems as well as object detect
 
 ### Classification
 
-There are three types of classification tasks: **binary**, **multi-class,** and **multi-label**.
+There are three types of classification tasks: **binary**, **multiclass,** and **multi-label**.
 
 #### Binary
 
@@ -188,7 +188,7 @@ Read more about these different averaging methods in the [Averaging Methods guid
 
 ## Limitations and Biases
 
-TP, FP, TN, and FN are four metrics based on the assumption that each sample/instance can be classified as a positive
+TP, FP, FN, and TN are four metrics based on the assumption that each sample/instance can be classified as a positive
 or a negative, thus they can only be applied to single-class applications. The workaround for multiple-class
 applications is to compute these metrics for each label using the **one-vs-rest** (OvR) strategy and then treat it
 as a single-class problem.

--- a/kolena/workflow/metrics/_formula.py
+++ b/kolena/workflow/metrics/_formula.py
@@ -15,7 +15,7 @@
 
 def precision(true_positives: int, false_positives: int) -> float:
     """
-    Precision represents the proportion of predictions that are correct.
+    Precision represents the proportion of inferences that are correct.
 
     $$
     \\text{Precision} = \\frac{\\text{# True Positives}}{\\text{# True Positives} + \\text{# False Positives}}
@@ -25,8 +25,8 @@ def precision(true_positives: int, false_positives: int) -> float:
     - :kolena-metrics-glossary-16: Metrics Glossary: [Precision ↗](../../metrics/precision.md)
     </div>
 
-    :param true_positives: Number of true positive predictions.
-    :param false_positives: Number of false positive predictions.
+    :param true_positives: Number of true positive inferences.
+    :param false_positives: Number of false positive inferences.
     """
     denominator = true_positives + false_positives
     return true_positives / denominator if denominator > 0 else 0
@@ -44,7 +44,7 @@ def recall(true_positives: int, false_negatives: int) -> float:
     - :kolena-metrics-glossary-16: Metrics Glossary: [Recall ↗](../../metrics/recall.md)
     </div>
 
-    :param true_positives: Number of true positive predictions.
+    :param true_positives: Number of true positive inferences.
     :param false_negatives: Number of false negatives.
     """
     denominator = true_positives + false_negatives
@@ -53,7 +53,7 @@ def recall(true_positives: int, false_negatives: int) -> float:
 
 def f1_score(true_positives: int, false_positives: int, false_negatives: int) -> float:
     """
-    F1 score is the harmonic mean between [`precision`][kolena.workflow.metrics.precision] and
+    F<sub>1</sub>-score is the harmonic mean between [`precision`][kolena.workflow.metrics.precision] and
     [`recall`][kolena.workflow.metrics.recall].
 
     $$
@@ -68,8 +68,8 @@ def f1_score(true_positives: int, false_positives: int, false_negatives: int) ->
     - :kolena-metrics-glossary-16: Metrics Glossary: [F<sub>1</sub>-score ↗](../../metrics/f1-score.md)
     </div>
 
-    :param true_positives: Number of true positive predictions.
-    :param false_positives: Number of false positive predictions.
+    :param true_positives: Number of true positive inferences.
+    :param false_positives: Number of false positive inferences.
     :param false_negatives: Number of false negatives.
     """
     prec = precision(true_positives, false_positives)

--- a/kolena/workflow/metrics/_geometry.py
+++ b/kolena/workflow/metrics/_geometry.py
@@ -80,7 +80,7 @@ def iou(a: Union[BoundingBox, Polygon], b: Union[BoundingBox, Polygon]) -> float
 
     :param a: The first geometry in computation.
     :param b: The second geometry in computation.
-    :return: The value of the IOU between geometries `a` and `b`.
+    :return: The value of the IoU between geometries `a` and `b`.
     """
 
     if isinstance(a, BoundingBox) and isinstance(b, BoundingBox):
@@ -117,7 +117,7 @@ class InferenceMatches(Generic[GT, Inf]):
 
     matched: List[Tuple[GT, Inf]]
     """
-    Pairs of matched ground truth and inference objects above the IOU threshold. Considered as true positive
+    Pairs of matched ground truth and inference objects above the IoU threshold. Considered as true positive
     detections after applying some confidence threshold.
     """
 
@@ -145,13 +145,13 @@ def _match_inferences_single_class_pascal_voc(
     # sort inferences by highest confidence first
     inferences = sorted(inferences, key=lambda inf: -inf.score)
 
-    # for each inference, find the ground truth with the highest IOU
+    # for each inference, find the ground truth with the highest IoU
     for inf in inferences:
         best_gt = None
         best_gt_iou = -1.0
         for g, gt in enumerate(gt_objects):
             inf_gt_iou = iou(gt, inf)
-            # track the highest iou over the threshold
+            # track the highest IoU over the threshold
             if inf_gt_iou >= iou_threshold and inf_gt_iou > best_gt_iou:
                 best_gt_iou = inf_gt_iou
                 best_gt = g
@@ -185,7 +185,7 @@ def match_inferences(
 
     Available modes:
 
-    - `pascal` (PASCAL VOC): For every inference by order of highest confidence, the ground truth of highest IOU is
+    - `pascal` (PASCAL VOC): For every inference by order of highest confidence, the ground truth of highest IoU is
       its match. Multiple inferences are able to match with the same ignored ground truth. See the
       [PASCAL VOC paper](https://homepages.inf.ed.ac.uk/ckiw/postscript/ijcv_voc09.pdf) for more information.
 
@@ -203,7 +203,7 @@ def match_inferences(
         ground truths to ignore. These ignored ground truths and any inferences matched with them are
         omitted from the returned [`InferenceMatches`][kolena.workflow.metrics.InferenceMatches].
     :param mode: The matching methodology to use. See available modes above.
-    :param iou_threshold: The IOU (intersection over union, see [`iou`][kolena.workflow.metrics.iou]) threshold for
+    :param iou_threshold: The IoU (intersection over union, see [`iou`][kolena.workflow.metrics.iou]) threshold for
         valid matches.
     :return: [`InferenceMatches`][kolena.workflow.metrics.InferenceMatches] containing the matches (true positives),
         unmatched ground truths (false negatives) and unmatched inferences (false positives).
@@ -241,13 +241,13 @@ class MulticlassInferenceMatches(Generic[GT_Multiclass, Inf_Multiclass]):
 
     matched: List[Tuple[GT_Multiclass, Inf_Multiclass]]
     """
-    Pairs of matched ground truth and inference objects above the IOU threshold. Considered as true positive
+    Pairs of matched ground truth and inference objects above the IoU threshold. Considered as true positive
     detections after applying some confidence threshold.
     """
 
     unmatched_gt: List[Tuple[GT_Multiclass, Optional[Inf_Multiclass]]]
     """
-    Pairs of unmatched ground truth objects with its confused inference object (i.e. IOU above threshold with
+    Pairs of unmatched ground truth objects with its confused inference object (i.e. IoU above threshold with
     mismatching `label`), if such an inference exists. Considered as false negatives and "confused" detections.
     """
 
@@ -268,12 +268,12 @@ def match_inferences_multiclass(
 
     This matcher considers `label` values matching per class. After matching inferences and ground truths with
     equivalent `label` values, unmatched inferences and unmatched ground truths are matched once more to identify
-    confused matches, where localization succeeded (i.e. IOU above `iou_threshold`) but classification failed (i.e.
+    confused matches, where localization succeeded (i.e. IoU above `iou_threshold`) but classification failed (i.e.
     mismatching `label` values).
 
     Available modes:
 
-    - `pascal` (PASCAL VOC): For every inference by order of highest confidence, the ground truth of highest IOU is
+    - `pascal` (PASCAL VOC): For every inference by order of highest confidence, the ground truth of highest IoU is
       its match. Multiple inferences are able to match with the same ignored ground truth. See the
       [PASCAL VOC paper](https://homepages.inf.ed.ac.uk/ckiw/postscript/ijcv_voc09.pdf) for more information.
 
@@ -293,7 +293,7 @@ def match_inferences_multiclass(
         truths and any inferences matched with them are omitted from the returned
         [`MulticlassInferenceMatches`][kolena.workflow.metrics.MulticlassInferenceMatches].
     :param mode: The matching methodology to use. See available modes above.
-    :param iou_threshold: The IOU threshold cutoff for valid matches.
+    :param iou_threshold: The IoU threshold cutoff for valid matches.
     :return:
         [`MulticlassInferenceMatches`][kolena.workflow.metrics.MulticlassInferenceMatches] containing the matches
         (true positives), unmatched ground truths (false negatives), and unmatched inferences (false positives).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,8 +53,8 @@ nav:
       - Metrics Glossary: metrics/index.md
       - metrics/accuracy.md
       - metrics/averaging-methods.md
-      - metrics/geometry-matching.md
       - metrics/f1-score.md
+      - metrics/geometry-matching.md
       - metrics/iou.md
       - metrics/precision.md
       - metrics/recall.md


### PR DESCRIPTION
### Linked issue(s):
[KOL-2578](https://linear.app/kolena/issue/KOL-2578/consistent-capitalization-and-wordings-like-inference-across-metrics), [KOL-2584](https://linear.app/kolena/issue/KOL-2584/metrics-ordered-differently-in-the-metrics-grid-and-the-side-bar), [KOL-2585](https://linear.app/kolena/issue/KOL-2585/replace-samples-with-ground-truths), [KOL-2593](https://linear.app/kolena/issue/KOL-2593/unbalanced-imbalanced), [KOL-2595](https://linear.app/kolena/issue/KOL-2595/terminology-predictions-are-used-in-kolenaworkflowmetrics), [KOL-2599](https://linear.app/kolena/issue/KOL-2599/iou-iou), [KOL-2603](https://linear.app/kolena/issue/KOL-2603/typo-in-recall-section), [KOL-2594](https://linear.app/kolena/issue/KOL-2594/terminology-update-task-to-workflow)

### What change does this PR introduce and why?
* predictions -> inferences
* multi-class -> multiclass
* samples -> ground truths
* F1 score -> F<sub>1</sub>-score
* Added links to any existing metrics references 
* IOU -> IoU
* unbalanced -> imbalanced
* typo in recall / precision pages
* tasks -> workflows

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
