### PR TITLE
Use derived bbox area in 2D OD example seed scripts

### DIFF
--- a/examples/object_detection_2d/object_detection_2d/extended/seed_test_suite.py
+++ b/examples/object_detection_2d/object_detection_2d/extended/seed_test_suite.py
@@ -36,7 +36,6 @@ from object_detection_2d.extended.workflow import TestSample
 from object_detection_2d.extended.workflow import TestSuite
 
 import kolena
-from kolena.workflow.annotation import BoundingBox
 
 
 def load_transportation_data() -> Dict[str, List[ExtendedBoundingBox]]:
@@ -56,7 +55,7 @@ def load_transportation_data() -> Dict[str, List[ExtendedBoundingBox]]:
     label_map: Dict[int, str] = {int(category["id"]): category["name"] for category in coco_data["categories"]}
 
     # cache bounding boxes per image
-    image_to_boxes: Dict[int, List[ExtendedBoundingBox]] = defaultdict(lambda: [])
+    image_to_boxes: Dict[str, List[ExtendedBoundingBox]] = defaultdict(lambda: [])
     for annotation in coco_data["annotations"]:
         image_id = annotation["image_id"]
         label = label_map[annotation["category_id"]]
@@ -146,7 +145,7 @@ def seed_test_suite_by_bounding_box_size(test_suite_name: str, complete_test_cas
     def filter_gt_bboxes(gt: GroundTruth, filter_fn: Callable[[float], bool]) -> GroundTruth:
         bboxes, ignored_bboxes = [], gt.ignored_bboxes
         for bbox in gt.bboxes:
-            bboxes.append(bbox) if filter_fn(_area(bbox)) else ignored_bboxes.append(bbox)
+            bboxes.append(bbox) if filter_fn(bbox.area) else ignored_bboxes.append(bbox)
         return GroundTruth(bboxes=bboxes, ignored_bboxes=ignored_bboxes)
 
     # create each test case by stratification
@@ -172,12 +171,6 @@ def seed_test_suite_by_bounding_box_size(test_suite_name: str, complete_test_cas
         reset=True,
     )
     print(f"created test suite '{test_suite.name}' v{test_suite.version}")
-
-
-def _area(bbox: BoundingBox) -> float:
-    width = bbox.bottom_right[0] - bbox.top_left[0]
-    height = bbox.bottom_right[1] - bbox.top_left[1]
-    return width * height
 
 
 def main(args: Namespace) -> None:

--- a/examples/object_detection_2d/object_detection_2d/seed_test_suite.py
+++ b/examples/object_detection_2d/object_detection_2d/seed_test_suite.py
@@ -35,7 +35,6 @@ from kolena._experimental.object_detection import GroundTruth
 from kolena._experimental.object_detection import TestCase
 from kolena._experimental.object_detection import TestSample
 from kolena._experimental.object_detection import TestSuite
-from kolena.workflow.annotation import BoundingBox
 from kolena.workflow.annotation import LabeledBoundingBox
 
 
@@ -56,7 +55,7 @@ def load_transportation_data() -> Dict[str, List[LabeledBoundingBox]]:
     label_map: Dict[int, str] = {int(category["id"]): category["name"] for category in coco_data["categories"]}
 
     # cache bounding boxes per image
-    image_to_boxes: Dict[int, List[LabeledBoundingBox]] = defaultdict(lambda: [])
+    image_to_boxes: Dict[str, List[LabeledBoundingBox]] = defaultdict(lambda: [])
     for annotation in coco_data["annotations"]:
         image_id = annotation["image_id"]
         label = label_map[annotation["category_id"]]
@@ -146,7 +145,7 @@ def seed_test_suite_by_bounding_box_size(test_suite_name: str, complete_test_cas
     def filter_gt_bboxes(gt: GroundTruth, filter_fn: Callable[[float], bool]) -> GroundTruth:
         bboxes, ignored_bboxes = [], gt.ignored_bboxes
         for bbox in gt.bboxes:
-            bboxes.append(bbox) if filter_fn(_area(bbox)) else ignored_bboxes.append(bbox)
+            bboxes.append(bbox) if filter_fn(bbox.area) else ignored_bboxes.append(bbox)
         return GroundTruth(bboxes=bboxes, ignored_bboxes=ignored_bboxes)
 
     # create each test case by stratification
@@ -172,12 +171,6 @@ def seed_test_suite_by_bounding_box_size(test_suite_name: str, complete_test_cas
         reset=True,
     )
     print(f"created test suite '{test_suite.name}' v{test_suite.version}")
-
-
-def _area(bbox: BoundingBox) -> float:
-    width = bbox.bottom_right[0] - bbox.top_left[0]
-    height = bbox.bottom_right[1] - bbox.top_left[1]
-    return width * height
 
 
 def main(args: Namespace) -> None:


### PR DESCRIPTION
`area` was introduced in #172 as a derived value of the provided coordinates. No need to implement the `_area` function in the 2D OD example seed scripts.