### PR TITLE
Change text summarization example with faster remote evaluator

### DIFF
--- a/examples/text_summarization/pyproject.toml
+++ b/examples/text_summarization/pyproject.toml
@@ -19,7 +19,6 @@ torch = [
     {platform = "linux", url = "https://download.pytorch.org/whl/cpu/torch-2.0.1%2Bcpu-cp39-cp39-linux_x86_64.whl"},
     {platform = "win32", url = "https://download.pytorch.org/whl/cpu/torch-2.0.1%2Bcpu-cp39-cp39-win_amd64.whl"}
 ]
-
 evaluate = "^0.4.0"
 bert-score = "^0.3.13"
 absl-py = "^1.4.0"

--- a/examples/text_summarization/pyproject.toml
+++ b/examples/text_summarization/pyproject.toml
@@ -6,15 +6,20 @@ authors = ["Kolena Engineering <eng@kolena.io>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = ">=3.9,<3.10"
 kolena = ">=0.76.0,<1"
 s3fs = "^2022.7.1"
 scikit-learn = "^1.1.2"
 numba = "^0.56.0"
 opencv-python-headless = "^4.6.0"
 # Transient dependency of `bert-score` -- pin to CPU-only to unbreak CI. This can be safely removed on GPU systems
-# Further reading: https://github.com/python-poetry/poetry/issues/6409#issuecomment-1310655479
-torch = { version = "^2.0.1+cpu", source = "torch+cpu" }
+torch = [
+    {platform = "darwin", markers = "platform_machine != 'x86_64'", url = "https://download.pytorch.org/whl/cpu/torch-2.0.1-cp39-none-macosx_11_0_arm64.whl"},
+    {platform = "darwin", markers = "platform_machine == 'x86_64'", url = "https://download.pytorch.org/whl/cpu/torch-2.0.1-cp39-none-macosx_10_9_x86_64.whl"},
+    {platform = "linux", url = "https://download.pytorch.org/whl/cpu/torch-2.0.1%2Bcpu-cp39-cp39-linux_x86_64.whl"},
+    {platform = "win32", url = "https://download.pytorch.org/whl/cpu/torch-2.0.1%2Bcpu-cp39-cp39-win_amd64.whl"}
+]
+
 evaluate = "^0.4.0"
 bert-score = "^0.3.13"
 absl-py = "^1.4.0"
@@ -27,11 +32,6 @@ pandera = ">=0.9.0,<0.16"
 pre-commit = "^2.17"
 pytest = "^7"
 pytest-depends = "^1.0.1"
-
-[[tool.poetry.source]]
-name = "torch+cpu"
-url = "https://download.pytorch.org/whl/cpu"
-priority = "explicit"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/text_summarization/text_summarization/evaluator.py
+++ b/examples/text_summarization/text_summarization/evaluator.py
@@ -16,6 +16,8 @@ from typing import Tuple
 
 import evaluate
 import numpy as np
+from text_summarization.utils import compute_metric_vs_metric_plot
+from text_summarization.utils import compute_score_distribution_plot
 from text_summarization.workflow import GroundTruth
 from text_summarization.workflow import Inference
 from text_summarization.workflow import TestCase
@@ -24,8 +26,6 @@ from text_summarization.workflow import TestSample
 from text_summarization.workflow import TestSampleMetric
 from text_summarization.workflow import TestSuiteMetric
 
-from examples.text_summarization.text_summarization.utils import compute_metric_vs_metric_plot
-from examples.text_summarization.text_summarization.utils import compute_score_distribution_plot
 from kolena.workflow import Plot
 from kolena.workflow.evaluator_function import EvaluationResults
 from kolena.workflow.evaluator_function import TestCases

--- a/examples/text_summarization/text_summarization/evaluator.py
+++ b/examples/text_summarization/text_summarization/evaluator.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import List
-from typing import Optional
 from typing import Tuple
-from typing import Union
 
 import evaluate
 import numpy as np
@@ -26,10 +24,8 @@ from text_summarization.workflow import TestSample
 from text_summarization.workflow import TestSampleMetric
 from text_summarization.workflow import TestSuiteMetric
 
-from kolena.workflow import AxisConfig
-from kolena.workflow import Curve
-from kolena.workflow import CurvePlot
-from kolena.workflow import Histogram
+from examples.text_summarization.text_summarization.utils import compute_metric_vs_metric_plot
+from examples.text_summarization.text_summarization.utils import compute_score_distribution_plot
 from kolena.workflow import Plot
 from kolena.workflow.evaluator_function import EvaluationResults
 from kolena.workflow.evaluator_function import TestCases
@@ -93,64 +89,6 @@ def compute_aggregate_metrics(
         ROUGE_L=mean_metric_ignoring_failures("ROUGE_L"),
         BLEU=mean_metric_ignoring_failures("BLEU"),
         inf_to_gt_word_count=mean_metric_ignoring_failures("inf_to_gt_word_count"),
-    )
-
-
-def compute_score_distribution_plot(
-    score: str,
-    metrics: List[Union[TestSampleMetric, Inference]],
-    binning_info: Optional[Tuple[float, float, float]] = None,  # start, end, num
-    logarithmic: bool = False,
-) -> Histogram:
-    scores = [getattr(m, score) for m in metrics]
-    if logarithmic:
-        bins = np.logspace(*binning_info, base=2)
-    else:
-        bins = np.linspace(*binning_info)
-
-    hist, _ = np.histogram(scores, bins=bins)
-    return Histogram(
-        title=f"Distribution of {score}",
-        x_label=f"{score}",
-        y_label="Count",
-        buckets=list(bins),
-        frequency=list(hist),
-        x_config=AxisConfig(type="log") if logarithmic else None,
-    )
-
-
-def compute_metric_vs_metric_plot(
-    x_metric: str,
-    y_metric: str,
-    x_metrics: List[Union[TestSampleMetric, Inference]],
-    y_metrics: List[Union[TestSampleMetric, Inference]],
-    binning_info: Optional[Tuple[float, float, float]] = None,  # start, end, num
-    x_logarithmic: bool = False,
-    y_logarithmic: bool = False,
-) -> CurvePlot:
-    y_values = [getattr(m, y_metric) for m in y_metrics]
-    x_values = [getattr(m, x_metric) for m in x_metrics]
-    if x_logarithmic:
-        bins = list(np.logspace(*binning_info, base=2))
-    else:
-        bins = list(np.linspace(*binning_info))
-
-    bins_centers: List[float] = []
-    bins_values: List[float] = []
-    for i in range(len(bins) - 1):
-        lo, hi = bins[i : i + 2]
-        bin_values = [y for y, x in zip(y_values, x_values) if lo <= x < hi]
-        if len(bin_values) > 0:
-            bins_centers.append(lo + ((hi - lo) / 2))
-            bins_values.append(np.mean(bin_values))
-
-    return CurvePlot(
-        title=f"{y_metric} vs. {x_metric}",
-        x_label=f"{x_metric}",
-        y_label=f"{y_metric}",
-        curves=[Curve(x=bins_centers, y=bins_values)],
-        x_config=AxisConfig(type="log") if x_logarithmic else None,
-        y_config=AxisConfig(type="log") if y_logarithmic else None,
     )
 
 

--- a/examples/text_summarization/text_summarization/evaluator_fast.py
+++ b/examples/text_summarization/text_summarization/evaluator_fast.py
@@ -1,0 +1,85 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+from typing import Tuple
+
+import pandas as pd
+from text_summarization.workflow import GroundTruth
+from text_summarization.workflow import Inference
+from text_summarization.workflow import TestCase
+from text_summarization.workflow import TestCaseMetric
+from text_summarization.workflow import TestSample
+from text_summarization.workflow import TestSampleMetric
+
+from examples.text_summarization.text_summarization.evaluator import compute_aggregate_metrics
+from examples.text_summarization.text_summarization.evaluator import compute_plots
+from examples.text_summarization.text_summarization.evaluator import compute_test_suite_metrics
+from kolena.workflow import Plot
+from kolena.workflow.evaluator_function import EvaluationResults
+from kolena.workflow.evaluator_function import TestCases
+
+
+def compute_test_sample_metrics(ts: TestSample, gt: GroundTruth, inf: Inference, df: pd.DataFrame) -> TestSampleMetric:
+    record = df.loc[df["article_id"] == ts.id]
+
+    return TestSampleMetric(
+        BERT_prec=float(record["BERT_prec"].values[0]) if not inf.is_failure else 0.0,
+        BERT_rec=float(record["BERT_rec"].values[0]) if not inf.is_failure else 0.0,
+        BERT_f1=float(record["BERT_f1"].values[0]) if not inf.is_failure else 0.0,
+        ROUGE_1=float(record["ROUGE_1"].values[0]) if not inf.is_failure else 0.0,
+        ROUGE_2=float(record["ROUGE_2"].values[0]) if not inf.is_failure else 0.0,
+        ROUGE_L=float(record["ROUGE_L"].values[0]) if not inf.is_failure else 0.0,
+        BLEU=float(record["BLEU"].values[0]) if not inf.is_failure else 0.0,
+        inf_to_gt_word_count=float(inf.word_count) / gt.word_count,
+    )
+
+
+def evaluate_text_summarization_fast(
+    test_samples: List[TestSample],
+    ground_truths: List[GroundTruth],
+    inferences: List[Inference],
+    test_cases: TestCases,
+) -> EvaluationResults:
+    print("computing test sample metrics...")
+    df = pd.read_csv(inferences[0].source)
+    # sanitize column names to use underscores instead of spaces, dots, dashes, or slashes
+    df.columns = df.columns.str.replace(r"(\s|\.|\/|\-)+", "_", regex=True)
+
+    # Compute test sample metrics
+    test_sample_metrics: List[TestSampleMetric] = [
+        compute_test_sample_metrics(ts, gt, inf, df) for ts, gt, inf in zip(test_samples, ground_truths, inferences)
+    ]
+
+    all_test_case_metrics: List[Tuple[TestCase, TestCaseMetric]] = []
+    all_test_case_plots: List[Tuple[TestCase, List[Plot]]] = []
+    for test_case, tc_test_samples, tc_gts, tc_infs, tc_ts_metrics in test_cases.iter(
+        test_samples,
+        ground_truths,
+        inferences,
+        test_sample_metrics,
+    ):
+        print(f"computing aggregate metrics for test case '{test_case.name}'...")
+        test_case_metrics = compute_aggregate_metrics(tc_ts_metrics, tc_test_samples, tc_gts, tc_infs)
+        all_test_case_metrics.append((test_case, test_case_metrics))
+
+        print(f"computing plots for test case '{test_case.name}'...")
+        test_case_plots = compute_plots(tc_ts_metrics, tc_test_samples, tc_infs)
+        all_test_case_plots.append((test_case, test_case_plots))
+
+    return EvaluationResults(
+        metrics_test_sample=list(zip(test_samples, test_sample_metrics)),
+        metrics_test_case=all_test_case_metrics,
+        metrics_test_suite=compute_test_suite_metrics(test_samples, inferences, all_test_case_metrics),
+        plots_test_case=all_test_case_plots,
+    )

--- a/examples/text_summarization/text_summarization/evaluator_fast.py
+++ b/examples/text_summarization/text_summarization/evaluator_fast.py
@@ -15,6 +15,9 @@ from typing import List
 from typing import Tuple
 
 import pandas as pd
+from text_summarization.evaluator import compute_aggregate_metrics
+from text_summarization.evaluator import compute_plots
+from text_summarization.evaluator import compute_test_suite_metrics
 from text_summarization.workflow import GroundTruth
 from text_summarization.workflow import Inference
 from text_summarization.workflow import TestCase
@@ -22,9 +25,6 @@ from text_summarization.workflow import TestCaseMetric
 from text_summarization.workflow import TestSample
 from text_summarization.workflow import TestSampleMetric
 
-from examples.text_summarization.text_summarization.evaluator import compute_aggregate_metrics
-from examples.text_summarization.text_summarization.evaluator import compute_plots
-from examples.text_summarization.text_summarization.evaluator import compute_test_suite_metrics
 from kolena.workflow import Plot
 from kolena.workflow.evaluator_function import EvaluationResults
 from kolena.workflow.evaluator_function import TestCases
@@ -32,7 +32,6 @@ from kolena.workflow.evaluator_function import TestCases
 
 def compute_test_sample_metrics(ts: TestSample, gt: GroundTruth, inf: Inference, df: pd.DataFrame) -> TestSampleMetric:
     record = df.loc[df["article_id"] == ts.id]
-
     return TestSampleMetric(
         BERT_prec=float(record["BERT_prec"].values[0]) if not inf.is_failure else 0.0,
         BERT_rec=float(record["BERT_rec"].values[0]) if not inf.is_failure else 0.0,

--- a/examples/text_summarization/text_summarization/remote_evaluator.py
+++ b/examples/text_summarization/text_summarization/remote_evaluator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import os
 
-from text_summarization.evaluator import evaluate_text_summarization
+from text_summarization.evaluator_fast import evaluate_text_summarization_fast
 from text_summarization.workflow import Model
 from text_summarization.workflow import TestSuite
 
@@ -35,5 +35,5 @@ test_suite = TestSuite.load(test_suite_name, version=test_suite_version)
 print(f"using test_suite: {test_suite}")
 
 print("running evaluation...")
-test(model, test_suite, evaluate_text_summarization)
+test(model, test_suite, evaluate_text_summarization_fast)
 print("finished running evaluation")

--- a/examples/text_summarization/text_summarization/utils.py
+++ b/examples/text_summarization/text_summarization/utils.py
@@ -12,8 +12,79 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+import numpy as np
+from text_summarization.workflow import Inference
+from text_summarization.workflow import TestSampleMetric
+
+from kolena.workflow import AxisConfig
+from kolena.workflow import Curve
+from kolena.workflow import CurvePlot
+from kolena.workflow import Histogram
 
 
 def get_readable(text: str) -> str:
     # no spaces before periods, only after
     return re.sub(r"\s+(\.)", r"\1", text)
+
+
+def compute_score_distribution_plot(
+    score: str,
+    metrics: List[Union[TestSampleMetric, Inference]],
+    binning_info: Optional[Tuple[float, float, float]] = None,  # start, end, num
+    logarithmic: bool = False,
+) -> Histogram:
+    scores = [getattr(m, score) for m in metrics]
+    if logarithmic:
+        bins = np.logspace(*binning_info, base=2)
+    else:
+        bins = np.linspace(*binning_info)
+
+    hist, _ = np.histogram(scores, bins=bins)
+    return Histogram(
+        title=f"Distribution of {score}",
+        x_label=f"{score}",
+        y_label="Count",
+        buckets=list(bins),
+        frequency=list(hist),
+        x_config=AxisConfig(type="log") if logarithmic else None,
+    )
+
+
+def compute_metric_vs_metric_plot(
+    x_metric: str,
+    y_metric: str,
+    x_metrics: List[Union[TestSampleMetric, Inference]],
+    y_metrics: List[Union[TestSampleMetric, Inference]],
+    binning_info: Optional[Tuple[float, float, float]] = None,  # start, end, num
+    x_logarithmic: bool = False,
+    y_logarithmic: bool = False,
+) -> CurvePlot:
+    y_values = [getattr(m, y_metric) for m in y_metrics]
+    x_values = [getattr(m, x_metric) for m in x_metrics]
+    if x_logarithmic:
+        bins = list(np.logspace(*binning_info, base=2))
+    else:
+        bins = list(np.linspace(*binning_info))
+
+    bins_centers: List[float] = []
+    bins_values: List[float] = []
+    for i in range(len(bins) - 1):
+        lo, hi = bins[i : i + 2]
+        bin_values = [y for y, x in zip(y_values, x_values) if lo <= x < hi]
+        if len(bin_values) > 0:
+            bins_centers.append(lo + ((hi - lo) / 2))
+            bins_values.append(np.mean(bin_values))
+
+    return CurvePlot(
+        title=f"{y_metric} vs. {x_metric}",
+        x_label=f"{x_metric}",
+        y_label=f"{y_metric}",
+        curves=[Curve(x=bins_centers, y=bins_values)],
+        x_config=AxisConfig(type="log") if x_logarithmic else None,
+        y_config=AxisConfig(type="log") if y_logarithmic else None,
+    )

--- a/examples/text_summarization/text_summarization/workflow.py
+++ b/examples/text_summarization/text_summarization/workflow.py
@@ -42,13 +42,11 @@ class GroundTruth(BaseGroundTruth):
 @dataclass(frozen=True)
 class Inference(BaseInference):
     summary: str
+    source: str
     word_count: int
     is_failure: bool = False
     inference_time: Optional[float] = None
-    tokens_input_text: Optional[int] = None
-    tokens_ref_summary: Optional[int] = None
-    tokens_pred_summary: Optional[int] = None
-    tokens_prompt: Optional[int] = None
+    tokens_used: Optional[int] = None
     cost: Optional[float] = None
 
 


### PR DESCRIPTION
Remote evaluator is slow due to recomputing test sample metrics. Rather than recomputing, the script was changed to pull test sample metrics from CSVs.

- Changed `pyproject.toml` since torch download was failing
- Refactored helper functions into `utils`
- Made `evaluator_fast` to feed into the remote evaluator
- Cleaned up `workflow.py`

Remote evaluator works: [link](https://trunk.kolena.io/mark/testing?testSuiteId=24&testCaseId=106)