### PR TITLE
Override md-code-bg-color derivatives

### DIFF
--- a/docs/assets/css/theme.css
+++ b/docs/assets/css/theme.css
@@ -90,6 +90,8 @@ figcaption {
 
     --md-code-fg-color:                hsla(var(--md-hue), 7%, 90%, 1);
     --md-code-bg-color:                hsla(var(--md-hue), 7%, 17%, 1);
+    --md-code-bg-color--light:         hsla(var(--md-hue), 7%, 17%, 0.75);
+    --md-code-bg-color--lighter:       hsla(var(--md-hue), 7%, 17%, 0.5);
 
     --md-footer-bg-color:              hsla(var(--md-hue), 7%, 10%, 0.87);
     --md-footer-bg-color--dark:        hsla(var(--md-hue), 7%, 8%, 1);


### PR DESCRIPTION
Minor fix for discolored code block copy buttons in dark mode:

![Jun-29-2023 13-56-06](https://github.com/kolenaIO/kolena/assets/9648886/64efd44a-63b7-48f3-8f78-f357a06904eb)

Fixes KOL-2507