### PR TITLE
Added a type cast for `get_histogram_range`

### DIFF
--- a/kolena/_experimental/classification/utils.py
+++ b/kolena/_experimental/classification/utils.py
@@ -72,7 +72,7 @@ def get_histogram_range(values: List[float]) -> Optional[Tuple[float, float, int
         else:
             min_score = max_score - NUM002
 
-    return min_score, max_score, (max_score - min_score - 1e-9) // NUM002 + 1
+    return min_score, max_score, int((max_score - min_score - 1e-9) // NUM002) + 1
 
 
 def create_histogram(

--- a/tests/unit/_experimental/classification/test_utils.py
+++ b/tests/unit/_experimental/classification/test_utils.py
@@ -87,6 +87,8 @@ def test__get_histogram_range(
 ) -> None:
     range = get_histogram_range(values)
     assert range == expected
+    if expected is not None:
+        assert isinstance(range[2], int)  # making sure the # of bin is integer
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?
Non-integer type # of bin output from `get_histogram_range` will break `create_histogram` on `np.histogram`.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
