### PR TITLE
Fix Prebuilt OD Class Level Image Counts

### DIFF
--- a/kolena/_experimental/object_detection/evaluator_multiclass.py
+++ b/kolena/_experimental/object_detection/evaluator_multiclass.py
@@ -217,7 +217,7 @@ class MulticlassObjectDetectionEvaluator(Evaluator):
         self.compute_and_cache_f1_optimal_thresholds(configuration, inferences)
         return [(ts, self.compute_image_metrics(gt, inf, configuration, test_case.name)) for ts, gt, inf in inferences]
 
-    def bbox_matches_for_one_label(
+    def bbox_matches_and_count_for_one_label(
         self,
         matchings: List[MulticlassInferenceMatches],
         label: str,
@@ -239,7 +239,6 @@ class MulticlassObjectDetectionEvaluator(Evaluator):
                     match_unmatched_gt.append((gt, inf))
             for inf in match.unmatched_inf:
                 if inf.label == label:
-                    sample_flag = True
                     match_unmatched_inf.append(inf)
             if sample_flag:
                 samples_count += 1
@@ -295,7 +294,10 @@ class MulticlassObjectDetectionEvaluator(Evaluator):
         label: str,
         thresholds: Dict[str, float],
     ) -> ClassMetricsPerTestCase:
-        match_and_count: Tuple[MulticlassInferenceMatches, int] = self.bbox_matches_for_one_label(matchings, label)
+        match_and_count: Tuple[MulticlassInferenceMatches, int] = self.bbox_matches_and_count_for_one_label(
+            matchings,
+            label,
+        )
         class_matches: MulticlassInferenceMatches = match_and_count[0]
         samples_count: int = match_and_count[1]
 

--- a/tests/unit/_experimental/object_detection/test_evaluators.py
+++ b/tests/unit/_experimental/object_detection/test_evaluators.py
@@ -988,12 +988,12 @@ def test__object_detection__single_class__test_case_metrics_single_class(
                         ScoredLabeledBoundingBox((1, 1), (2, 2), "a", 0.2),
                     ],
                 ),
-                2,
+                1,
             ),
         ),
     ],
 )
-def test__object_detection__multiclass__bbox_matches_for_one_label(
+def test__object_detection__multiclass__bbox_matches_and_count_for_one_label(
     test_name: str,
     matchings: List[MulticlassInferenceMatches],
     label: str,
@@ -1002,7 +1002,7 @@ def test__object_detection__multiclass__bbox_matches_for_one_label(
     from kolena._experimental.object_detection.evaluator_multiclass import MulticlassObjectDetectionEvaluator
 
     od_multi = MulticlassObjectDetectionEvaluator()
-    result = od_multi.bbox_matches_for_one_label(
+    result = od_multi.bbox_matches_and_count_for_one_label(
         matchings=matchings,
         label=label,
     )


### PR DESCRIPTION
After talking with @sandalns , nested class metric `nImages` is not as clear as it should be - it counts `unmatched_infs`.

Current setup:
When a complete test case has 10 images, and only 1 image has a `class of interest`, but the model makes predictions of this class on other images, we could see `nImages` range from 1 to 10.

Fix:
Only count an image if it has at least one ground truth (a match or unmatched_gt) of the `class of interest`.