### PR TITLE
Rename _validate_locator to _validate_image_locator

### DIFF
--- a/kolena/_utils/dataframes/validators.py
+++ b/kolena/_utils/dataframes/validators.py
@@ -58,12 +58,12 @@ def validate_df_record_count(df: pd.DataFrame, max_records_allowed: Optional[int
 
 
 def _is_locator_cell_valid(cell: pa.typing.String) -> bool:
-    matcher = re.compile(r"^(s3|gs|http|https)://(.+/)+.+$")
+    matcher = re.compile(r"^(s3|gs|https)://(.+/)+.+$")
     return isinstance(cell, str) and bool(matcher.match(cell.lower()))
 
 
 def _is_image_locator_cell_valid(cell: pa.typing.String) -> bool:
-    matcher = re.compile(r"^(s3|gs|http|https)://(.+/)+.+\.(png|jpe?g|gif|tiff?)$")
+    matcher = re.compile(r"^(s3|gs|https)://(.+/)+.+\.(png|jpe?g|gif|tiff?)$")
     return isinstance(cell, str) and bool(matcher.match(cell.lower()))
 
 

--- a/kolena/_utils/dataframes/validators.py
+++ b/kolena/_utils/dataframes/validators.py
@@ -57,16 +57,16 @@ def validate_df_record_count(df: pd.DataFrame, max_records_allowed: Optional[int
 # https://pandera.readthedocs.io/en/stable/reference/generated/pandera.extensions.html?highlight=register_check_method#pandera.extensions.register_check_method
 
 
-def _is_locator_cell_valid(cell: pa.typing.String) -> bool:
+def _is_image_locator_cell_valid(cell: pa.typing.String) -> bool:
     matcher = re.compile(r"^(s3|gs|http|https)://(.+/)+.+\.(png|jpe?g|gif|tiff?)$")
     return isinstance(cell, str) and bool(matcher.match(cell.lower()))
 
 
 @register_check_method(check_type="element_wise")
-def _element_wise_validate_locator(cell: pa.typing.String) -> bool:
-    return _is_locator_cell_valid(cell)
+def _element_wise_validate_image_locator(cell: pa.typing.String) -> bool:
+    return _is_image_locator_cell_valid(cell)
 
 
 @register_check_method()
-def _validate_locator(series: Series) -> bool:
-    return series.dropna().apply(_is_locator_cell_valid).all()
+def _validate_image_locator(series: Series) -> bool:
+    return series.dropna().apply(_is_image_locator_cell_valid).all()

--- a/kolena/_utils/dataframes/validators.py
+++ b/kolena/_utils/dataframes/validators.py
@@ -57,14 +57,29 @@ def validate_df_record_count(df: pd.DataFrame, max_records_allowed: Optional[int
 # https://pandera.readthedocs.io/en/stable/reference/generated/pandera.extensions.html?highlight=register_check_method#pandera.extensions.register_check_method
 
 
+def _is_locator_cell_valid(cell: pa.typing.String) -> bool:
+    matcher = re.compile(r"^(s3|gs|http|https)://(.+/)+.+$")
+    return isinstance(cell, str) and bool(matcher.match(cell.lower()))
+
+
 def _is_image_locator_cell_valid(cell: pa.typing.String) -> bool:
     matcher = re.compile(r"^(s3|gs|http|https)://(.+/)+.+\.(png|jpe?g|gif|tiff?)$")
     return isinstance(cell, str) and bool(matcher.match(cell.lower()))
 
 
 @register_check_method(check_type="element_wise")
+def _element_wise_validate_locator(cell: pa.typing.String) -> bool:
+    return _is_locator_cell_valid(cell)
+
+
+@register_check_method(check_type="element_wise")
 def _element_wise_validate_image_locator(cell: pa.typing.String) -> bool:
     return _is_image_locator_cell_valid(cell)
+
+
+@register_check_method()
+def _validate_locator(series: Series) -> bool:
+    return series.dropna().apply(_is_locator_cell_valid).all()
 
 
 @register_check_method()

--- a/kolena/detection/_datatypes.py
+++ b/kolena/detection/_datatypes.py
@@ -45,7 +45,7 @@ JSONObject = object
 
 
 class TestImageDataFrameSchema(pa.SchemaModel):
-    locator: Series[pa.typing.String] = pa.Field(coerce=True, _element_wise_validate_locator=())
+    locator: Series[pa.typing.String] = pa.Field(coerce=True, _element_wise_validate_image_locator=())
     dataset: Series[pa.typing.String] = pa.Field(coerce=True)
     ground_truths: Series[object] = pa.Field(coerce=True, nullable=True, _validate_ground_truths=())
     metadata: Series[JSONObject] = pa.Field(coerce=True)

--- a/kolena/detection/_internal/datatypes.py
+++ b/kolena/detection/_internal/datatypes.py
@@ -27,7 +27,7 @@ JSONObject = object
 
 class LoadTestImagesDataFrameSchema(pa.SchemaModel):
     test_sample_id: Series[pa.typing.Int64] = pa.Field(coerce=True)
-    locator: Series[pa.typing.String] = pa.Field(coerce=True, _validate_locator=())
+    locator: Series[pa.typing.String] = pa.Field(coerce=True, _validate_image_locator=())
     dataset: Series[pa.typing.String] = pa.Field(coerce=True, nullable=True)
     metadata: Series[JSONObject] = pa.Field(coerce=True)
 

--- a/kolena/fr/datatypes.py
+++ b/kolena/fr/datatypes.py
@@ -146,7 +146,7 @@ class TestImageDataFrameSchema(pa.SchemaModel):
     image_id: Series[pa.typing.Int64] = pa.Field(coerce=True)
     """Internal ID corresponding to this image."""
 
-    locator: Series[pa.typing.String] = pa.Field(coerce=True, _validate_locator=())
+    locator: Series[pa.typing.String] = pa.Field(coerce=True, _validate_image_locator=())
     """External locator pointing to image in bucket."""
 
     data_source: Series[pa.typing.String] = pa.Field(coerce=True, nullable=True)
@@ -158,7 +158,7 @@ class TestImageDataFrameSchema(pa.SchemaModel):
     height: Series[pa.typing.Int64] = pa.Field(coerce=True, _validate_optional_dimension=())
     """Height of the image, in pixels. The value `-1` is used to specify "unspecified"."""
 
-    original_locator: Series[pa.typing.String] = pa.Field(coerce=True, nullable=True, _validate_locator=())
+    original_locator: Series[pa.typing.String] = pa.Field(coerce=True, nullable=True, _validate_image_locator=())
     """Specify that this image is an augmented version of another (registered) image."""
 
     augmentation_spec: Series[JSONObject] = pa.Field(coerce=True, nullable=True, _validate_json_object=())
@@ -205,8 +205,8 @@ TEST_IMAGE_COLUMNS = [
 
 
 class TestCaseDataFrameSchema(pa.SchemaModel):
-    locator_a: Series[pa.typing.String] = pa.Field(coerce=True, _validate_locator=())
-    locator_b: Series[pa.typing.String] = pa.Field(coerce=True, _validate_locator=())
+    locator_a: Series[pa.typing.String] = pa.Field(coerce=True, _validate_image_locator=())
+    locator_b: Series[pa.typing.String] = pa.Field(coerce=True, _validate_image_locator=())
     is_same: Series[pa.typing.Bool] = pa.Field(coerce=True)
 
 

--- a/tests/unit/utils/dataframes/test_validators.py
+++ b/tests/unit/utils/dataframes/test_validators.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from kolena._utils.dataframes.validators import _is_image_locator_cell_valid
+from kolena._utils.dataframes.validators import _is_locator_cell_valid
 
 
 def test__validate_image_locator() -> None:
@@ -37,3 +38,28 @@ def test__validate_image_locator() -> None:
 
     for locator in invalid_image_locators:
         assert not _is_image_locator_cell_valid(locator)
+
+
+def test__validate_locator() -> None:
+    valid_locators = [
+        "s3://bucket-name/path/to/image.jpg",
+        "gs://bucket/path/to/image.png",
+        "s3://bucket/image with spaces.jpg",  # spaces should be allowed
+        "s3://bucket/UPPERCASE.JPG",  # uppercase
+        "gs://bucket/lower.jpG",
+        "http://bucket/lower.jpG",
+        "https://bucket/lower.jpG",
+        "s3://bucket/image.txt",  # non-image extension
+    ]
+    invalid_locators = [
+        "garbage",
+        "closer://but/still/garbage.jpg",
+        "s3://image.jpg",  # missing bucket name
+        "s3:/bucket/image.jpg",  # malformed
+    ]
+
+    for locator in valid_locators:
+        assert _is_locator_cell_valid(locator)
+
+    for locator in invalid_locators:
+        assert not _is_locator_cell_valid(locator)

--- a/tests/unit/utils/dataframes/test_validators.py
+++ b/tests/unit/utils/dataframes/test_validators.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from kolena._utils.dataframes.validators import _is_locator_cell_valid
+from kolena._utils.dataframes.validators import _is_image_locator_cell_valid
 
 
-def test__validate_locator() -> None:
-    valid_locators = [
+def test__validate_image_locator() -> None:
+    valid_image_locators = [
         "s3://bucket-name/path/to/image.jpg",
         "gs://bucket/path/to/image.png",
         "s3://bucket/image with spaces.jpg",  # spaces should be allowed
@@ -24,7 +24,7 @@ def test__validate_locator() -> None:
         "http://bucket/lower.jpG",
         "https://bucket/lower.jpG",
     ]
-    invalid_locators = [
+    invalid_image_locators = [
         "garbage",
         "closer://but/still/garbage.jpg",
         "s3://image.jpg",  # missing bucket name
@@ -32,8 +32,8 @@ def test__validate_locator() -> None:
         "s3:/bucket/image.jpg",  # malformed
     ]
 
-    for locator in valid_locators:
-        assert _is_locator_cell_valid(locator)
+    for locator in valid_image_locators:
+        assert _is_image_locator_cell_valid(locator)
 
-    for locator in invalid_locators:
-        assert not _is_locator_cell_valid(locator)
+    for locator in invalid_image_locators:
+        assert not _is_image_locator_cell_valid(locator)

--- a/tests/unit/utils/dataframes/test_validators.py
+++ b/tests/unit/utils/dataframes/test_validators.py
@@ -22,13 +22,13 @@ def test__validate_image_locator() -> None:
         "s3://bucket/image with spaces.jpg",  # spaces should be allowed
         "s3://bucket/UPPERCASE.JPG",  # uppercase
         "gs://bucket/lower.jpG",
-        "http://bucket/lower.jpG",
         "https://bucket/lower.jpG",
     ]
     invalid_image_locators = [
         "garbage",
         "closer://but/still/garbage.jpg",
         "s3://image.jpg",  # missing bucket name
+        "http://bucket/lower.jpG",  # non-https scheme
         "s3://bucket/image.txt",  # non-image extension
         "s3:/bucket/image.jpg",  # malformed
     ]
@@ -47,7 +47,6 @@ def test__validate_locator() -> None:
         "s3://bucket/image with spaces.jpg",  # spaces should be allowed
         "s3://bucket/UPPERCASE.JPG",  # uppercase
         "gs://bucket/lower.jpG",
-        "http://bucket/lower.jpG",
         "https://bucket/lower.jpG",
         "s3://bucket/image.txt",  # non-image extension
     ]
@@ -55,6 +54,7 @@ def test__validate_locator() -> None:
         "garbage",
         "closer://but/still/garbage.jpg",
         "s3://image.jpg",  # missing bucket name
+        "http://bucket/lower.jpG",  # non-https scheme
         "s3:/bucket/image.jpg",  # malformed
     ]
 


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?
Rename _validate_locator to _validate_image_locator and re-implement _validate_locator for non-images

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
