### PR TITLE
Link numpy definitions in API docs

### DIFF
--- a/kolena/workflow/test_run.py
+++ b/kolena/workflow/test_run.py
@@ -89,7 +89,7 @@ class TestRun(Frozen, WithTelemetry, metaclass=ABCMeta):
 
     model: Model
     test_suite: TestSuite
-    evaluator: Union[Evaluator, BasicEvaluatorFunction, None]
+    evaluator: Optional[Union[Evaluator, BasicEvaluatorFunction]]
     configurations: Optional[List[EvaluatorConfiguration]]
 
     @validate_arguments(config=ValidatorConfig)
@@ -97,7 +97,7 @@ class TestRun(Frozen, WithTelemetry, metaclass=ABCMeta):
         self,
         model: Model,
         test_suite: TestSuite,
-        evaluator: Union[Evaluator, BasicEvaluatorFunction, None] = None,
+        evaluator: Optional[Union[Evaluator, BasicEvaluatorFunction]] = None,
         configurations: Optional[List[EvaluatorConfiguration]] = None,
         reset: bool = False,
     ):
@@ -478,7 +478,7 @@ class TestRun(Frozen, WithTelemetry, metaclass=ABCMeta):
 def test(
     model: Model,
     test_suite: TestSuite,
-    evaluator: Union[Evaluator, BasicEvaluatorFunction, None] = None,
+    evaluator: Optional[Union[Evaluator, BasicEvaluatorFunction]] = None,
     configurations: Optional[List[EvaluatorConfiguration]] = None,
     reset: bool = False,
 ) -> None:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,7 @@ plugins:
       python:
         import:
           - https://docs.python.org/3/objects.inv
+          - https://docs.scipy.org/doc/numpy/objects.inv
         options:
           docstring_style: sphinx
           merge_init_into_class: true


### PR DESCRIPTION
Add `numpy/objects.inv` to extra imports for docs rendering such that any `np` definitions in signatures are linked to the respective official documentation:

| [Before](https://docs.kolena.io/reference/workflow/visualization/#kolena.workflow.visualization.encode_png) | After |
| ---- | --- |
| ![Screen Shot 2023-08-23 at 3 36 54 PM](https://github.com/kolenaIO/kolena/assets/9648886/6d0d9db1-5ae9-4ad5-88fa-2d6afddfee97) | ![Screen Shot 2023-08-23 at 3 36 43 PM](https://github.com/kolenaIO/kolena/assets/9648886/4644de8c-8ba5-472e-a3a1-f1350b360491) |