### PR TITLE
Add derived values to kolena.workflow.BoundingBox{,3D}

### DIFF
--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -145,7 +145,7 @@ class DataObject(metaclass=ABCMeta):
                 f"cast=False, not casting field '{field.name}' to type '{field_type}' with value '{field_value}'",
             )
 
-        items = {f.name: deserialize_field(f, obj_dict.get(f.name, None)) for f in dataclasses.fields(cls)}
+        items = {f.name: deserialize_field(f, obj_dict.get(f.name, None)) for f in dataclasses.fields(cls) if f.init}
         return cls(**items)
 
 

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -89,11 +89,10 @@ class BoundingBox(Annotation):
         return _AnnotationType.BOUNDING_BOX
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "width", getattr(self, "width", self.bottom_right[0] - self.top_left[0]))
-        object.__setattr__(self, "height", getattr(self, "height", self.bottom_right[1] - self.top_left[1]))
-        object.__setattr__(self, "area", getattr(self, "area", self.width * self.height))
-        aspect_ratio = getattr(self, "aspect_ratio", self.width / self.height if self.height != 0 else 0)
-        object.__setattr__(self, "aspect_ratio", aspect_ratio)
+        object.__setattr__(self, "width", self.bottom_right[0] - self.top_left[0])
+        object.__setattr__(self, "height", self.bottom_right[1] - self.top_left[1])
+        object.__setattr__(self, "area", self.width * self.height)
+        object.__setattr__(self, "aspect_ratio", self.width / self.height if self.height != 0 else 0)
 
 
 @dataclass(frozen=True, config=ValidatorConfig)
@@ -230,7 +229,7 @@ class BoundingBox3D(Annotation):
         return _AnnotationType.BOUNDING_BOX_3D
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "volume", getattr(self, "volume", reduce(lambda a, b: a * b, self.dimensions)))
+        object.__setattr__(self, "volume", reduce(lambda a, b: a * b, self.dimensions))
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -31,6 +31,7 @@ For example, when viewing images in the Studio, any annotations (such as lists o
 [`Inference`][kolena.workflow.Inference], or [`MetricsTestSample`][kolena.workflow.MetricsTestSample] objects are
 rendered on top of the image.
 """
+import dataclasses
 from abc import ABCMeta
 from typing import Dict
 from typing import List
@@ -73,9 +74,20 @@ class BoundingBox(Annotation):
     bottom_right: Tuple[float, float]
     """The bottom right vertex (in `(x, y)` image coordinates) of this bounding box."""
 
+    height: float = dataclasses.field(init=False)
+    width: float = dataclasses.field(init=False)
+    area: float = dataclasses.field(init=False)
+    aspect_ratio: float = dataclasses.field(init=False)
+
     @staticmethod
     def _data_type() -> _AnnotationType:
         return _AnnotationType.BOUNDING_BOX
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "width", self.bottom_right[0] - self.top_left[0])
+        object.__setattr__(self, "height", self.bottom_right[1] - self.top_left[1])
+        object.__setattr__(self, "area", self.width * self.height)
+        object.__setattr__(self, "aspect_ratio", self.width / self.height)
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -32,8 +32,8 @@ For example, when viewing images in the Studio, any annotations (such as lists o
 rendered on top of the image.
 """
 import dataclasses
+import math
 from abc import ABCMeta
-from functools import reduce
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -229,7 +229,7 @@ class BoundingBox3D(Annotation):
         return _AnnotationType.BOUNDING_BOX_3D
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "volume", reduce(lambda a, b: a * b, self.dimensions))
+        object.__setattr__(self, "volume", math.prod(self.dimensions))
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -32,8 +32,8 @@ For example, when viewing images in the Studio, any annotations (such as lists o
 rendered on top of the image.
 """
 import dataclasses
-import math
 from abc import ABCMeta
+from functools import reduce
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -229,7 +229,7 @@ class BoundingBox3D(Annotation):
         return _AnnotationType.BOUNDING_BOX_3D
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "volume", math.prod(self.dimensions))
+        object.__setattr__(self, "volume", reduce(lambda a, b: a * b, self.dimensions))
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -89,10 +89,11 @@ class BoundingBox(Annotation):
         return _AnnotationType.BOUNDING_BOX
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "width", self.bottom_right[0] - self.top_left[0])
-        object.__setattr__(self, "height", self.bottom_right[1] - self.top_left[1])
-        object.__setattr__(self, "area", self.width * self.height)
-        object.__setattr__(self, "aspect_ratio", self.width / self.height if self.height != 0 else 0)
+        object.__setattr__(self, "width", getattr(self, "width", self.bottom_right[0] - self.top_left[0]))
+        object.__setattr__(self, "height", getattr(self, "height", self.bottom_right[1] - self.top_left[1]))
+        object.__setattr__(self, "area", getattr(self, "area", self.width * self.height))
+        aspect_ratio = getattr(self, "aspect_ratio", self.width / self.height if self.height != 0 else 0)
+        object.__setattr__(self, "aspect_ratio", aspect_ratio)
 
 
 @dataclass(frozen=True, config=ValidatorConfig)
@@ -229,7 +230,7 @@ class BoundingBox3D(Annotation):
         return _AnnotationType.BOUNDING_BOX_3D
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "volume", reduce(lambda a, b: a * b, self.dimensions))
+        object.__setattr__(self, "volume", getattr(self, "volume", reduce(lambda a, b: a * b, self.dimensions)))
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -33,6 +33,7 @@ rendered on top of the image.
 """
 import dataclasses
 from abc import ABCMeta
+from functools import reduce
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -74,8 +75,8 @@ class BoundingBox(Annotation):
     bottom_right: Tuple[float, float]
     """The bottom right vertex (in `(x, y)` image coordinates) of this bounding box."""
 
-    height: float = dataclasses.field(init=False)
     width: float = dataclasses.field(init=False)
+    height: float = dataclasses.field(init=False)
     area: float = dataclasses.field(init=False)
     aspect_ratio: float = dataclasses.field(init=False)
 
@@ -87,7 +88,7 @@ class BoundingBox(Annotation):
         object.__setattr__(self, "width", self.bottom_right[0] - self.top_left[0])
         object.__setattr__(self, "height", self.bottom_right[1] - self.top_left[1])
         object.__setattr__(self, "area", self.width * self.height)
-        object.__setattr__(self, "aspect_ratio", self.width / self.height)
+        object.__setattr__(self, "aspect_ratio", self.width / self.height if self.height != 0 else 0)
 
 
 @dataclass(frozen=True, config=ValidatorConfig)
@@ -215,9 +216,14 @@ class BoundingBox3D(Annotation):
     rotations: Tuple[float, float, float]
     """Rotations in degrees about each `(x, y, z)` axis."""
 
+    volume: float = dataclasses.field(init=False)
+
     @staticmethod
     def _data_type() -> _AnnotationType:
         return _AnnotationType.BOUNDING_BOX_3D
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "volume", reduce(lambda a, b: a * b, self.dimensions))
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -67,7 +67,11 @@ class Annotation(TypedDataObject[_AnnotationType], metaclass=ABCMeta):
 
 @dataclass(frozen=True, config=ValidatorConfig)
 class BoundingBox(Annotation):
-    """Rectangular bounding box specified with pixel coordinates of the top left and bottom right vertices."""
+    """
+    Rectangular bounding box specified with pixel coordinates of the top left and bottom right vertices.
+
+    The fields `width`, `height`, `area`, and `aspect_ratio` are automatically derived from the provided coordinates.
+    """
 
     top_left: Tuple[float, float]
     """The top left vertex (in `(x, y)` image coordinates) of this bounding box."""
@@ -205,6 +209,8 @@ class BoundingBox3D(Annotation):
 
     Specified by `(x, y, z)` coordinates for the `center` of the cuboid, `(x, y, z)` `dimensions`, and a `rotation`
     parameter specifying the degrees of rotation about each axis `(x, y, z)` ranging `[-π, π]`.
+
+    The field `volume` is automatically derived from the provided `dimensions`.
     """
 
     center: Tuple[float, float, float]

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -70,14 +70,15 @@ class BoundingBox(Annotation):
     """
     Rectangular bounding box specified with pixel coordinates of the top left and bottom right vertices.
 
-    The fields `width`, `height`, `area`, and `aspect_ratio` are automatically derived from the provided coordinates.
+    The reserved fields `width`, `height`, `area`, and `aspect_ratio` are automatically populated with values derived
+    from the provided coordinates.
     """
 
     top_left: Tuple[float, float]
-    """The top left vertex (in `(x, y)` image coordinates) of this bounding box."""
+    """The top left vertex (in `(x, y)` pixel coordinates) of this bounding box."""
 
     bottom_right: Tuple[float, float]
-    """The bottom right vertex (in `(x, y)` image coordinates) of this bounding box."""
+    """The bottom right vertex (in `(x, y)` pixel coordinates) of this bounding box."""
 
     width: float = dataclasses.field(init=False)
     height: float = dataclasses.field(init=False)
@@ -136,7 +137,7 @@ class Polygon(Annotation):
     """Arbitrary polygon specified by three or more pixel coordinates."""
 
     points: List[Tuple[float, float]]
-    """The sequence of `(x, y)` points comprising the boundary of this polygon."""
+    """The sequence of `(x, y)` pixel coordinates comprising the boundary of this polygon."""
 
     @staticmethod
     def _data_type() -> _AnnotationType:
@@ -183,7 +184,7 @@ class Keypoints(Annotation):
     """Array of any number of keypoints specified in pixel coordinates."""
 
     points: List[Tuple[float, float]]
-    """The sequence of discrete `(x, y)` points comprising this keypoints annotation."""
+    """The sequence of discrete `(x, y)` pixel coordinates comprising this keypoints annotation."""
 
     @staticmethod
     def _data_type() -> _AnnotationType:
@@ -195,7 +196,7 @@ class Polyline(Annotation):
     """Polyline with any number of vertices specified in pixel coordinates."""
 
     points: List[Tuple[float, float]]
-    """The sequence of connected `(x, y)` points comprising this polyline."""
+    """The sequence of connected `(x, y)` pixel coordinates comprising this polyline."""
 
     @staticmethod
     def _data_type() -> _AnnotationType:
@@ -210,7 +211,7 @@ class BoundingBox3D(Annotation):
     Specified by `(x, y, z)` coordinates for the `center` of the cuboid, `(x, y, z)` `dimensions`, and a `rotation`
     parameter specifying the degrees of rotation about each axis `(x, y, z)` ranging `[-π, π]`.
 
-    The field `volume` is automatically derived from the provided `dimensions`.
+    The reserved field `volume` is automatically derived from the provided `dimensions`.
     """
 
     center: Tuple[float, float, float]

--- a/tests/unit/workflow/test_annotation.py
+++ b/tests/unit/workflow/test_annotation.py
@@ -154,6 +154,40 @@ def test__bounding_box__derived(
         assert getattr(bbox, field) == expected_value
 
 
+@pytest.mark.parametrize("dataclass_decorator", [dataclasses.dataclass, pydantic.dataclasses.dataclass])
+def test__bounding_box__derived__override_values(dataclass_decorator: Callable[..., Any]) -> None:
+    @dataclass_decorator(frozen=True)
+    class ExtendedBoundingBox(BoundingBox):
+        area: float
+        aspect_ratio: float = 0.0
+
+    bbox = ExtendedBoundingBox(top_left=(0, 0), bottom_right=(10, 10), area=1.0)
+    assert bbox.width == 10
+    assert bbox.height == 10
+    assert bbox.area == 1.0
+    assert bbox.aspect_ratio == 0.0
+
+
+@pytest.mark.parametrize(
+    "dataclass_decorator",
+    [
+        # dataclasses.dataclass,  # NOTE: overriding with different types only works for pydantic dataclasses
+        pydantic.dataclasses.dataclass,
+    ],
+)
+def test__bounding_box__derived__override_types(dataclass_decorator: Callable[..., Any]) -> None:
+    @dataclass_decorator(frozen=True)
+    class ExtendedBoundingBox(BoundingBox):
+        area: str
+        aspect_ratio: bool = False
+
+    bbox = ExtendedBoundingBox(top_left=(0, 0), bottom_right=(10, 10), area="test")
+    assert bbox.width == 10
+    assert bbox.height == 10
+    assert bbox.area == "test"
+    assert bbox.aspect_ratio is False
+
+
 @pytest.mark.parametrize(
     "dimensions,expected",
     [

--- a/tests/unit/workflow/test_annotation.py
+++ b/tests/unit/workflow/test_annotation.py
@@ -34,7 +34,7 @@ from kolena.workflow.annotation import Polyline
 from kolena.workflow.annotation import SegmentationMask
 
 
-def test__serialize__simple() -> None:
+def test__serde__simple() -> None:
     obj = LabeledPolygon(points=[(1, 1), (2, 2), (3, 3)], label="test")
     obj_dict = obj._to_dict()
     assert obj_dict == {
@@ -45,7 +45,7 @@ def test__serialize__simple() -> None:
     assert LabeledPolygon._from_dict(obj_dict) == obj
 
 
-def test__serialize__derived() -> None:
+def test__serde__derived() -> None:
     obj = BoundingBox(top_left=(0, 0), bottom_right=(0, 0))
     obj_dict = obj._to_dict()
     assert obj_dict == {
@@ -57,10 +57,13 @@ def test__serialize__derived() -> None:
         "aspect_ratio": 0,
         DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.BOUNDING_BOX.value}",
     }
+    # deserialization from dict containing all fields, including derived
     assert BoundingBox._from_dict(obj_dict) == obj
+    # deserialization from dict containing only non-derived fields
+    assert BoundingBox._from_dict({k: obj_dict[k] for k in ["top_left", "bottom_right", DATA_TYPE_FIELD]}) == obj
 
 
-def test__serialize__nested() -> None:
+def test__serde__nested() -> None:
     @dataclass(frozen=True)
     class Tester(DataObject):
         b: BoundingBox

--- a/tests/unit/workflow/test_annotation.py
+++ b/tests/unit/workflow/test_annotation.py
@@ -154,40 +154,6 @@ def test__bounding_box__derived(
         assert getattr(bbox, field) == expected_value
 
 
-@pytest.mark.parametrize("dataclass_decorator", [dataclasses.dataclass, pydantic.dataclasses.dataclass])
-def test__bounding_box__derived__override_values(dataclass_decorator: Callable[..., Any]) -> None:
-    @dataclass_decorator(frozen=True)
-    class ExtendedBoundingBox(BoundingBox):
-        area: float
-        aspect_ratio: float = 0.0
-
-    bbox = ExtendedBoundingBox(top_left=(0, 0), bottom_right=(10, 10), area=1.0)
-    assert bbox.width == 10
-    assert bbox.height == 10
-    assert bbox.area == 1.0
-    assert bbox.aspect_ratio == 0.0
-
-
-@pytest.mark.parametrize(
-    "dataclass_decorator",
-    [
-        # dataclasses.dataclass,  # NOTE: overriding with different types only works for pydantic dataclasses
-        pydantic.dataclasses.dataclass,
-    ],
-)
-def test__bounding_box__derived__override_types(dataclass_decorator: Callable[..., Any]) -> None:
-    @dataclass_decorator(frozen=True)
-    class ExtendedBoundingBox(BoundingBox):
-        area: str
-        aspect_ratio: bool = False
-
-    bbox = ExtendedBoundingBox(top_left=(0, 0), bottom_right=(10, 10), area="test")
-    assert bbox.width == 10
-    assert bbox.height == 10
-    assert bbox.area == "test"
-    assert bbox.aspect_ratio is False
-
-
 @pytest.mark.parametrize(
     "dimensions,expected",
     [

--- a/tests/unit/workflow/test_annotation.py
+++ b/tests/unit/workflow/test_annotation.py
@@ -35,11 +35,29 @@ from kolena.workflow.annotation import SegmentationMask
 
 
 def test__serialize__simple() -> None:
-    assert LabeledPolygon(points=[(1, 1), (2, 2), (3, 3)], label="test")._to_dict() == {
+    obj = LabeledPolygon(points=[(1, 1), (2, 2), (3, 3)], label="test")
+    obj_dict = obj._to_dict()
+    assert obj_dict == {
         "label": "test",
         "points": [[1, 1], [2, 2], [3, 3]],
         DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.POLYGON.value}",
     }
+    assert LabeledPolygon._from_dict(obj_dict) == obj
+
+
+def test__serialize__derived() -> None:
+    obj = BoundingBox(top_left=(0, 0), bottom_right=(0, 0))
+    obj_dict = obj._to_dict()
+    assert obj_dict == {
+        "top_left": [0, 0],
+        "bottom_right": [0, 0],
+        "width": 0,
+        "height": 0,
+        "area": 0,
+        "aspect_ratio": 0,
+        DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.BOUNDING_BOX.value}",
+    }
+    assert BoundingBox._from_dict(obj_dict) == obj
 
 
 def test__serialize__nested() -> None:


### PR DESCRIPTION
Automatically hydrate `BoundingBox` and `BoundingBox3D` with derived fields such as `area` and `volume`. This approach is transparent to the end user and does not impact serde or extension of these annotation objects.