### PR TITLE
Binary Classification Evaluator

### DIFF
--- a/examples/classification/classification/evaluator.py
+++ b/examples/classification/classification/evaluator.py
@@ -1,0 +1,85 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+from typing import Tuple
+
+from classification.evaluator_binary import BinaryClassificationEvaluator
+from classification.evaluator_multiclass import MulticlassClassificationEvaluator
+from classification.workflow import GroundTruth
+from classification.workflow import Inference
+from classification.workflow import TestCase
+from classification.workflow import TestCaseMetrics
+from classification.workflow import TestSample
+from classification.workflow import ThresholdConfiguration
+
+from kolena._experimental.classification.utils import get_histogram_range
+from kolena._utils import log
+from kolena.workflow import EvaluationResults
+from kolena.workflow import Plot
+from kolena.workflow import TestCases
+
+
+def evaluate_classification(
+    test_samples: List[TestSample],
+    ground_truths: List[GroundTruth],
+    inferences: List[Inference],
+    test_cases: TestCases,
+    configuration: ThresholdConfiguration,
+) -> EvaluationResults:
+    is_binary = all(len(inf.inferences) == 1 for inf in inferences)
+
+    if is_binary:
+        log.info("evaluating binary classification test suite")
+        evaluator = BinaryClassificationEvaluator()
+    else:
+        log.info("evaluating multiclass classification test suite")
+        evaluator = MulticlassClassificationEvaluator()
+
+    test_sample_metrics = [
+        evaluator.compute_test_sample_metrics(gt, inf, configuration) for gt, inf in zip(ground_truths, inferences)
+    ]
+
+    confidence_scores: List[float] = [
+        metric.classification.score for metric in test_sample_metrics if metric.classification
+    ]
+    confidence_range = get_histogram_range(confidence_scores)
+
+    metrics_test_case: List[Tuple[TestCase, TestCaseMetrics]] = []
+    plots_test_case: List[Tuple[TestCase, List[Plot]]] = []
+    for tc, _, tc_gts, tc_infs, tc_metrics in test_cases.iter(
+        test_samples,
+        ground_truths,
+        inferences,
+        test_sample_metrics,
+    ):
+        gt_labels = sorted({tc_gt.classification.label for tc_gt in tc_gts})
+        test_case_metrics = evaluator.compute_test_case_metrics(tc_gts, tc_metrics, gt_labels)
+        test_case_plots = evaluator.compute_test_case_plots(
+            tc_gts,
+            tc_infs,
+            tc_metrics,
+            gt_labels,
+            confidence_range,
+        )
+        metrics_test_case.append((tc, test_case_metrics))
+        plots_test_case.append((tc, test_case_plots))
+
+    metrics_test_suite = evaluator.compute_test_suite_metrics(test_sample_metrics, configuration)
+
+    return EvaluationResults(
+        metrics_test_sample=list(zip(test_samples, test_sample_metrics)),
+        metrics_test_case=metrics_test_case,
+        plots_test_case=plots_test_case,
+        metrics_test_suite=metrics_test_suite,
+    )

--- a/examples/classification/classification/evaluator_base.py
+++ b/examples/classification/classification/evaluator_base.py
@@ -1,0 +1,130 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from abc import ABC
+from abc import abstractmethod
+from dataclasses import make_dataclass
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+from classification.workflow import GroundTruth
+from classification.workflow import Inference
+from classification.workflow import TestCaseMetrics
+from classification.workflow import TestCaseMetricsSingleClass
+from classification.workflow import TestSampleMetrics
+from classification.workflow import TestSampleMetricsSingleClass
+from classification.workflow import TestSuiteMetrics
+from classification.workflow import ThresholdConfiguration
+
+from kolena._experimental.classification.utils import create_histogram
+from kolena.workflow import Plot
+from kolena.workflow.plot import Histogram
+
+
+class BaseClassificationEvaluator(ABC):
+    @abstractmethod
+    def compute_test_sample_metrics(
+        self,
+        ground_truth: GroundTruth,
+        inference: Inference,
+        threshold_configuration: ThresholdConfiguration,
+    ) -> Union[TestSampleMetricsSingleClass, TestSampleMetrics]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def compute_test_case_metrics(
+        self,
+        ground_truths: List[GroundTruth],
+        metrics_test_samples: List[Union[TestSampleMetricsSingleClass, TestSampleMetrics]],
+        labels: Optional[List[str]],
+    ) -> Union[TestCaseMetricsSingleClass, TestCaseMetrics]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def compute_test_case_plots(
+        self,
+        ground_truths: List[GroundTruth],
+        inferences: List[Inference],
+        metrics: List[Union[TestSampleMetricsSingleClass, TestSampleMetrics]],
+        gt_labels: List[str],
+        confidence_range: Optional[Tuple[float, float, int]],
+    ) -> List[Plot]:
+        raise NotImplementedError
+
+    def compute_test_suite_metrics(
+        self,
+        test_sample_metrics: List[TestSampleMetrics],
+        configuration: ThresholdConfiguration,
+    ) -> TestSuiteMetrics:
+        n_images = len(test_sample_metrics)
+        n_correct = sum([tsm.is_correct for tsm in test_sample_metrics])
+        metrics = dict(
+            n_images=n_images,
+            n_invalid=len([mts for mts in test_sample_metrics if mts.classification is None]),
+            n_correct=n_correct,
+            overall_accuracy=n_correct / n_images if n_images > 0 else 0,
+        )
+
+        if configuration.threshold is not None:
+            dc = make_dataclass(
+                "ExtendedTestSuiteMetrics",
+                bases=(TestSuiteMetrics,),
+                fields=[("threshold", float)],
+                frozen=True,
+            )
+            metrics_test_suite = dc(
+                **metrics,
+                threshold=configuration.threshold,
+            )
+        else:
+            metrics_test_suite = TestSuiteMetrics(
+                **metrics,
+            )
+
+        return metrics_test_suite
+
+    def _compute_test_case_confidence_histograms(
+        self,
+        metrics: List[Union[TestSampleMetricsSingleClass, TestSampleMetrics]],
+        range: Tuple[float, float, int],
+    ) -> List[Histogram]:
+        all = [mts.classification.score for mts in metrics if mts.classification]
+        correct = [mts.classification.score for mts in metrics if mts.classification and mts.is_correct]
+        incorrect = [mts.classification.score for mts in metrics if mts.classification and not mts.is_correct]
+
+        plots = [
+            create_histogram(
+                values=all,
+                range=range,
+                title="Score Distribution (All)",
+                x_label="Confidence",
+                y_label="Count",
+            ),
+            create_histogram(
+                values=correct,
+                range=range,
+                title="Score Distribution (Correct)",
+                x_label="Confidence",
+                y_label="Count",
+            ),
+            create_histogram(
+                values=incorrect,
+                range=range,
+                title="Score Distribution (Incorrect)",
+                x_label="Confidence",
+                y_label="Count",
+            ),
+        ]
+        return plots

--- a/examples/classification/classification/evaluator_binary.py
+++ b/examples/classification/classification/evaluator_binary.py
@@ -1,0 +1,124 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from classification.evaluator_base import BaseClassificationEvaluator
+from classification.workflow import GroundTruth
+from classification.workflow import Inference
+from classification.workflow import TestCaseMetricsSingleClass
+from classification.workflow import TestSampleMetricsSingleClass
+from classification.workflow import ThresholdConfiguration
+
+from kolena._experimental.classification.utils import compute_confusion_matrix
+from kolena._experimental.classification.utils import compute_roc_curves
+from kolena._utils import log
+from kolena.workflow import Plot
+from kolena.workflow.metrics import accuracy as compute_accuracy
+from kolena.workflow.metrics import f1_score as compute_f1_score
+from kolena.workflow.metrics import precision as compute_precision
+from kolena.workflow.metrics import recall as compute_recall
+
+
+class BinaryClassificationEvaluator(BaseClassificationEvaluator):
+    def compute_test_sample_metrics(
+        self,
+        ground_truth: GroundTruth,
+        inference: Inference,
+        threshold_configuration: ThresholdConfiguration,
+    ) -> TestSampleMetricsSingleClass:
+        if len(inference.inferences) != 1:
+            log.warn(
+                f"detected more than one ({len(inference.inferences)}) predicted labels for a binary "
+                "classification test suite — aborting test",
+            )
+            raise ValueError
+
+        threshold = threshold_configuration.threshold
+        if threshold is None:
+            threshold = 0.5
+
+        prediction = inference.inferences[0]
+        is_positive_prediction = prediction.score >= threshold
+        is_positive_sample = ground_truth.classification.label == prediction.label
+        return TestSampleMetricsSingleClass(
+            classification=prediction,
+            threshold=threshold,
+            is_correct=is_positive_prediction == is_positive_sample,
+            is_TP=is_positive_sample and is_positive_prediction,
+            is_FP=not is_positive_sample and is_positive_prediction,
+            is_FN=is_positive_sample and not is_positive_prediction,
+            is_TN=not is_positive_sample and not is_positive_prediction,
+        )
+
+    def compute_test_case_metrics(
+        self,
+        ground_truths: List[GroundTruth],
+        metrics_test_samples: List[TestSampleMetricsSingleClass],
+        labels: Optional[List[str]],
+    ) -> TestCaseMetricsSingleClass:
+        n_tp = sum([mts.is_TP for mts in metrics_test_samples])
+        n_fn = sum([mts.is_FN for mts in metrics_test_samples])
+        n_fp = sum([mts.is_FP for mts in metrics_test_samples])
+        n_tn = sum([mts.is_TN for mts in metrics_test_samples])
+
+        return TestCaseMetricsSingleClass(
+            TP=n_tp,
+            FP=n_fp,
+            FN=n_fn,
+            TN=n_tn,
+            Accuracy=compute_accuracy(n_tp, n_fp, n_fn, n_tn),
+            Precision=compute_precision(n_tp, n_fp),
+            Recall=compute_recall(n_tp, n_fn),
+            F1=compute_f1_score(n_tp, n_fp, n_fn),
+            FPR=n_fp / (n_fp + n_tn) if n_fp + n_tn > 0 else 0,
+        )
+
+    def compute_test_case_plots(
+        self,
+        ground_truths: List[GroundTruth],
+        inferences: List[Inference],
+        metrics: List[TestSampleMetricsSingleClass],
+        gt_labels: List[str],
+        confidence_range: Optional[Tuple[float, float, int]],
+    ) -> List[Plot]:
+        plots: List[Plot] = []
+
+        if confidence_range:
+            plots.extend(self._compute_test_case_confidence_histograms(metrics, confidence_range))
+        else:
+            log.warn("skipping test case confidence histograms: unsupported confidence range")
+
+        positive_label = next(iter({inf.inferences[0].label for inf in inferences}))
+        negative_label = next(iter(set(gt_labels) - set(positive_label)))
+
+        plots.append(
+            compute_roc_curves(
+                [gt.classification for gt in ground_truths],
+                [inf.inferences for inf in inferences],
+                labels=[positive_label],
+            ),
+        )
+
+        plots.append(
+            compute_confusion_matrix(
+                [gt.classification.label for gt in ground_truths],
+                [positive_label if metric.is_TP or metric.is_FP else negative_label for metric in metrics],
+                labels=[positive_label, negative_label],
+            ),
+        )
+        plots = list(filter(lambda plot: plot is not None, plots))
+
+        return plots

--- a/examples/classification/classification/evaluator_multiclass.py
+++ b/examples/classification/classification/evaluator_multiclass.py
@@ -11,251 +11,135 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from dataclasses import make_dataclass
 from typing import List
 from typing import Optional
 from typing import Tuple
 
 import numpy as np
+from classification.evaluator_base import BaseClassificationEvaluator
 from classification.workflow import ClassMetricsPerTestCase
 from classification.workflow import GroundTruth
 from classification.workflow import Inference
-from classification.workflow import TestCase
 from classification.workflow import TestCaseMetrics
-from classification.workflow import TestSample
 from classification.workflow import TestSampleMetrics
-from classification.workflow import TestSuiteMetrics
 from classification.workflow import ThresholdConfiguration
 
 from kolena._experimental.classification.utils import compute_confusion_matrix
 from kolena._experimental.classification.utils import compute_roc_curves
-from kolena._experimental.classification.utils import create_histogram
-from kolena._experimental.classification.utils import get_histogram_range
 from kolena._utils import log
-from kolena.workflow import EvaluationResults
 from kolena.workflow import Plot
-from kolena.workflow import TestCases
 from kolena.workflow.metrics import accuracy as compute_accuracy
 from kolena.workflow.metrics import f1_score as compute_f1_score
 from kolena.workflow.metrics import precision as compute_precision
 from kolena.workflow.metrics import recall as compute_recall
-from kolena.workflow.plot import Histogram
 
 
-def compute_test_sample_metric(
-    ground_truth: GroundTruth,
-    inference: Inference,
-    threshold_configuration: ThresholdConfiguration,
-) -> TestSampleMetrics:
-    empty_metrics = TestSampleMetrics(
-        classification=None,
-        margin=None,
-        is_correct=False,
-    )
+class MulticlassClassificationEvaluator(BaseClassificationEvaluator):
+    def compute_test_sample_metrics(
+        self,
+        ground_truth: GroundTruth,
+        inference: Inference,
+        threshold_configuration: ThresholdConfiguration,
+    ) -> TestSampleMetrics:
+        empty_metrics = TestSampleMetrics(
+            classification=None,
+            margin=None,
+            threshold=None,
+            is_correct=False,
+        )
 
-    if len(inference.inferences) == 0:
-        return empty_metrics
+        if len(inference.inferences) == 0:
+            return empty_metrics
 
-    sorted_infs = sorted(inference.inferences, key=lambda x: x.score, reverse=True)
-    predicted_match = sorted_infs[0]
-    predicted_label, predicted_score = predicted_match.label, predicted_match.score
+        sorted_infs = sorted(inference.inferences, key=lambda x: x.score, reverse=True)
+        predicted_match = sorted_infs[0]
+        predicted_label, predicted_score = predicted_match.label, predicted_match.score
 
-    if threshold_configuration.threshold is not None and predicted_score < threshold_configuration.threshold:
-        return empty_metrics
+        if threshold_configuration.threshold is not None and predicted_score < threshold_configuration.threshold:
+            return empty_metrics
 
-    return TestSampleMetrics(
-        classification=predicted_match,
-        margin=predicted_score - sorted_infs[1].score if len(sorted_infs) >= 2 else None,
-        is_correct=predicted_label == ground_truth.classification.label,
-    )
+        return TestSampleMetrics(
+            classification=predicted_match,
+            margin=predicted_score - sorted_infs[1].score if len(sorted_infs) >= 2 else None,
+            is_correct=predicted_label == ground_truth.classification.label,
+            threshold=threshold_configuration.threshold,
+        )
 
+    def compute_test_case_metrics(
+        self,
+        ground_truths: List[GroundTruth],
+        metrics_test_samples: List[TestSampleMetrics],
+        labels: Optional[List[str]],
+    ) -> TestCaseMetrics:
+        classification_pairs = [
+            (gt.classification.label, tsm.classification.label if tsm.classification else None)
+            for gt, tsm in zip(ground_truths, metrics_test_samples)
+        ]
+        n_images = len(classification_pairs)
+        class_level_metrics: List[ClassMetricsPerTestCase] = []
+        for label in sorted(labels):
+            n_tp = len([True for gt, inf in classification_pairs if gt == label and inf == label])
+            n_fn = len([True for gt, inf in classification_pairs if gt == label and inf != label])
+            n_fp = len([True for gt, inf in classification_pairs if gt != label and inf == label])
+            n_tn = len([True for gt, inf in classification_pairs if gt != label and inf != label])
 
-def compute_test_case_metrics(
-    ground_truths: List[GroundTruth],
-    metrics_test_samples: List[TestSampleMetrics],
-    labels: List[str],
-) -> TestCaseMetrics:
-    classification_pairs = [
-        (gt.classification.label, tsm.classification.label if tsm.classification else None)
-        for gt, tsm in zip(ground_truths, metrics_test_samples)
-    ]
-    n_images = len(classification_pairs)
-    class_level_metrics: List[ClassMetricsPerTestCase] = []
-    for label in sorted(labels):
-        n_tp = len([True for gt, inf in classification_pairs if gt == label and inf == label])
-        n_fn = len([True for gt, inf in classification_pairs if gt == label and inf != label])
-        n_fp = len([True for gt, inf in classification_pairs if gt != label and inf == label])
-        n_tn = len([True for gt, inf in classification_pairs if gt != label and inf != label])
+            class_level_metrics.append(
+                ClassMetricsPerTestCase(
+                    label=label,
+                    TP=n_tp,
+                    FP=n_fp,
+                    FN=n_fn,
+                    TN=n_tn,
+                    Accuracy=compute_accuracy(n_tp, n_fp, n_fn, n_tn),
+                    Precision=compute_precision(n_tp, n_fp),
+                    Recall=compute_recall(n_tp, n_fn),
+                    F1=compute_f1_score(n_tp, n_fp, n_fn),
+                    FPR=n_fp / (n_fp + n_tn) if n_fp + n_tn > 0 else 0,
+                ),
+            )
 
-        class_level_metrics.append(
-            ClassMetricsPerTestCase(
-                label=label,
-                TP=n_tp,
-                FP=n_fp,
-                FN=n_fn,
-                TN=n_tn,
-                Accuracy=compute_accuracy(n_tp, n_fp, n_fn, n_tn),
-                Precision=compute_precision(n_tp, n_fp),
-                Recall=compute_recall(n_tp, n_fn),
-                F1=compute_f1_score(n_tp, n_fp, n_fn),
-                FPR=n_fp / (n_fp + n_tn) if n_fp + n_tn > 0 else 0,
+        n_correct = sum([mts.is_correct for mts in metrics_test_samples])
+        return TestCaseMetrics(
+            PerClass=class_level_metrics,
+            n_labels=len(labels),
+            n_correct=n_correct,
+            n_incorrect=n_images - n_correct,
+            Accuracy=n_correct / n_images,
+            macro_Accuracy=np.mean([class_metric.Accuracy for class_metric in class_level_metrics]),
+            macro_Precision=np.mean([class_metric.Precision for class_metric in class_level_metrics]),
+            macro_Recall=np.mean([class_metric.Recall for class_metric in class_level_metrics]),
+            macro_F1=np.mean([class_metric.F1 for class_metric in class_level_metrics]),
+            macro_FPR=np.mean([class_metric.FPR for class_metric in class_level_metrics]),
+        )
+
+    def compute_test_case_plots(
+        self,
+        ground_truths: List[GroundTruth],
+        inferences: List[Inference],
+        metrics: List[TestSampleMetrics],
+        gt_labels: List[str],
+        confidence_range: Optional[Tuple[float, float, int]],
+    ) -> List[Plot]:
+        plots: List[Plot] = []
+
+        if confidence_range:
+            plots.extend(self._compute_test_case_confidence_histograms(metrics, confidence_range))
+        else:
+            log.warn("skipping test case confidence histograms: unsupported confidence range")
+
+        plots.append(
+            compute_roc_curves(
+                [gt.classification for gt in ground_truths],
+                [inf.inferences for inf in inferences],
+                gt_labels,
             ),
         )
-
-    n_correct = sum([mts.is_correct for mts in metrics_test_samples])
-    return TestCaseMetrics(
-        PerClass=class_level_metrics,
-        n_labels=len(labels),
-        n_correct=n_correct,
-        n_incorrect=n_images - n_correct,
-        Accuracy=n_correct / n_images,
-        macro_Accuracy=np.mean([class_metric.Accuracy for class_metric in class_level_metrics]),
-        macro_Precision=np.mean([class_metric.Precision for class_metric in class_level_metrics]),
-        macro_Recall=np.mean([class_metric.Recall for class_metric in class_level_metrics]),
-        macro_F1=np.mean([class_metric.F1 for class_metric in class_level_metrics]),
-        macro_FPR=np.mean([class_metric.FPR for class_metric in class_level_metrics]),
-    )
-
-
-def compute_test_case_confidence_histograms(
-    metrics: List[TestSampleMetrics],
-    range: Tuple[float, float, int],
-) -> List[Histogram]:
-    all = [mts.classification.score for mts in metrics if mts.classification]
-    correct = [mts.classification.score for mts in metrics if mts.classification and mts.is_correct]
-    incorrect = [mts.classification.score for mts in metrics if mts.classification and not mts.is_correct]
-
-    plots = [
-        create_histogram(
-            values=all,
-            range=range,
-            title="Score Distribution (All)",
-            x_label="Confidence",
-            y_label="Count",
-        ),
-        create_histogram(
-            values=correct,
-            range=range,
-            title="Score Distribution (Correct)",
-            x_label="Confidence",
-            y_label="Count",
-        ),
-        create_histogram(
-            values=incorrect,
-            range=range,
-            title="Score Distribution (Incorrect)",
-            x_label="Confidence",
-            y_label="Count",
-        ),
-    ]
-    return plots
-
-
-def compute_test_case_plots(
-    ground_truths: List[GroundTruth],
-    inferences: List[Inference],
-    metrics: List[TestSampleMetrics],
-    gt_labels: List[str],
-    confidence_range: Optional[Tuple[float, float, int]],
-) -> List[Plot]:
-    plots: List[Plot] = []
-
-    if confidence_range:
-        plots.extend(compute_test_case_confidence_histograms(metrics, confidence_range))
-    else:
-        log.warn("skipping test case confidence histograms: unsupported confidence range")
-
-    plots.append(
-        compute_roc_curves(
-            [gt.classification for gt in ground_truths],
-            [inf.inferences for inf in inferences],
-            gt_labels,
-        ),
-    )
-    plots.append(
-        compute_confusion_matrix(
-            [gt.classification.label for gt in ground_truths],
-            [metric.classification.label if metric.classification is not None else "None" for metric in metrics],
-        ),
-    )
-    plots = list(filter(lambda plot: plot is not None, plots))
-
-    return plots
-
-
-def compute_test_suite_metrics(
-    test_sample_metrics: List[TestSampleMetrics],
-    configuration: ThresholdConfiguration,
-) -> TestSuiteMetrics:
-    n_images = len(test_sample_metrics)
-    n_correct = sum([tsm.is_correct for tsm in test_sample_metrics])
-    metrics = dict(
-        n_images=n_images,
-        n_invalid=len([mts for mts in test_sample_metrics if mts.classification is None]),
-        n_correct=n_correct,
-        overall_accuracy=n_correct / n_images if n_images > 0 else 0,
-    )
-
-    if configuration.threshold is not None:
-        dc = make_dataclass(
-            "ExtendedTestSuiteMetrics",
-            bases=(TestSuiteMetrics,),
-            fields=[("threshold", float)],
-            frozen=True,
+        plots.append(
+            compute_confusion_matrix(
+                [gt.classification.label for gt in ground_truths],
+                [metric.classification.label if metric.classification is not None else "None" for metric in metrics],
+            ),
         )
-        metrics_test_suite = dc(
-            **metrics,
-            threshold=configuration.threshold,
-        )
-    else:
-        metrics_test_suite = TestSuiteMetrics(
-            **metrics,
-        )
+        plots = list(filter(lambda plot: plot is not None, plots))
 
-    return metrics_test_suite
-
-
-def evaluate_classification(
-    test_samples: List[TestSample],
-    ground_truths: List[GroundTruth],
-    inferences: List[Inference],
-    test_cases: TestCases,
-    configuration: ThresholdConfiguration,
-) -> EvaluationResults:
-    test_sample_metrics = [
-        compute_test_sample_metric(gt, inf, configuration) for gt, inf in zip(ground_truths, inferences)
-    ]
-
-    confidence_scores: List[float] = [
-        metric.classification.score for metric in test_sample_metrics if metric.classification
-    ]
-    confidence_range = get_histogram_range(confidence_scores)
-
-    metrics_test_case: List[Tuple[TestCase, TestCaseMetrics]] = []
-    plots_test_case: List[Tuple[TestCase, List[Plot]]] = []
-    for tc, _, tc_gts, tc_infs, tc_metrics in test_cases.iter(
-        test_samples,
-        ground_truths,
-        inferences,
-        test_sample_metrics,
-    ):
-        gt_labels = sorted({tc_gt.classification.label for tc_gt in tc_gts})
-        test_case_metrics = compute_test_case_metrics(tc_gts, tc_metrics, gt_labels)
-        test_case_plots = compute_test_case_plots(
-            tc_gts,
-            tc_infs,
-            tc_metrics,
-            gt_labels,
-            confidence_range,
-        )
-        metrics_test_case.append((tc, test_case_metrics))
-        plots_test_case.append((tc, test_case_plots))
-
-    metrics_test_suite = compute_test_suite_metrics(test_sample_metrics, configuration)
-
-    return EvaluationResults(
-        metrics_test_sample=list(zip(test_samples, test_sample_metrics)),
-        metrics_test_case=metrics_test_case,
-        plots_test_case=plots_test_case,
-        metrics_test_suite=metrics_test_suite,
-    )
+        return plots

--- a/examples/classification/classification/workflow.py
+++ b/examples/classification/classification/workflow.py
@@ -80,7 +80,13 @@ workflow, TestCase, TestSuite, Model = define_workflow(
 
 @dataclass(frozen=True)
 class TestSampleMetricsSingleClass(MetricsTestSample):
-    """Image-level metrics for Classification workflow."""
+    """
+    Image-level metrics for Binary Classification workflow.
+
+    It is evaluated as a binary classification workflow when there is only
+    one label's prediction provided as part of `Inference`, and this label is considered
+    to be positive.
+    """
 
     is_correct: bool
     """An indication of the `classification_label` matching the associated ground truth label."""
@@ -111,11 +117,7 @@ class TestSampleMetricsSingleClass(MetricsTestSample):
 
     classification: ScoredClassificationLabel
     """
-    The model classification for this image. Empty when no inferences have a sufficient confidence score determined
-    by the `ThresholdConfiguration`.
-
-    For binary classification, if only one label's confidence score is provided as part of `Inference`, then
-    `classification` will reflect that.
+    The model inference for this image.
     """
 
     threshold: float
@@ -132,7 +134,7 @@ class TestSampleMetricsSingleClass(MetricsTestSample):
 
 @dataclass(frozen=True)
 class TestSampleMetrics(MetricsTestSample):
-    """Image-level metrics for Classification workflow."""
+    """Image-level metrics for Multiclass Classification workflow."""
 
     is_correct: bool
     """An indication of the `classification_label` matching the associated ground truth label."""
@@ -164,7 +166,13 @@ class TestSampleMetrics(MetricsTestSample):
 
 @dataclass(frozen=True)
 class TestCaseMetricsSingleClass(MetricsTestCase):
-    """Test-case-level aggregate metrics for Binary Classification workflow."""
+    """
+    Test-case-level aggregate metrics for Binary Classification workflow.
+
+    It is evaluated as a binary classification workflow when there is only
+    one label's prediction provided as part of `Inference`, and this label is considered
+    to be positive.
+    """
 
     TP: int
     """Total number of true positives within this test case."""
@@ -204,7 +212,7 @@ class ClassMetricsPerTestCase(TestCaseMetricsSingleClass):
 
 @dataclass(frozen=True)
 class TestCaseMetrics(MetricsTestCase):
-    """Test-case-level aggregate metrics for Classification workflow."""
+    """Test-case-level aggregate metrics for Multiclass Classification workflow."""
 
     n_labels: int
     """Total number of classes within this test case."""

--- a/examples/classification/classification/workflow.py
+++ b/examples/classification/classification/workflow.py
@@ -42,8 +42,12 @@ class TestSample(Image):
 class GroundTruth(BaseGroundTruth):
     """Ground truth type for Classification workflow."""
 
-    classification: Optional[ClassificationLabel]
-    """The classfication label associated with an image. For binary classification, the negative class is `None`."""
+    classification: ClassificationLabel
+    """
+    The classfication label associated with an image.
+
+    For binary classification, the negative class should also be labeled. (e.g., `dog` vs. `not dog` or `dog` vs. `cat`)
+    """
 
 
 @dataclass(frozen=True)
@@ -54,6 +58,15 @@ class Inference(BaseInference):
     """
     The model inferences for an image. For `N`-class problems, `label` is expected to contain `N` entries, one for
     each class and its associated confidence score.
+
+    For binary classification, only positive class's confidence score is required. `ThresholdConfiguration` will be
+    applied to the positive class only. If inferences for both positive and negative class are provided, then it will
+    be treated as multiclass classification.
+    """
+
+    ignored: bool = False
+    """
+    Whether the image should be ignored in evaluating the results of the model.
     """
 
 
@@ -66,8 +79,63 @@ workflow, TestCase, TestSuite, Model = define_workflow(
 
 
 @dataclass(frozen=True)
+class TestSampleMetricsSingleClass(MetricsTestSample):
+    """Image-level metrics for Classification workflow."""
+
+    is_correct: bool
+    """An indication of the `classification_label` matching the associated ground truth label."""
+
+    is_TP: bool
+    """
+    An indication of the `classification_label` correctly matching the associated positive ground
+    truth label.
+    """
+
+    is_FP: bool
+    """
+    An indication of the `classification_label` incorrectly matching the associated negative ground
+    truth label.
+    """
+
+    is_FN: bool
+    """
+    An indication of the `classification_label` incorrectly matching the associated positive ground
+    truth label.
+    """
+
+    is_TN: bool
+    """
+    An indication of the `classification_label` correctly matching the associated negative ground
+    truth label.
+    """
+
+    classification: ScoredClassificationLabel
+    """
+    The model classification for this image. Empty when no inferences have a sufficient confidence score determined
+    by the `ThresholdConfiguration`.
+
+    For binary classification, if only one label's confidence score is provided as part of `Inference`, then
+    `classification` will reflect that.
+    """
+
+    threshold: float
+    """
+    The threshold used in evaluation — specified by the `ThresholdConfiguration`. It is commonly used in a binary
+    classification problem.
+    """
+
+    missing_inference: bool = False
+
+    def __post_init__(self):
+        object.__setattr__(self, "missing_inference", self.classification is None)
+
+
+@dataclass(frozen=True)
 class TestSampleMetrics(MetricsTestSample):
     """Image-level metrics for Classification workflow."""
+
+    is_correct: bool
+    """An indication of the `classification_label` matching the associated ground truth label."""
 
     classification: Optional[ScoredClassificationLabel]
     """
@@ -75,14 +143,18 @@ class TestSampleMetrics(MetricsTestSample):
     by the `ThresholdConfiguration`.
     """
 
-    margin: Optional[float]
+    margin: Optional[float] = None
     """
     The difference in confidence scores between the `classification_score` and the inference with the second-highest
-    confidence score. Empty when no prediction with sufficient confidence score is provided.
+    confidence score. Empty when no prediction with sufficient confidence score is provided or when it's a binary
+    classification.
     """
 
-    is_correct: bool
-    """An indication of the `classification_label` matching the associated ground truth label."""
+    threshold: Optional[float] = None
+    """
+    The threshold used in evaluation — specified by the `ThresholdConfiguration`. It is commonly used in a binary
+    classification problem.
+    """
 
     missing_inference: bool = False
 
@@ -92,7 +164,7 @@ class TestSampleMetrics(MetricsTestSample):
 
 @dataclass(frozen=True)
 class TestCaseMetricsSingleClass(MetricsTestCase):
-    """Test-case-level aggregate metrics for the binary Classification workflow."""
+    """Test-case-level aggregate metrics for Binary Classification workflow."""
 
     TP: int
     """Total number of true positives within this test case."""

--- a/examples/classification/scripts/multiclass/seed_test_run.py
+++ b/examples/classification/scripts/multiclass/seed_test_run.py
@@ -18,7 +18,7 @@ from argparse import Namespace
 from typing import List
 
 import pandas as pd
-from classification.evaluator_multiclass import evaluate_classification
+from classification.evaluator import evaluate_classification
 from classification.workflow import Inference
 from classification.workflow import Model
 from classification.workflow import TestSample


### PR DESCRIPTION
### Linked issue(s):
Fixes KOL-2704

### What change does this PR introduce and why?
* Refactors multiclass classification evaluator
* Modified the workflow schema 

[dogs-vs-cats binary classification (threshold=0.5)](https://trunk.kolena.io/yoohee/results?modelIds=684&workflow=Image+Classification&testSuiteId=1370&evaluators=N4IgjAzAbAHCBcpZ3mADATgCwF8A04EA7GgkjFguhlAbAKxWa0ixRM045A)
[dogs-vs-cats multiclass classification](https://trunk.kolena.io/yoohee/results?modelIds=686&workflow=Image+Classification&testSuiteId=1370&evaluators=N4IgjAzAbAHCBcpZ3mADATgCwF8A04EA7GgkjFguhlAbAKxWa0ixRM045A)

Based on the # of prediction labels seeded as part of `Inference` determines which evaluator to run.  If only positive label's prediction is used, then it will be treated as a binary classification.  If both labels' predictions are added, then it will be 2 class multiclass evaluation. 

How are multiclass and binary evaluator different?:
* Per-class evaluation for multiclass (for both "dog" and "cat" class metrics are available) (e.g., TP for class "cat" is for correctly predicted "cat" class) — binary shows the same information but in different wordings (e.g., TP is for positive label which in this case is "dog" and TN is for negative label which in this case is "cat") 
* ROC curve on positive label only for binary vs on both labels for multiclass
* Score distribution (for binary, only the positive prediction scores are used so it ranges from 0 to 1; whereas, for multiclass, maximum confidence score label is used so it will range from 0.5 - 1.
* Classification label annotation: for binary, it will only show the prediction on the positive label and for multiclass, the label which has the "maximum" confidence score will be shown. 

<img width="300" alt="Screen Shot 2023-08-03 at 9 58 53 AM" src="https://github.com/kolenaIO/kolena/assets/17771952/9ffbc422-3b4f-41ee-85d4-b60e2d938cef"> <img width="300" alt="Screen Shot 2023-08-03 at 9 59 02 AM" src="https://github.com/kolenaIO/kolena/assets/17771952/4f42ad37-0653-4fbe-a44c-413aab313e4a">

* TestSampleMetrics: for binary, there are more fields like `is_TP`, `is_FN` and etc., whereas for multiclass, only `is_correct` and predicted label is shown.

<img width="300" alt="Screen Shot 2023-08-03 at 10 01 08 AM" src="https://github.com/kolenaIO/kolena/assets/17771952/dee88e8e-a31b-470c-ac53-1fdc69c58e0b">
<img width="300" alt="Screen Shot 2023-08-03 at 10 01 20 AM" src="https://github.com/kolenaIO/kolena/assets/17771952/787eda48-b75e-4665-9731-e43c69bdefff">

For binary classification cases where performance on positive label can be clearly defined (e.g., "is_live" or "is_dog") then using binary classification evaluator is a better experience.  For cases where both label are equally important (e.g., "dog" vs "cat") where a positive label cannot be specified, using multiclass evaluator is preferred.

Proposal on UX improvement:
Once we make this into a pre-built, we should consider changing the color of `TestSampleMetrics.classification` label to be green (if `is_correct=True`) or red (otherwise).

### Please check if the PR fulfills these requirements


- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
