### PR TITLE
Revert "Add derived values to kolena.workflow.BoundingBox{,3D} (#172)"

### DIFF
--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -145,7 +145,7 @@ class DataObject(metaclass=ABCMeta):
                 f"cast=False, not casting field '{field.name}' to type '{field_type}' with value '{field_value}'",
             )
 
-        items = {f.name: deserialize_field(f, obj_dict.get(f.name, None)) for f in dataclasses.fields(cls) if f.init}
+        items = {f.name: deserialize_field(f, obj_dict.get(f.name, None)) for f in dataclasses.fields(cls)}
         return cls(**items)
 
 

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -31,9 +31,7 @@ For example, when viewing images in the Studio, any annotations (such as lists o
 [`Inference`][kolena.workflow.Inference], or [`MetricsTestSample`][kolena.workflow.MetricsTestSample] objects are
 rendered on top of the image.
 """
-import dataclasses
 from abc import ABCMeta
-from functools import reduce
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -67,33 +65,17 @@ class Annotation(TypedDataObject[_AnnotationType], metaclass=ABCMeta):
 
 @dataclass(frozen=True, config=ValidatorConfig)
 class BoundingBox(Annotation):
-    """
-    Rectangular bounding box specified with pixel coordinates of the top left and bottom right vertices.
-
-    The reserved fields `width`, `height`, `area`, and `aspect_ratio` are automatically populated with values derived
-    from the provided coordinates.
-    """
+    """Rectangular bounding box specified with pixel coordinates of the top left and bottom right vertices."""
 
     top_left: Tuple[float, float]
-    """The top left vertex (in `(x, y)` pixel coordinates) of this bounding box."""
+    """The top left vertex (in `(x, y)` image coordinates) of this bounding box."""
 
     bottom_right: Tuple[float, float]
-    """The bottom right vertex (in `(x, y)` pixel coordinates) of this bounding box."""
-
-    width: float = dataclasses.field(init=False)
-    height: float = dataclasses.field(init=False)
-    area: float = dataclasses.field(init=False)
-    aspect_ratio: float = dataclasses.field(init=False)
+    """The bottom right vertex (in `(x, y)` image coordinates) of this bounding box."""
 
     @staticmethod
     def _data_type() -> _AnnotationType:
         return _AnnotationType.BOUNDING_BOX
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "width", self.bottom_right[0] - self.top_left[0])
-        object.__setattr__(self, "height", self.bottom_right[1] - self.top_left[1])
-        object.__setattr__(self, "area", self.width * self.height)
-        object.__setattr__(self, "aspect_ratio", self.width / self.height if self.height != 0 else 0)
 
 
 @dataclass(frozen=True, config=ValidatorConfig)
@@ -137,7 +119,7 @@ class Polygon(Annotation):
     """Arbitrary polygon specified by three or more pixel coordinates."""
 
     points: List[Tuple[float, float]]
-    """The sequence of `(x, y)` pixel coordinates comprising the boundary of this polygon."""
+    """The sequence of `(x, y)` points comprising the boundary of this polygon."""
 
     @staticmethod
     def _data_type() -> _AnnotationType:
@@ -184,7 +166,7 @@ class Keypoints(Annotation):
     """Array of any number of keypoints specified in pixel coordinates."""
 
     points: List[Tuple[float, float]]
-    """The sequence of discrete `(x, y)` pixel coordinates comprising this keypoints annotation."""
+    """The sequence of discrete `(x, y)` points comprising this keypoints annotation."""
 
     @staticmethod
     def _data_type() -> _AnnotationType:
@@ -196,7 +178,7 @@ class Polyline(Annotation):
     """Polyline with any number of vertices specified in pixel coordinates."""
 
     points: List[Tuple[float, float]]
-    """The sequence of connected `(x, y)` pixel coordinates comprising this polyline."""
+    """The sequence of connected `(x, y)` points comprising this polyline."""
 
     @staticmethod
     def _data_type() -> _AnnotationType:
@@ -210,8 +192,6 @@ class BoundingBox3D(Annotation):
 
     Specified by `(x, y, z)` coordinates for the `center` of the cuboid, `(x, y, z)` `dimensions`, and a `rotation`
     parameter specifying the degrees of rotation about each axis `(x, y, z)` ranging `[-π, π]`.
-
-    The reserved field `volume` is automatically derived from the provided `dimensions`.
     """
 
     center: Tuple[float, float, float]
@@ -223,14 +203,9 @@ class BoundingBox3D(Annotation):
     rotations: Tuple[float, float, float]
     """Rotations in degrees about each `(x, y, z)` axis."""
 
-    volume: float = dataclasses.field(init=False)
-
     @staticmethod
     def _data_type() -> _AnnotationType:
         return _AnnotationType.BOUNDING_BOX_3D
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "volume", reduce(lambda a, b: a * b, self.dimensions))
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/tests/unit/workflow/test_annotation.py
+++ b/tests/unit/workflow/test_annotation.py
@@ -11,17 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import dataclasses
 from dataclasses import dataclass
-from typing import Any
-from typing import Callable
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
-
-import pydantic
-import pytest
 
 from kolena.workflow._datatypes import DATA_TYPE_FIELD
 from kolena.workflow._datatypes import DataObject
@@ -38,61 +31,15 @@ from kolena.workflow.annotation import Polyline
 from kolena.workflow.annotation import SegmentationMask
 
 
-def test__serde__simple() -> None:
-    obj = LabeledPolygon(points=[(1, 1), (2, 2), (3, 3)], label="test")
-    obj_dict = obj._to_dict()
-    assert obj_dict == {
-        "label": "test",
-        "points": [[1, 1], [2, 2], [3, 3]],
-        DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.POLYGON.value}",
-    }
-    assert LabeledPolygon._from_dict(obj_dict) == obj
-
-
-def test__serde__derived() -> None:
-    obj = BoundingBox(top_left=(0, 0), bottom_right=(0, 0))
-    obj_dict = obj._to_dict()
-    assert obj_dict == {
-        "top_left": [0, 0],
-        "bottom_right": [0, 0],
-        "width": 0,
-        "height": 0,
-        "area": 0,
-        "aspect_ratio": 0,
+def test__serialize__simple() -> None:
+    assert BoundingBox(top_left=(1, 1), bottom_right=(2, 2))._to_dict() == {
+        "top_left": [1, 1],
+        "bottom_right": [2, 2],
         DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.BOUNDING_BOX.value}",
     }
-    # deserialization from dict containing all fields, including derived
-    assert BoundingBox._from_dict(obj_dict) == obj
-    # deserialization from dict containing only non-derived fields
-    assert BoundingBox._from_dict({k: obj_dict[k] for k in ["top_left", "bottom_right", DATA_TYPE_FIELD]}) == obj
 
 
-@pytest.mark.parametrize("dataclass_decorator", [dataclasses.dataclass, pydantic.dataclasses.dataclass])
-def test__serde__derived__extended(dataclass_decorator: Callable[..., Any]) -> None:
-    @dataclass_decorator(frozen=True)
-    class ExtendedBoundingBox(BoundingBox):
-        a: str
-        b: bool = False
-        c: Optional[int] = None
-
-    obj = ExtendedBoundingBox(top_left=(0, 0), bottom_right=(0, 0), a="a", c=0)
-    obj_dict = obj._to_dict()
-    assert obj_dict == {
-        "top_left": [0, 0],
-        "bottom_right": [0, 0],
-        "width": 0,
-        "height": 0,
-        "area": 0,
-        "aspect_ratio": 0,
-        "a": "a",
-        "b": False,
-        "c": 0,
-        DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.BOUNDING_BOX.value}",
-    }
-    assert ExtendedBoundingBox._from_dict(obj_dict) == obj
-
-
-def test__serde__nested() -> None:
+def test__serialize__nested() -> None:
     @dataclass(frozen=True)
     class Tester(DataObject):
         b: BoundingBox
@@ -128,41 +75,9 @@ def test__serde__nested() -> None:
     )
     obj_dict = obj._to_dict()
 
-    assert obj_dict["e"] == {
-        "points": [[0, 0], [1, 1], [2, 2], [0, 0]],
-        "label": "e",
-        DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.POLYGON.value}",
+    assert obj_dict["b"] == {
+        "top_left": [0, 0],
+        "bottom_right": [1, 1],
+        DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.BOUNDING_BOX.value}",
     }
     assert Tester._from_dict(obj_dict) == obj
-
-
-@pytest.mark.parametrize(
-    "top_left,bottom_right,expected",
-    [
-        ((0, 0), (0, 0), dict(width=0, height=0, area=0, aspect_ratio=0)),
-        ((10, 10), (10, 10), dict(width=0, height=0, area=0, aspect_ratio=0)),
-        ((10, 10), (20, 30), dict(width=10, height=20, area=200, aspect_ratio=0.5)),
-    ],
-)
-def test__bounding_box__derived(
-    top_left: Tuple[float, float],
-    bottom_right: Tuple[float, float],
-    expected: Dict[str, float],
-) -> None:
-    bbox = BoundingBox(top_left=top_left, bottom_right=bottom_right)
-    for field, expected_value in expected.items():
-        assert getattr(bbox, field) == expected_value
-
-
-@pytest.mark.parametrize(
-    "dimensions,expected",
-    [
-        ((0, 0, 0), 0),
-        ((10, 10, 10), 1000),
-        ((1, 1, 1), 1),
-        ((1000, 0, 1000), 0),
-    ],
-)
-def test__bounding_box_3d__derived(dimensions: Tuple[float, float, float], expected: float) -> None:
-    bbox = BoundingBox3D(center=(0, 0, 0), dimensions=dimensions, rotations=(0, 0, 0))
-    assert bbox.volume == expected


### PR DESCRIPTION
This reverts commit beafb820bd7ab7a927af18c918e277b80e50b760.

### Linked issue(s):

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
