### PR TITLE
Threshold curves for binary classification example

### DIFF
--- a/examples/classification/classification/evaluator_binary.py
+++ b/examples/classification/classification/evaluator_binary.py
@@ -24,12 +24,14 @@ from classification.workflow import ThresholdConfiguration
 
 from kolena._experimental.classification.utils import compute_confusion_matrix
 from kolena._experimental.classification.utils import compute_roc_curves
+from kolena._experimental.classification.utils import compute_threshold_curves
 from kolena._utils import log
 from kolena.workflow import Plot
 from kolena.workflow.metrics import accuracy as compute_accuracy
 from kolena.workflow.metrics import f1_score as compute_f1_score
 from kolena.workflow.metrics import precision as compute_precision
 from kolena.workflow.metrics import recall as compute_recall
+from kolena.workflow.plot import CurvePlot
 
 
 class BinaryClassificationEvaluator(BaseClassificationEvaluator):
@@ -123,6 +125,21 @@ class BinaryClassificationEvaluator(BaseClassificationEvaluator):
                 labels=[positive_label, negative_label],
             ),
         )
+
+        threshold_curves = compute_threshold_curves(
+            [gt.classification for gt in ground_truths],
+            [inf.inferences[0] for inf in inferences],
+        )
+        if threshold_curves is not None:
+            plots.append(
+                CurvePlot(
+                    title="Scores vs. Confidence Threshold",
+                    x_label="Confidence Threshold",
+                    y_label="Score",
+                    curves=threshold_curves,
+                ),
+            )
+
         plots = list(filter(lambda plot: plot is not None, plots))
 
         return plots

--- a/examples/classification/classification/evaluator_binary.py
+++ b/examples/classification/classification/evaluator_binary.py
@@ -24,14 +24,12 @@ from classification.workflow import ThresholdConfiguration
 
 from kolena._experimental.classification.utils import compute_confusion_matrix
 from kolena._experimental.classification.utils import compute_roc_curves
-from kolena._experimental.classification.utils import compute_threshold_curves
 from kolena._utils import log
 from kolena.workflow import Plot
 from kolena.workflow.metrics import accuracy as compute_accuracy
 from kolena.workflow.metrics import f1_score as compute_f1_score
 from kolena.workflow.metrics import precision as compute_precision
 from kolena.workflow.metrics import recall as compute_recall
-from kolena.workflow.plot import CurvePlot
 
 
 class BinaryClassificationEvaluator(BaseClassificationEvaluator):
@@ -125,21 +123,6 @@ class BinaryClassificationEvaluator(BaseClassificationEvaluator):
                 labels=[positive_label, negative_label],
             ),
         )
-
-        threshold_curves = compute_threshold_curves(
-            [gt.classification for gt in ground_truths],
-            [inf.inferences[0] for inf in inferences],
-        )
-        if threshold_curves is not None:
-            plots.append(
-                CurvePlot(
-                    title="Scores vs. Confidence Threshold",
-                    x_label="Confidence Threshold",
-                    y_label="Score",
-                    curves=threshold_curves,
-                ),
-            )
-
         plots = list(filter(lambda plot: plot is not None, plots))
 
         return plots

--- a/kolena/_experimental/classification/utils.py
+++ b/kolena/_experimental/classification/utils.py
@@ -207,7 +207,7 @@ def compute_roc_curves(
 
     :param ground_truths: The list of ground truth
         [`ClassificationLabel`][kolena.workflow.annotation.ClassificationLabel]. For binary classification, the negative
-        class is `None`.
+        class can be `None`.
     :param inferences: The list of inference
         [`ScoredClassificationLabel`][kolena.workflow.annotation.ScoredClassificationLabel]. For `N`-class problems,
         each inference is expected to contain `N` entries, one for each class and its associated confidence score.
@@ -261,6 +261,23 @@ def compute_threshold_curves(
     inferences: List[ScoredClassificationLabel],
     thresholds: Optional[List[float]] = None,
 ) -> Optional[List[CurvePlot]]:
+    """
+    Computes scores (i.e. [`Precision`][kolena.workflow.metrics.precision], [`Recall`](kolena.workflow.metrics.recall)
+    and [`F1-score`](kolena.workflow.metrics.f1_score)) vs. threshold curves for a **single** class presented in
+    `inferences`.
+
+    :param ground_truths: The list of ground truth
+        [`ClassificationLabel`][kolena.workflow.annotation.ClassificationLabel]. For binary classification, the negative
+        class can be `None`.
+    :param inferences: The list of inference
+        [`ScoredClassificationLabel`][kolena.workflow.annotation.ScoredClassificationLabel]. The list should only
+         include inferences of a specific class to plot the threshold curves for.
+    :param thresholds: The list of thresholds to plot with. If not specified, all the unique confidence scores are used
+        as thresholds, including evenly spaced thresholds from 0 to 1 with 0.1 step.
+    :return: A list of [`CurvePlot`][kolena.workflow.plot.CurvePlot]s if there is any valid `Curve` computed;
+        otherwise, `None`.
+
+    """
     if len(ground_truths) != len(inferences):
         log.warn(f"ground_truths ({len(ground_truths)}) and inferences ({len(inferences)}) differ in length")
         return None

--- a/kolena/_experimental/classification/utils.py
+++ b/kolena/_experimental/classification/utils.py
@@ -22,6 +22,9 @@ import numpy as np
 from kolena._utils import log
 from kolena.workflow.annotation import ClassificationLabel
 from kolena.workflow.annotation import ScoredClassificationLabel
+from kolena.workflow.metrics import f1_score
+from kolena.workflow.metrics import precision
+from kolena.workflow.metrics import recall
 from kolena.workflow.plot import ConfusionMatrix
 from kolena.workflow.plot import Curve
 from kolena.workflow.plot import CurvePlot
@@ -251,3 +254,58 @@ def compute_roc_curves(
             curves=curves,
         )
     return None
+
+
+def compute_threshold_curves(
+    ground_truths: List[Optional[ClassificationLabel]],
+    inferences: List[ScoredClassificationLabel],
+    thresholds: Optional[List[float]] = None,
+) -> Optional[List[CurvePlot]]:
+    if len(ground_truths) != len(inferences):
+        log.warn(f"ground_truths ({len(ground_truths)}) and inferences ({len(inferences)}) differ in length")
+        return None
+
+    if len(ground_truths) == 0 or len(inferences) == 0:
+        log.warn(
+            "insufficient # of samples to compute threshold curves — need at least 1 but received "
+            f"{len(ground_truths)}",
+        )
+        return None
+
+    inference_label = {inf.label for inf in inferences}
+    if len(inference_label) > 1:
+        log.warn(
+            f"more than one class passed in as inferences: {inference_label} — expecting inferences belonging to "
+            "a single class",
+        )
+        return None
+
+    inference_label = next(iter(inference_label))
+    y_true = [gt.label == inference_label if gt else False for gt in ground_truths]
+
+    if thresholds is None:
+        unique_scores = list({inf.score for inf in inferences})
+        initial_thresholds = list(np.linspace(0, 1, 11))
+        thresholds = [0.0]
+        for threshold in sorted(set(initial_thresholds + unique_scores)):
+            if abs(threshold - thresholds[-1]) >= 1e-2:
+                thresholds.append(threshold)
+
+    precisions = []
+    recalls = []
+    f1s = []
+    for threshold in thresholds:
+        y_pred = [inf.score >= threshold for inf in inferences]
+        tp = len([True for t, p in zip(y_true, y_pred) if t and p])
+        fp = len([True for t, p in zip(y_true, y_pred) if not t and p])
+        fn = len([True for t, p in zip(y_true, y_pred) if t and not p])
+
+        precisions.append(precision(tp, fp))
+        recalls.append(recall(tp, fn))
+        f1s.append(f1_score(tp, fp, fn))
+
+    return [
+        Curve(x=thresholds, y=precisions, label="Precision"),
+        Curve(x=thresholds, y=recalls, label="Recall"),
+        Curve(x=thresholds, y=f1s, label="F1"),
+    ]


### PR DESCRIPTION
### Linked issue(s):
Fixes KOL-2793

### What change does this PR introduce and why?
* Adds util function for computing threshold curves for a single label
* Adds threshold curves (precision, recall and f1 vs. thresholds) for binary classification evaluator
* Intentionally left out accuracy as precision, recall and f1 scores are more meaningful metrics.

[example plot](https://trunk.kolena.io/yoohee/results?modelIds=684&testSuiteId=1371&workflow=Image+Classification&evaluators=N4IgjAzA7GIFygGwA4As8wAYCciC%2BeQA)

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
