### PR TITLE
[Hotfix] Remove version upper bound from `importlib-metadata` (#162)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ pydantic = ">=1.8,<2"
 dacite = ">=1.6,<2"
 requests = ">=2.20,<2.30" # TODO: revert upper bound when urllib3 situation sorts out: https://github.com/psf/requests/issues/6432
 requests-toolbelt = "*"
-importlib-metadata = { version = "<5.0", python = "<3.8" }
+importlib-metadata = { version = "*", python = "<3.8" }
 tqdm = ">=4,<5"
 Pillow = "^9.1.1"
 retrying = "^1.3.3"


### PR DESCRIPTION
Hotfix of #162 — will cut 0.79.1