### PR TITLE
Add CNAME file to docs directory

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.kolena.io


### PR DESCRIPTION
Follow the pattern [used by mkdocs itself](https://github.com/mkdocs/mkdocs/blob/master/docs/CNAME) and specify a CNAME inside `./docs`. This will prevent `mkdocs gh-deploy` from clearing custom domain settings manually configured in the GitHub UI.

This is a good fix to get in while we're porting the docs hosting over to S3 ([KOL-2634](https://linear.app/kolena/issue/KOL-2634/migrate-docskolenaio-from-github-pages-to-s3)), which is something we should get to sooner rather than later given yesterday's GitHub Pages outage and the general flakiness of GitHub services.

Fixes KOL-2633