### PR TITLE
CircleCI test-splitting needs legacy format

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -207,8 +207,8 @@ jobs:
               TESTFILES=$(find tests/integration/$TEST_GROUP -name "test_*.py" |
                 circleci tests split --split-by=timings --timings-type=filename)
             fi
-            poetry run pytest -vv --durations=10 --cov=kolena --cov-branch --junitxml=test-results/result.xml \
-              $TESTFILES
+            poetry run pytest -vv --durations=10 --cov=kolena --cov-branch -o junit_family=legacy \
+              --junitxml=test-results/result.xml $TESTFILES
       - when:
           # Generate coverage only from one python version
           condition:


### PR DESCRIPTION
### Linked issue(s):

https://circleci.com/docs/troubleshoot-test-splitting/#are-you-setting-the-junit-family-in-your-pytest-ini

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
