### PR TITLE
Update poetry-core minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ mkdocs-git-revision-date-localized-plugin = "^1.2.0"
 kolena = 'kolena._utils.cli:run'
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.2"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Our `pyproject.toml` uses `group` dependencies, which are incompatible with older `poetry-core` versions ([see 1.2 release notes](https://python-poetry.org/blog/announcing-poetry-1.2.0/)). This caused installation to fail on systems with `poetry-core<1.2` installed, throwing errors like the following when running `pip install kolena`:

```
      RuntimeError: The Poetry configuration is invalid:
        - Additional properties are not allowed ('group' was unexpected)
```