### PR TITLE
Added a multiclass classification example on CIFAR-10 dataset

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -325,7 +325,7 @@ workflows:
       - example-test:
           matrix:
             parameters:
-              subproject: [ keypoint_detection, age_estimation, object_detection_3d ]
+              subproject: [ keypoint_detection, age_estimation, object_detection_3d, classification ]
               resource-class: [ small ]
               python-version: [ "3.9" ]
   example-evaluator:

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,5 +14,5 @@ arbitrary ML problem.
   [KITTI](https://www.cvlibs.net/datasets/kitti/eval_object.php?obj_benchmark=3d) dataset
 - [Text Summarization](./text_summarization): abstractive text summarization using the
   [CNN-DailyMail](https://paperswithcode.com/dataset/cnn-daily-mail-1) dataset
-- [Mutliclass Classification](./classification#multiclass-classification-on-cifar-10): Multiclass Classification
+- [Mutliclass Classification](https://github.com/kolenaIO/kolena/tree/trunk/examples/classification#multiclass-classification-on-cifar-10): Multiclass Classification
   on image data from [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,3 +14,5 @@ arbitrary ML problem.
   [KITTI](https://www.cvlibs.net/datasets/kitti/eval_object.php?obj_benchmark=3d) dataset
 - [Text Summarization](./text_summarization): abstractive text summarization using the
   [CNN-DailyMail](https://paperswithcode.com/dataset/cnn-daily-mail-1) dataset
+- [Mutliclass Classification](./classification#multiclass-classification-on-cifar-10): Multiclass Classification
+  on image data from [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset

--- a/examples/classification/README.md
+++ b/examples/classification/README.md
@@ -1,0 +1,46 @@
+# Example Integration: Classification
+
+This example integration uses the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) and open-source
+classification models to demonstrate how to test multiclass classification problems on Kolena.
+
+## Setup
+
+This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
+
+```shell
+poetry update && poetry install
+```
+
+## Usage
+
+The data for this example integration lives in the publicly accessible S3 bucket `s3://kolena-public-datasets`.
+
+First, ensure that the `KOLENA_TOKEN` environment variable is populated in your environment. See our
+[initialization documentation](https://docs.kolena.io/installing-kolena/#initialization) for details.
+
+### Multiclass Classification on CIFAR-10
+
+This project defines two scripts that perform the following operations:
+
+1. [`seed_test_suite.py`](scripts/multiclass/seed_test_suite.py) creates the following test suite:
+
+    - `complete cifar10/test [classification]`: complete CIFAR-10
+
+2. [`seed_test_run.py`](scripts/multiclass/seed_test_run.py) tests a specified model, e.g. `resnet50v2`, on the above test suite.
+
+Command line arguments are defined within each script to specify what model to use and what test suite to seed/evaluate.
+Run a script using the `--help` flag for more information:
+
+```shell
+$ poetry run python3 scripts/multiclass/seed_test_run.py --help
+usage: seed_test_run.py [-h] [--models MODELS [MODELS ...]]
+                        [--test_suites TEST_SUITES [TEST_SUITES ...]]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --models MODELS [MODELS ...]
+                        Name(s) of model(s) in directory to test
+  --test_suites TEST_SUITES [TEST_SUITES ...]
+                        Name(s) of test suite(s) to test.
+```

--- a/examples/classification/README.md
+++ b/examples/classification/README.md
@@ -25,9 +25,19 @@ This project defines two scripts that perform the following operations:
 
 1. [`seed_test_suite.py`](scripts/multiclass/seed_test_suite.py) creates the following test suite:
 
-    - `complete cifar10/test [classification]`: complete CIFAR-10
+    - `complete cifar10/test`: complete CIFAR-10
+
+    Run this command to seed the default test suite:
+    ```shell
+    poetry run python3 scripts/multiclass/seed_test_suite.py
+    ```
 
 2. [`seed_test_run.py`](scripts/multiclass/seed_test_run.py) tests a specified model, e.g. `resnet50v2`, on the above test suite.
+
+    Run this command to evaluate the default models on `complete cifar10/test` test suite:
+    ```shell
+    poetry run python3 scripts/multiclass/seed_test_run.py
+    ```
 
 Command line arguments are defined within each script to specify what model to use and what test suite to seed/evaluate.
 Run a script using the `--help` flag for more information:

--- a/examples/classification/classification/__init__.py
+++ b/examples/classification/classification/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/classification/classification/evaluator_multiclass.py
+++ b/examples/classification/classification/evaluator_multiclass.py
@@ -1,0 +1,261 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import make_dataclass
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+import numpy as np
+from classification.workflow import ClassMetricsPerTestCase
+from classification.workflow import GroundTruth
+from classification.workflow import Inference
+from classification.workflow import TestCase
+from classification.workflow import TestCaseMetrics
+from classification.workflow import TestSample
+from classification.workflow import TestSampleMetrics
+from classification.workflow import TestSuiteMetrics
+from classification.workflow import ThresholdConfiguration
+
+from kolena._experimental.classification.utils import compute_confusion_matrix
+from kolena._experimental.classification.utils import compute_roc_curves
+from kolena._experimental.classification.utils import create_histogram
+from kolena._experimental.classification.utils import get_histogram_range
+from kolena._utils import log
+from kolena.workflow import EvaluationResults
+from kolena.workflow import Plot
+from kolena.workflow import TestCases
+from kolena.workflow.metrics import accuracy as compute_accuracy
+from kolena.workflow.metrics import f1_score as compute_f1_score
+from kolena.workflow.metrics import precision as compute_precision
+from kolena.workflow.metrics import recall as compute_recall
+from kolena.workflow.plot import Histogram
+
+
+def compute_test_sample_metric(
+    ground_truth: GroundTruth,
+    inference: Inference,
+    threshold_configuration: ThresholdConfiguration,
+) -> TestSampleMetrics:
+    empty_metrics = TestSampleMetrics(
+        classification=None,
+        margin=None,
+        is_correct=False,
+    )
+
+    if len(inference.inferences) == 0:
+        return empty_metrics
+
+    sorted_infs = sorted(inference.inferences, key=lambda x: x.score, reverse=True)
+    predicted_match = sorted_infs[0]
+    predicted_label, predicted_score = predicted_match.label, predicted_match.score
+
+    if threshold_configuration.threshold is not None and predicted_score < threshold_configuration.threshold:
+        return empty_metrics
+
+    return TestSampleMetrics(
+        classification=predicted_match,
+        margin=predicted_score - sorted_infs[1].score if len(sorted_infs) >= 2 else None,
+        is_correct=predicted_label == ground_truth.classification.label,
+    )
+
+
+def compute_test_case_metrics(
+    ground_truths: List[GroundTruth],
+    metrics_test_samples: List[TestSampleMetrics],
+    labels: List[str],
+) -> TestCaseMetrics:
+    classification_pairs = [
+        (gt.classification.label, tsm.classification.label if tsm.classification else None)
+        for gt, tsm in zip(ground_truths, metrics_test_samples)
+    ]
+    n_images = len(classification_pairs)
+    class_level_metrics: List[ClassMetricsPerTestCase] = []
+    for label in sorted(labels):
+        n_tp = len([True for gt, inf in classification_pairs if gt == label and inf == label])
+        n_fn = len([True for gt, inf in classification_pairs if gt == label and inf != label])
+        n_fp = len([True for gt, inf in classification_pairs if gt != label and inf == label])
+        n_tn = len([True for gt, inf in classification_pairs if gt != label and inf != label])
+
+        class_level_metrics.append(
+            ClassMetricsPerTestCase(
+                label=label,
+                TP=n_tp,
+                FP=n_fp,
+                FN=n_fn,
+                TN=n_tn,
+                Accuracy=compute_accuracy(n_tp, n_fp, n_fn, n_tn),
+                Precision=compute_precision(n_tp, n_fp),
+                Recall=compute_recall(n_tp, n_fn),
+                F1=compute_f1_score(n_tp, n_fp, n_fn),
+                FPR=n_fp / (n_fp + n_tn) if n_fp + n_tn > 0 else 0,
+            ),
+        )
+
+    n_correct = sum([mts.is_correct for mts in metrics_test_samples])
+    return TestCaseMetrics(
+        PerClass=class_level_metrics,
+        n_labels=len(labels),
+        n_correct=n_correct,
+        n_incorrect=n_images - n_correct,
+        Accuracy=n_correct / n_images,
+        macro_Accuracy=np.mean([class_metric.Accuracy for class_metric in class_level_metrics]),
+        macro_Precision=np.mean([class_metric.Precision for class_metric in class_level_metrics]),
+        macro_Recall=np.mean([class_metric.Recall for class_metric in class_level_metrics]),
+        macro_F1=np.mean([class_metric.F1 for class_metric in class_level_metrics]),
+        macro_FPR=np.mean([class_metric.FPR for class_metric in class_level_metrics]),
+    )
+
+
+def compute_test_case_confidence_histograms(
+    metrics: List[TestSampleMetrics],
+    range: Tuple[float, float, int],
+) -> List[Histogram]:
+    all = [mts.classification.score for mts in metrics if mts.classification]
+    correct = [mts.classification.score for mts in metrics if mts.classification and mts.is_correct]
+    incorrect = [mts.classification.score for mts in metrics if mts.classification and not mts.is_correct]
+
+    plots = [
+        create_histogram(
+            values=all,
+            range=range,
+            title="Score Distribution (All)",
+            x_label="Confidence",
+            y_label="Count",
+        ),
+        create_histogram(
+            values=correct,
+            range=range,
+            title="Score Distribution (Correct)",
+            x_label="Confidence",
+            y_label="Count",
+        ),
+        create_histogram(
+            values=incorrect,
+            range=range,
+            title="Score Distribution (Incorrect)",
+            x_label="Confidence",
+            y_label="Count",
+        ),
+    ]
+    return plots
+
+
+def compute_test_case_plots(
+    ground_truths: List[GroundTruth],
+    inferences: List[Inference],
+    metrics: List[TestSampleMetrics],
+    gt_labels: List[str],
+    confidence_range: Optional[Tuple[float, float, int]],
+) -> List[Plot]:
+    plots: List[Plot] = []
+
+    if confidence_range:
+        plots.extend(compute_test_case_confidence_histograms(metrics, confidence_range))
+    else:
+        log.warn("skipping test case confidence histograms: unsupported confidence range")
+
+    plots.append(
+        compute_roc_curves(
+            [gt.classification for gt in ground_truths],
+            [inf.inferences for inf in inferences],
+            gt_labels,
+        ),
+    )
+    plots.append(
+        compute_confusion_matrix(
+            [gt.classification.label for gt in ground_truths],
+            [metric.classification.label if metric.classification is not None else "None" for metric in metrics],
+        ),
+    )
+    plots = list(filter(lambda plot: plot is not None, plots))
+
+    return plots
+
+
+def compute_test_suite_metrics(
+    test_sample_metrics: List[TestSampleMetrics],
+    configuration: ThresholdConfiguration,
+) -> TestSuiteMetrics:
+    n_images = len(test_sample_metrics)
+    n_correct = sum([tsm.is_correct for tsm in test_sample_metrics])
+    metrics = dict(
+        n_images=n_images,
+        n_invalid=len([mts for mts in test_sample_metrics if mts.classification is None]),
+        n_correct=n_correct,
+        overall_accuracy=n_correct / n_images if n_images > 0 else 0,
+    )
+
+    if configuration.threshold is not None:
+        dc = make_dataclass(
+            "ExtendedTestSuiteMetrics",
+            bases=(TestSuiteMetrics,),
+            fields=[("threshold", float)],
+            frozen=True,
+        )
+        metrics_test_suite = dc(
+            **metrics,
+            threshold=configuration.threshold,
+        )
+    else:
+        metrics_test_suite = TestSuiteMetrics(
+            **metrics,
+        )
+
+    return metrics_test_suite
+
+
+def evaluate_classification(
+    test_samples: List[TestSample],
+    ground_truths: List[GroundTruth],
+    inferences: List[Inference],
+    test_cases: TestCases,
+    configuration: ThresholdConfiguration,
+) -> EvaluationResults:
+    test_sample_metrics = [
+        compute_test_sample_metric(gt, inf, configuration) for gt, inf in zip(ground_truths, inferences)
+    ]
+
+    confidence_scores: List[float] = [
+        metric.classification.score for metric in test_sample_metrics if metric.classification
+    ]
+    confidence_range = get_histogram_range(confidence_scores)
+
+    metrics_test_case: List[Tuple[TestCase, TestCaseMetrics]] = []
+    plots_test_case: List[Tuple[TestCase, List[Plot]]] = []
+    for tc, _, tc_gts, tc_infs, tc_metrics in test_cases.iter(
+        test_samples,
+        ground_truths,
+        inferences,
+        test_sample_metrics,
+    ):
+        gt_labels = sorted({tc_gt.classification.label for tc_gt in tc_gts})
+        test_case_metrics = compute_test_case_metrics(tc_gts, tc_metrics, gt_labels)
+        test_case_plots = compute_test_case_plots(
+            tc_gts,
+            tc_infs,
+            tc_metrics,
+            gt_labels,
+            confidence_range,
+        )
+        metrics_test_case.append((tc, test_case_metrics))
+        plots_test_case.append((tc, test_case_plots))
+
+    metrics_test_suite = compute_test_suite_metrics(test_sample_metrics, configuration)
+
+    return EvaluationResults(
+        metrics_test_sample=list(zip(test_samples, test_sample_metrics)),
+        metrics_test_case=metrics_test_case,
+        plots_test_case=plots_test_case,
+        metrics_test_suite=metrics_test_suite,
+    )

--- a/examples/classification/classification/workflow.py
+++ b/examples/classification/classification/workflow.py
@@ -1,0 +1,201 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import dataclasses
+from typing import List
+from typing import Optional
+
+from pydantic.dataclasses import dataclass
+
+from kolena.workflow import define_workflow
+from kolena.workflow import EvaluatorConfiguration
+from kolena.workflow import GroundTruth as BaseGroundTruth
+from kolena.workflow import Image
+from kolena.workflow import Inference as BaseInference
+from kolena.workflow import Metadata
+from kolena.workflow import MetricsTestCase
+from kolena.workflow import MetricsTestSample
+from kolena.workflow import MetricsTestSuite
+from kolena.workflow.annotation import ClassificationLabel
+from kolena.workflow.annotation import ScoredClassificationLabel
+
+
+@dataclass(frozen=True)
+class TestSample(Image):
+    """Test sample type for Classification workflow."""
+
+    metadata: Metadata = dataclasses.field(default_factory=dict)
+    """The metadata associated with the test sample."""
+
+
+@dataclass(frozen=True)
+class GroundTruth(BaseGroundTruth):
+    """Ground truth type for Classification workflow."""
+
+    classification: Optional[ClassificationLabel]
+    """The classfication label associated with an image. For binary classification, the negative class is `None`."""
+
+
+@dataclass(frozen=True)
+class Inference(BaseInference):
+    """Inference type for the multiclass classification workflow."""
+
+    inferences: List[ScoredClassificationLabel]
+    """
+    The model inferences for an image. For `N`-class problems, `label` is expected to contain `N` entries, one for
+    each class and its associated confidence score.
+    """
+
+
+workflow, TestCase, TestSuite, Model = define_workflow(
+    "Image Classification",
+    TestSample,
+    GroundTruth,
+    Inference,
+)
+
+
+@dataclass(frozen=True)
+class TestSampleMetrics(MetricsTestSample):
+    """Image-level metrics for Classification workflow."""
+
+    classification: Optional[ScoredClassificationLabel]
+    """
+    The model classification for this image. Empty when no inferences have a sufficient confidence score determined
+    by the `ThresholdConfiguration`.
+    """
+
+    margin: Optional[float]
+    """
+    The difference in confidence scores between the `classification_score` and the inference with the second-highest
+    confidence score. Empty when no prediction with sufficient confidence score is provided.
+    """
+
+    is_correct: bool
+    """An indication of the `classification_label` matching the associated ground truth label."""
+
+    missing_inference: bool = False
+
+    def __post_init__(self):
+        object.__setattr__(self, "missing_inference", self.classification is None)
+
+
+@dataclass(frozen=True)
+class TestCaseMetricsSingleClass(MetricsTestCase):
+    """Test-case-level aggregate metrics for the binary Classification workflow."""
+
+    TP: int
+    """Total number of true positives within this test case."""
+
+    FP: int
+    """Total number of false positives within this test case."""
+
+    FN: int
+    """Total number of false negatives within this test case."""
+
+    TN: int
+    """Total number of true negatives within this test case."""
+
+    Accuracy: float
+    """Accuracy score for predictions within this test case."""
+
+    Precision: float
+    """Precision score for predictions within this test case."""
+
+    Recall: float
+    """Recall score for predictions within this test case. Equivalent to **True Positive Rate** (TPR)."""
+
+    F1: float
+    """F1 score for predictions within this test case."""
+
+    FPR: float
+    """FPR score for predictions within this test case."""
+
+
+@dataclass(frozen=True)
+class ClassMetricsPerTestCase(TestCaseMetricsSingleClass):
+    """Class-level aggregate metrics for a single class within a multiclass test case."""
+
+    label: str
+    """Label associated with this class."""
+
+
+@dataclass(frozen=True)
+class TestCaseMetrics(MetricsTestCase):
+    """Test-case-level aggregate metrics for Classification workflow."""
+
+    n_labels: int
+    """Total number of classes within this test case."""
+
+    n_correct: int
+    """Total number of correct predictions within this test case."""
+
+    n_incorrect: int
+    """Total number of incorrect predictions within this test case."""
+
+    Accuracy: float
+    """Overall accuracy for predictions within this test case. Same as micro-averaged precision, recall and F1-score."""
+
+    macro_Accuracy: float
+    """Macro-averaged accuracy for predictions within this test case."""
+
+    macro_Precision: float
+    """Macro-averaged precision score for all classes within this test case."""
+
+    macro_Recall: float
+    """Macro-averaged recall score for all classes within this test case."""
+
+    macro_F1: float
+    """Macro-averaged F1-score for all classes within this test case."""
+
+    macro_FPR: float
+    """Macro-averaged false positive rate (FPR) score for all classes within this test case."""
+
+    PerClass: List[ClassMetricsPerTestCase]
+    """Class-level metrics for each class within this test case."""
+
+
+@dataclass(frozen=True)
+class TestSuiteMetrics(MetricsTestSuite):
+    """Test-suite-level metrics for Classification workflow."""
+
+    n_images: int
+    """Number of images tested within this test suite."""
+
+    n_invalid: int
+    """Number of invalid images, i.e. images with no predicted class, within this test suite."""
+
+    n_correct: int
+    """Number of correct image classifications within this test suite."""
+
+    overall_accuracy: float
+    """Overall accuracy of all the images within this test suite."""
+
+
+@dataclass(frozen=True)
+class ThresholdConfiguration(EvaluatorConfiguration):
+    """
+    Confidence threshold configuration for Classification workflow.
+    Specify a minimum confidence `threshold` for predictions, or leave unspecified to include all inferences.
+    """
+
+    threshold: Optional[float] = None
+    """
+    Confidence score threshold to apply for predictions. The prediction with highest confidence is always used,
+    but can be invalid if the confidence score is below the threshold.
+    """
+
+    def display_name(self) -> str:
+        if self.threshold is not None:
+            return f"Confidence Above Threshold (threshold={self.threshold})"
+        return "Max Confidence"

--- a/examples/classification/pyproject.toml
+++ b/examples/classification/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "classification"
+version = "0.1.0"
+description = "Example Kolena integration for multiclass/binary classification"
+authors = ["Kolena Engineering <eng@kolena.io>"]
+license = "Apache-2.0"
+
+[tool.poetry.dependencies]
+python = ">=3.8,<3.12"
+kolena = { path = "../../../kolena/", develop = true }
+s3fs = "^2023.5.0"
+fsspec = "^2023.5.0"
+pandera = ">=0.9.0,<0.16"
+
+[tool.poetry.group.dev.dependencies]
+pre-commit = "^2.17"
+pytest = "^7"
+pytest-depends = "^1.0.1"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/examples/classification/pyproject.toml
+++ b/examples/classification/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = { path = "../../../kolena/", develop = true }
+kolena = ">=0.80.0,<1"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/classification/scripts/multiclass/__init__.py
+++ b/examples/classification/scripts/multiclass/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/classification/scripts/multiclass/seed_test_run.py
+++ b/examples/classification/scripts/multiclass/seed_test_run.py
@@ -1,0 +1,82 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+from argparse import ArgumentParser
+from argparse import Namespace
+from typing import List
+
+import pandas as pd
+from classification.evaluator_multiclass import evaluate_classification
+from classification.workflow import Inference
+from classification.workflow import Model
+from classification.workflow import TestSample
+from classification.workflow import TestSuite
+from classification.workflow import ThresholdConfiguration
+
+import kolena
+from kolena.workflow import test
+from kolena.workflow.annotation import ScoredClassificationLabel
+
+BUCKET = "kolena-public-datasets"
+DATASET = "cifar10/test"
+
+
+def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
+    df_results = pd.read_csv(f"s3://{BUCKET}/{DATASET}/results/{model_name}.csv")
+
+    labels = set(df_results.columns) - {"locator"}
+
+    def infer(test_sample: TestSample) -> Inference:
+        sample_result = df_results[df_results["locator"] == test_sample.locator].iloc[0]
+
+        inferences: List[ScoredClassificationLabel] = []
+        for label in labels:
+            inferences.append(ScoredClassificationLabel(label=label, score=sample_result[label]))
+
+        inferences.sort(key=lambda x: x.score, reverse=True)
+        return Inference(inferences=inferences)
+
+    model = Model(f"{model_name} [classification]", infer=infer)
+    print(f"Model: {model}")
+
+    for test_suite_name in test_suite_names:
+        test_suite = TestSuite.load(test_suite_name)
+        print(f"Test Suite: {test_suite}")
+
+        test(model, test_suite, evaluate_classification, configurations=[ThresholdConfiguration()], reset=True)
+
+
+def main(args: Namespace) -> int:
+    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    for model_name in args.models:
+        seed_test_run(model_name, args.test_suites)
+    return 0
+
+
+if __name__ == "__main__":
+    ap = ArgumentParser()
+    ap.add_argument(
+        "--models",
+        default=["resnet50v2", "inceptionv3"],
+        nargs="+",
+        help="Name(s) of model(s) in directory to test",
+    )
+    ap.add_argument(
+        "--test_suites",
+        default=["complete cifar10/test [classification]"],
+        nargs="+",
+        help="Name(s) of test suite(s) to test.",
+    )
+    sys.exit(main(ap.parse_args()))

--- a/examples/classification/scripts/multiclass/seed_test_run.py
+++ b/examples/classification/scripts/multiclass/seed_test_run.py
@@ -48,7 +48,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
         inferences.sort(key=lambda x: x.score, reverse=True)
         return Inference(inferences=inferences)
 
-    model = Model(f"{model_name} [classification]", infer=infer)
+    model = Model(f"{model_name}", infer=infer)
     print(f"Model: {model}")
 
     for test_suite_name in test_suite_names:
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     )
     ap.add_argument(
         "--test_suites",
-        default=["complete cifar10/test [classification]"],
+        default=[f"complete {DATASET}"],
         nargs="+",
         help="Name(s) of test suite(s) to test.",
     )

--- a/examples/classification/scripts/multiclass/seed_test_suite.py
+++ b/examples/classification/scripts/multiclass/seed_test_suite.py
@@ -48,14 +48,14 @@ def main(args: Namespace) -> int:
 
     # Basic Test Cases
     complete_test_case = TestCase(
-        f"complete {DATASET} [classification]",
+        f"complete {DATASET}",
         description=f"All images in {DATASET} dataset",
         test_samples=test_samples_and_ground_truths,
         reset=True,
     )
 
     test_suite = TestSuite(
-        f"complete {DATASET} [classification]",
+        f"complete {DATASET}",
         test_cases=[complete_test_case],
         reset=True,
     )

--- a/examples/classification/scripts/multiclass/seed_test_suite.py
+++ b/examples/classification/scripts/multiclass/seed_test_suite.py
@@ -1,0 +1,75 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+from argparse import ArgumentParser
+from argparse import Namespace
+
+import pandas as pd
+from classification.workflow import GroundTruth
+from classification.workflow import TestCase
+from classification.workflow import TestSample
+from classification.workflow import TestSuite
+
+import kolena
+from kolena.workflow.annotation import ClassificationLabel
+
+BUCKET = "kolena-public-datasets"
+DATASET = "cifar10/test"
+
+
+def main(args: Namespace) -> int:
+    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+
+    df_metadata = pd.read_csv(args.dataset_csv)
+
+    non_metadata_fields = {"locator", "label"}
+    test_samples_and_ground_truths = [
+        (
+            TestSample(
+                locator=record.locator,
+                metadata={f: getattr(record, f) for f in set(record._fields) - non_metadata_fields},
+            ),
+            GroundTruth(classification=ClassificationLabel(record.label)),
+        )
+        for record in df_metadata.itertuples(index=False)
+    ]
+
+    # Basic Test Cases
+    complete_test_case = TestCase(
+        f"complete {DATASET} [classification]",
+        description=f"All images in {DATASET} dataset",
+        test_samples=test_samples_and_ground_truths,
+        reset=True,
+    )
+
+    test_suite = TestSuite(
+        f"complete {DATASET} [classification]",
+        test_cases=[complete_test_case],
+        reset=True,
+    )
+    print(f"created test suite: {test_suite}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    ap = ArgumentParser()
+    ap.add_argument(
+        "--dataset_csv",
+        type=str,
+        default=f"s3://{BUCKET}/{DATASET}/meta/metadata.csv",
+        help="CSV file with a list of image `locator` and its `label`. See default CSV for details",
+    )
+    sys.exit(main(ap.parse_args()))

--- a/examples/classification/tests/test_classification.py
+++ b/examples/classification/tests/test_classification.py
@@ -25,5 +25,5 @@ def test__seed_test_suite__smoke() -> None:
 
 @pytest.mark.depends(on=["test__seed_test_suite__smoke"])
 def test__seed_test_run__smoke() -> None:
-    args = Namespace(model="ssrnet", test_suites=["complete cifar10/test [classification]"])
+    args = Namespace(models=["inceptionv3"], test_suites=["complete cifar10/test [classification]"])
     seed_test_run_main(args)

--- a/examples/classification/tests/test_classification.py
+++ b/examples/classification/tests/test_classification.py
@@ -14,8 +14,8 @@
 from argparse import Namespace
 
 import pytest
-from classification.seed_test_run import main as seed_test_run_main
-from classification.seed_test_suite import main as seed_test_suite_main
+from scripts.multiclass.seed_test_run import main as seed_test_run_main
+from scripts.multiclass.seed_test_suite import main as seed_test_suite_main
 
 
 def test__seed_test_suite__smoke() -> None:

--- a/examples/classification/tests/test_classification.py
+++ b/examples/classification/tests/test_classification.py
@@ -1,0 +1,29 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import Namespace
+
+import pytest
+from classification.seed_test_run import main as seed_test_run_main
+from classification.seed_test_suite import main as seed_test_suite_main
+
+
+def test__seed_test_suite__smoke() -> None:
+    args = Namespace(dataset_csv="s3://kolena-public-datasets/cifar10/test/meta/metadata.tiny5.csv")
+    seed_test_suite_main(args)
+
+
+@pytest.mark.depends(on=["test__seed_test_suite__smoke"])
+def test__seed_test_run__smoke() -> None:
+    args = Namespace(model="ssrnet", test_suites=["complete cifar10/test [classification]"])
+    seed_test_run_main(args)


### PR DESCRIPTION
### Linked issue(s):
Fixes KOL-2331

### What change does this PR introduce and why?
* Added a multiclass classification example on CIFAR-10 dataset

[CIFAR-10 test on Kolena (default configuration)](https://trunk.kolena.io/kolena/results?modelIds=1566&testSuiteId=3198&workflow=Image+Classification&evaluators=N4IgzAjAnAHCBcoIFYBsqFhmA7AXzyA)
[CIFAR-10 test on Kolena (configuration = threshold @ 0.5)](https://trunk.kolena.io/kolena/results?modelIds=1566&testSuiteId=3198&workflow=Image+Classification&evaluators=N4IgzAjAnAHCBcoIFYBsqFhgFmwXzyA)

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
