### PR TITLE
restrict pandera<0.16 as it requires pyspark to be installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ pandas = [
     { version = ">=1.1,<1.6", python = ">=3.7,<3.11" },
     { version = ">=1.5,<1.6", python = ">=3.11" },
 ]
-pandera = ">=0.9.0,<1"
+pandera = ">=0.9.0,<0.16"
 pydantic = ">=1.8,<2"
 dacite = ">=1.6,<2"
 requests = ">=2.20,<2.30" # TODO: revert upper bound when urllib3 situation sorts out: https://github.com/psf/requests/issues/6432


### PR DESCRIPTION
### Linked issue(s):
pandera 0.16 was released a few days ago and requires pyspark to be installed inorder to work.

Using the current version of the client (pandera < 1)
```
Type "help", "copyright", "credits" or "license" for more information.
>>> import kolena
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/niteshsandal/Library/Caches/pypoetry/virtualenvs/kolena-contrib-5vPEg8XT-py3.9/lib/python3.9/site-packages/kolena/__init__.py", line 43, in <module>
    import kolena.fr
  File "/Users/niteshsandal/Library/Caches/pypoetry/virtualenvs/kolena-contrib-5vPEg8XT-py3.9/lib/python3.9/site-packages/kolena/fr/__init__.py", line 16, in <module>
    from .datatypes import EmbeddingDataFrame
  File "/Users/niteshsandal/Library/Caches/pypoetry/virtualenvs/kolena-contrib-5vPEg8XT-py3.9/lib/python3.9/site-packages/kolena/fr/datatypes.py", line 29, in <module>
    import pandera as pa
  File "/Users/niteshsandal/Library/Caches/pypoetry/virtualenvs/kolena-contrib-5vPEg8XT-py3.9/lib/python3.9/site-packages/pandera/__init__.py", line 4, in <module>
    import pandera.backends
  File "/Users/niteshsandal/Library/Caches/pypoetry/virtualenvs/kolena-contrib-5vPEg8XT-py3.9/lib/python3.9/site-packages/pandera/backends/__init__.py", line 6, in <module>
    import pandera.backends.pandas
  File "/Users/niteshsandal/Library/Caches/pypoetry/virtualenvs/kolena-contrib-5vPEg8XT-py3.9/lib/python3.9/site-packages/pandera/backends/pandas/__init__.py", line 5, in <module>
    import pandera.typing
  File "/Users/niteshsandal/Library/Caches/pypoetry/virtualenvs/kolena-contrib-5vPEg8XT-py3.9/lib/python3.9/site-packages/pandera/typing/__init__.py", line 9, in <module>
    from pandera.typing import (
  File "/Users/niteshsandal/Library/Caches/pypoetry/virtualenvs/kolena-contrib-5vPEg8XT-py3.9/lib/python3.9/site-packages/pandera/typing/dask.py", line 5, in <module>
    from pandera.typing.common import DataFrameBase, IndexBase, SeriesBase
  File "/Users/niteshsandal/Library/Caches/pypoetry/virtualenvs/kolena-contrib-5vPEg8XT-py3.9/lib/python3.9/site-packages/pandera/typing/common.py", line 11, in <module>
    from pandera.engines import numpy_engine, pandas_engine, pyspark_engine
  File "/Users/niteshsandal/Library/Caches/pypoetry/virtualenvs/kolena-contrib-5vPEg8XT-py3.9/lib/python3.9/site-packages/pandera/engines/pyspark_engine.py", line 17, in <module>
    import pyspark.sql.types as pst
ModuleNotFoundError: No module named 'pyspark'
>>> 

```

After pinning to <0.16, `import kolena` works without issue.

 https://github.com/unionai-oss/pandera/issues/1267 for an issue that was created with pandera.


### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
