### PR TITLE
Set major version upper bounds for dependencies

### DIFF
--- a/examples/age_estimation/pyproject.toml
+++ b/examples/age_estimation/pyproject.toml
@@ -7,9 +7,8 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = ">=0.69.0,<1"
+kolena = ">=0.76.0,<1"
 s3fs = "^2023.5.0"
-pydantic = ">=1.8,<2.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.17"

--- a/examples/keypoint_detection/pyproject.toml
+++ b/examples/keypoint_detection/pyproject.toml
@@ -7,10 +7,9 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = ">=0.69.0,<1"
+kolena = ">=0.76.0,<1"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
-pydantic = ">=1.8,<2.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.17"

--- a/examples/text_summarization/pyproject.toml
+++ b/examples/text_summarization/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-kolena = ">=0.69.0,<1"
+kolena = ">=0.76.0,<1"
 s3fs = "^2022.7.1"
 scikit-learn = "^1.1.2"
 numba = "^0.56.0"
@@ -21,7 +21,6 @@ absl-py = "^1.4.0"
 nltk = "^3.8.1"
 rouge-score = "^0.1.2"
 sacrebleu = "^2.3.1"
-pydantic = ">=1.8,<2.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.17"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Testing with Kolena
-site_description: Python client for Kolena's machine learning (ML) testing and debugging platform
+site_description: Python client for Kolena's machine learning testing platform
 site_url: https://docs.kolena.io
 strict: true
 repo_name: kolenaIO/kolena

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "kolena"
 version = "0.999.0"  # version is automatically set to latest git tag during release process
-description = "Client for Kolena's machine learning (ML) testing and debugging platform."
+description = "Client for Kolena's machine learning testing platform."
 authors = ["Kolena Engineering <eng@kolena.io>"]
 homepage = "https://kolena.io"
 documentation = "https://docs.kolena.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ pandas = [
     { version = ">=1.1,<1.6", python = ">=3.7,<3.11" },
     { version = ">=1.5,<1.6", python = ">=3.11" },
 ]
-pandera = ">=0.9.0"
-pydantic = ">=1.8,<2.0"
-dacite = ">=1.6"
+pandera = ">=0.9.0,<1"
+pydantic = ">=1.8,<2"
+dacite = ">=1.6,<2"
 requests = ">=2.20,<2.30" # TODO: revert upper bound when urllib3 situation sorts out: https://github.com/psf/requests/issues/6432
 requests-toolbelt = "*"
 importlib-metadata = { version = "<5.0", python = "<3.8" }
@@ -47,11 +47,11 @@ Shapely = "^1.8.5"
 deprecation = "^2.1.0"
 termcolor = "^1.1.0"
 pyarrow = ">=8"
-typing-extensions = { version = "^4.5.0", python = "< 3.8" }
+typing-extensions = { version = "^4.5.0", python = "<3.8" }
 click = "^8.1.3"
 scikit-learn = [
     { version = ">=1.0,<1.0.3", python = ">=3.7.1,<3.8",  optional = true },
-    { version = ">=1.2", python = ">=3.8",  optional = true },
+    { version = ">=1.2,<2", python = ">=3.8",  optional = true },
 ]
 
 [tool.poetry.extras]


### PR DESCRIPTION
Following up on the recent Pydantic major version update breaking installs (#125, #129), this PR pins most dependencies to their current major version.