### PR TITLE
Remove superfluous 'labels' fields from prebuilt OD objects

### DIFF
--- a/kolena/_experimental/object_detection/evaluator_multiclass.py
+++ b/kolena/_experimental/object_detection/evaluator_multiclass.py
@@ -81,13 +81,9 @@ class MulticlassObjectDetectionEvaluator(Evaluator):
         self,
     ) -> TestSampleMetrics:
         return TestSampleMetrics(
-            TP_labels=[],
             TP=[],
-            FP_labels=[],
             FP=[],
-            FN_labels=[],
             FN=[],
-            Confused_labels=[],
             Confused=[],
             count_TP=0,
             count_FP=0,
@@ -101,7 +97,6 @@ class MulticlassObjectDetectionEvaluator(Evaluator):
             max_confidence_above_t=None,
             min_confidence_above_t=None,
             thresholds=[],
-            inference_labels=[],
         )
 
     def test_sample_metrics(
@@ -128,13 +123,9 @@ class MulticlassObjectDetectionEvaluator(Evaluator):
             if label in inference_labels
         ]
         return TestSampleMetrics(
-            TP_labels=sorted({inf.label for inf in tp}),
             TP=tp,
-            FP_labels=sorted({inf.label for inf in fp}),
             FP=fp,
-            FN_labels=sorted({inf.label for inf in fn}),
             FN=fn,
-            Confused_labels=sorted({inf.label for inf in confused}),
             Confused=confused,
             count_TP=len(tp),
             count_FP=len(fp),
@@ -148,7 +139,6 @@ class MulticlassObjectDetectionEvaluator(Evaluator):
             max_confidence_above_t=max(scores) if len(scores) > 0 else None,
             min_confidence_above_t=min(scores) if len(scores) > 0 else None,
             thresholds=fields,
-            inference_labels=sorted(inference_labels),
         )
 
     def compute_image_metrics(

--- a/kolena/_experimental/object_detection/workflow.py
+++ b/kolena/_experimental/object_detection/workflow.py
@@ -55,11 +55,9 @@ class GroundTruth(BaseGroundTruth):
     associated with an image.
     """
 
-    labels: List[str] = dataclasses.field(default_factory=list)
     n_bboxes: int = dataclasses.field(default_factory=lambda: 0)
 
     def __post_init__(self):
-        object.__setattr__(self, "labels", sorted({box.label for box in self.bboxes}))
         object.__setattr__(self, "n_bboxes", len(self.bboxes))
 
 
@@ -122,13 +120,9 @@ class TestCaseMetricsSingleClass(MetricsTestCase):
 
 @dataclass(frozen=True)
 class TestSampleMetrics(MetricsTestSample):
-    TP_labels: List[str]
     TP: List[ScoredLabeledBoundingBox]
-    FP_labels: List[str]
     FP: List[ScoredLabeledBoundingBox]
-    FN_labels: List[str]
     FN: List[LabeledBoundingBox]
-    Confused_labels: List[str]
     Confused: List[ScoredLabeledBoundingBox]
 
     count_TP: int
@@ -145,7 +139,6 @@ class TestSampleMetrics(MetricsTestSample):
     max_confidence_above_t: Optional[float]
     min_confidence_above_t: Optional[float]
     thresholds: List[ScoredClassificationLabel]
-    inference_labels: List[str]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
No longer necessary with new list filtering functionality.

Fixes KOL-2799