### PR TITLE
Remove 'placeholder' text from published documentation

### DIFF
--- a/docs/metrics/precision.md
+++ b/docs/metrics/precision.md
@@ -20,7 +20,7 @@ positive inferences.
 
 <figure markdown>
   ![Precision and recall from Wikipedia](../assets/images/metrics-precision-recall.png)
-  <figcaption markdown>Placeholder diagram of precision and recall from [Wikipedia](https://en.wikipedia.org/wiki/Precision_and_recall#Precision)
+  <figcaption markdown>Diagram of precision and recall from [Wikipedia](https://en.wikipedia.org/wiki/Precision_and_recall#Precision)
 </figure>
 </div>
 

--- a/docs/metrics/recall.md
+++ b/docs/metrics/recall.md
@@ -20,7 +20,7 @@ negative ground truths.
 
 <figure markdown>
   ![Precision and recall from Wikipedia](../assets/images/metrics-precision-recall.png)
-  <figcaption markdown>Placeholder diagram of precision and recall from [Wikipedia](https://en.wikipedia.org/wiki/Precision_and_recall#Precision)
+  <figcaption markdown>Diagram of precision and recall from [Wikipedia](https://en.wikipedia.org/wiki/Precision_and_recall#Precision)
 </figure>
 </div>
 


### PR DESCRIPTION
### Linked issue(s):
Partially addresses [KOL-2588](https://linear.app/kolena/issue/KOL-2588/diagram-on-metricsprecision-and-metricsrecall-doesnt-support-dark-mode)

### What change does this PR introduce and why?
Remove `Placeholder` in diagram description to clean up our published version.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
