### PR TITLE
AWS docs reorg

### DIFF
--- a/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
+++ b/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
@@ -9,7 +9,65 @@ Integrations can be established to Amazon S3.
 To get started, ensure you have administrator access within Kolena.
 Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations) page and click "Add Integration", then "Amazon S3".
 
-### 1. Allow CORS Access to Bucket
+### 1. Select Integration Scope
+
+Amazon S3 Integrations load bucket objects by creating an IAM Role for Kolena to assume.
+
+By default, Kolena will assume this Role when loading objects from any permitted bucket.
+Alternatively, if you wish for Kolena to assume this Role only while loading objects from one bucket, uncheck
+"Use role by default for all permitted buckets?" and specify the S3 bucket name.
+
+Click "Next".
+
+!!!note "Note: scoping Integrations"
+
+    If "Use role by default for all permitted buckets?" is selected, Kolena will load any locators beginning with `s3://` by assuming the Role
+    configured for this Integration and generating a presigned URL.
+    Scoping the Integration to one bucket (e.g. `my-bucket`) means Kolena will only assume the Role when generating presigned URLs for locators of the form
+    `s3://my-bucket/*`.
+
+### 2. Create an Access Policy in AWS
+
+If you selected "Use role by default for all permitted buckets?" in the previous step, you must now choose which buckets
+Kolena is permitted to load objects from.
+Enter these bucket names.
+
+When you have entered the bucket names, you will see an "Access Policy JSON" rendered to your page.
+Copy this JSON.
+
+!!!note "Note: IAM Write Permission Required"
+
+    You will require IAM write permissions within your AWS account to perform the next step.
+
+In your AWS console, navigate to the IAM policies page.
+Click the "Create Policy" button and select the "JSON" tab.
+Paste the "Access Policy JSON" copied previously.
+Click through the "Next" buttons, adding the desired name, description, and tags.
+
+### 3. Create a Role For Kolena to Assume
+
+Return to Kolena and copy the "Trust Policy JSON".
+
+In your AWS console, navigate to the IAM roles page.
+Click the "Create role" button and select 'Custom trust policy".
+Paste the "Trust Policy JSON" you copied above and click "Next".
+Search for and select the access policy created in [step 2](#2-create-an-access-policy-in-aws).
+Provide a role name and review the permissions, then click "Create role".
+
+**Copy the Role's ARN for use in the next step.**
+
+### 4. Save Integration
+
+Return to Kolena and fill in the remaining fields for the Integration and then click "Save".
+
+| Field            | Description                                                                                                                                        |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Role ARN         | The ARN of the role created in [step 3](#3-create-a-role-for-kolena-to-assume)                                                                     |
+| Endpoint URL     | The fully qualified endpoint of the webservice. This is only required when using a custom endpoint (for example, when using a local version of S3) |
+| Region           | The region your buckets will be accessed from (e.g. `us-east-1`)                                                                                   |
+| Force Path Style | Whether to force path style URLs for S3 objects (e.g., https://s3.amazonaws.com// instead of https://.s3.amazonaws.com/)                           |
+
+### 4. Allow CORS Access to Bucket
 
 CORS permissions are required for the Kolena domain to render content from your bucket.
 
@@ -27,99 +85,3 @@ Click "Edit" and add the following JSON snippet:
   }
 ]
 ```
-
-### 2. Create an Access Policy in AWS
-
-First ensure you have IAM write permissions within your AWS account.
-In your AWS console, navigate to the IAM policies page.
-Click the "Create Policy" button and select the "JSON" tab.
-
-Copy and paste the following JSON policy:
-
-
-!!!note "Note: Update Resource Name"
-
-    After copying the JSON below, ensure that `share-with-kolena` is replaced with the appropriate bucket you wish to provide access to.
-
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "S3ListBucket",
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject",
-        "s3:ListBucket"
-      ],
-      "Resource": [
-        "arn:aws:s3:::share-with-kolena",
-        "arn:aws:s3:::share-with-kolena/*"
-      ]
-    }
-  ]
-}
-```
-
-Click through the "Next" buttons, adding the desired name, description, and tags.
-
-### 3. Create a Role For Kolena to Assume
-
-Return to the Kolena platform [Integrations tab](https://app.kolena.io/redirect/organization?tab=integrations).
-
-On the "Create Amazon S3 Integration" page, click "Generate a Principal ARN".
-This will create a Principal which will be referenced in a trust policy.
-Setting an External Id to include within the trust policy is recommended.
-
-Once these steps are complete, copy the JSON which appears on the page.
-This will be of the form:
-
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "KolenaAssumeRole",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "<< Principal ARN >>"
-      },
-      "Action": "sts:AssumeRole",
-      "Condition": {
-        "StringEquals": {
-          "sts:ExternalId": ["<< External Id >>"]
-        }
-      }
-    }
-  ]
-}
-```
-
-Navigate to the IAM roles page in your AWS console.
-Click the "Create role" button and select 'Custom trust policy".
-Paste the JSON you copied above and click "Next".
-Search for and select the access policy created in [step 2](#2-create-an-access-policy-in-aws).
-Provide a role name and review the permissions, then click "Create role".
-
-Copy the role's ARN for use in the final step.
-
-### 4. Save Integration
-
-Return to the Kolena platform [Integrations tab](https://app.kolena.io/redirect/organization?tab=integrations).
-
-By default, any locators beginning with `s3://` will be loaded using this integration.
-
-!!!note "Note: scoping integrations"
-
-    Optionally, each integration can be scoped to a specific bucket such that only locators of the pattern `s3://<specific-bucket>/*` will be loaded using the integration.
-    This can be necessary if multiple integrations are required.
-    Unchecking "Apply to all buckets by default?" and specifying a bucket will enable this behavior.
-
-Fill in the fields for the integration and then click "Save".
-
-| Field            | Description                                                                                                                                        |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Role ARN         | The ARN of the role created in [step 3](#3-create-a-role-for-kolena-to-assume)                                                                     |
-| Endpoint URL     | The fully qualified endpoint of the webservice. This is only required when using a custom endpoint (for example, when using a local version of S3) |
-| Region Name      | The region your buckets will be accessed from                                                                                                      |
-| Force Path Style | Whether to force path style URLs for S3 objects (e.g., https://s3.amazonaws.com// instead of https://.s3.amazonaws.com/)                           |

--- a/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
+++ b/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
@@ -2,7 +2,7 @@
 icon: simple/amazons3
 ---
 
-# :simple-amazons3: Amazon S3
+# Connecting Cloud Storage: <nobr>:simple-amazons3: Amazon S3</nobr>
 
 Kolena connects with [Amazon S3](https://aws.amazon.com/s3/) to load files (e.g. images, videos, documents) directly
 into your browser for visualization. In this tutorial, we'll learn how to establish an integration between Kolena and

--- a/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
+++ b/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
@@ -4,29 +4,35 @@ icon: simple/amazons3
 
 # :simple-amazons3: Amazon S3
 
-Integrations can be established to Amazon S3.
+Kolena connects with [Amazon S3](https://aws.amazon.com/s3/) to load files (e.g. images, videos, documents) directly
+into your browser for visualization. In this tutorial, we'll learn how to establish an integration between Kolena and
+Amazon S3.
 
 To get started, ensure you have administrator access within Kolena.
-Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations) page and click "Add Integration", then "Amazon S3".
+Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations)
+page and click "Add Integration", then "Amazon S3".
 
-### 1. Select Integration Scope
+### Step 1: Select Integration Scope
 
-Amazon S3 Integrations load bucket objects by creating an IAM role for Kolena to assume.
+Amazon S3 integrations load bucket objects using [pre-signed URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html).
+Kolena generates these URLs by temporarily [assuming an IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html)
+that has access to the specified bucket(s).
 
 By default, Kolena will assume this role when loading objects from any permitted bucket.
 Alternatively, if you wish for Kolena to assume this role only while loading objects from one bucket, uncheck
-"Use role by default for all permitted buckets?" and specify the S3 bucket name.
+"Use role by default for all permitted buckets?" and specify the name of an S3 bucket.
 
 Click "Next".
 
-!!!note "Note: scoping Integrations"
+!!! note "Note: Scoping Integrations"
 
-    If "Use role by default for all permitted buckets?" is selected, Kolena will load any locators beginning with `s3://` by assuming the role
-    configured for this Integration and generating a presigned URL.
-    Scoping the Integration to one bucket (e.g. `my-bucket`) means Kolena will only assume the role when generating presigned URLs for locators of the form
-    `s3://my-bucket/*`.
+    If "Use role by default for all permitted buckets?" is selected, Kolena will load any locators beginning with
+    `s3://` by assuming the role configured for this Integration and generating a presigned URL.
 
-### 2. Create an Access Policy in AWS
+    Scoping the Integration to one bucket (e.g. `my-bucket`) means Kolena will only assume the role when generating
+    presigned URLs for locators of the form `s3://my-bucket/*`.
+
+### Step 2: Create an Access Policy in AWS
 
 If you selected "Use role by default for all permitted buckets?" in the previous step, you must now choose which buckets
 Kolena is permitted to load objects from.
@@ -35,7 +41,7 @@ Enter these bucket names.
 When you have entered the bucket names, you will see an "Access Policy JSON" rendered to your page.
 Copy this JSON.
 
-!!!note "Note: IAM Write Permission Required"
+!!! note "Note: IAM Write Permission Required"
 
     You will require IAM write permissions within your AWS account to perform the next step.
 
@@ -44,34 +50,36 @@ Click the "Create Policy" button and select the "JSON" tab.
 Paste the "Access Policy JSON" copied previously.
 Click through the "Next" buttons, adding the desired name, description, and tags.
 
-### 3. Create a Role For Kolena to Assume
+### Step 3: Create a Role For Kolena to Assume
 
 Return to Kolena and copy the "Trust Policy JSON".
 
 In your AWS console, navigate to the <a target="_blank" href="https://console.aws.amazon.com/iamv2/home#/roles">IAM roles page</a>.
 Click the "Create role" button and select 'Custom trust policy".
 Paste the "Trust Policy JSON" you copied above and click "Next".
-Search for and select the access policy created in [step 2](#2-create-an-access-policy-in-aws).
+Search for and select the access policy created in [step 2](#step-2-create-an-access-policy-in-aws).
 Provide a role name and review the permissions, then click "Create role".
 
 **Copy the role's ARN for use in the next step.**
 
-### 4. Save Integration
+### Step 4: Save Integration
 
 Return to Kolena and fill in the remaining fields for the Integration and then click "Save".
 
 | Field            | Description                                                                                                                                        |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Role ARN         | The ARN of the role created in [step 3](#3-create-a-role-for-kolena-to-assume)                                                                     |
+| Role ARN         | The ARN of the role created in [step 3](#step-3-create-a-role-for-kolena-to-assume)                                                                     |
 | Endpoint URL     | The fully qualified endpoint of the webservice. This is only required when using a custom endpoint (for example, when using a local version of S3) |
 | Region           | The region your buckets will be accessed from (e.g. `us-east-1`)                                                                                   |
-| Force Path Style | Whether to force path style URLs for S3 objects (e.g., https://s3.amazonaws.com// instead of https://.s3.amazonaws.com/)                           |
+| Force Path Style | Whether to force path style URLs for S3 objects (e.g., `https://s3.amazonaws.com/<bucket>/<key>` instead of `https://<bucket>.s3.amazonaws.com/<key>`) |
 
-### 4. Allow CORS Access to Bucket
+## Appendix
 
-CORS permissions are required for the Kolena domain to render content from your bucket.
+### Allow CORS Access to Bucket
 
-Navigate to your S3 bucket inside your AWS console.
+In some scenarios, CORS permissions are required for Kolena to render content from your bucket.
+
+To configure CORS access, navigate to your S3 bucket inside your AWS console.
 Click on the "Permissions" tab and navigate to the "Cross-origin resource sharing (CORS)" section.
 Click "Edit" and add the following JSON snippet:
 

--- a/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
+++ b/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
@@ -39,7 +39,7 @@ Copy this JSON.
 
     You will require IAM write permissions within your AWS account to perform the next step.
 
-In your AWS console, navigate to the IAM policies page.
+In your AWS console, navigate to the <a target="_blank" href="https://console.aws.amazon.com/iamv2/home#/policies">IAM policies page</a>.
 Click the "Create Policy" button and select the "JSON" tab.
 Paste the "Access Policy JSON" copied previously.
 Click through the "Next" buttons, adding the desired name, description, and tags.
@@ -48,7 +48,7 @@ Click through the "Next" buttons, adding the desired name, description, and tags
 
 Return to Kolena and copy the "Trust Policy JSON".
 
-In your AWS console, navigate to the IAM roles page.
+In your AWS console, navigate to the <a target="_blank" href="https://console.aws.amazon.com/iamv2/home#/roles">IAM roles page</a>.
 Click the "Create role" button and select 'Custom trust policy".
 Paste the "Trust Policy JSON" you copied above and click "Next".
 Search for and select the access policy created in [step 2](#2-create-an-access-policy-in-aws).

--- a/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
+++ b/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
@@ -68,12 +68,10 @@ In your AWS console, navigate to the <a target="_blank" href="https://console.aw
 
 Return to Kolena and fill in the remaining fields for the Integration and then click "Save".
 
-| Field            | Description                                                                                                                                            |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Role ARN         | The ARN of the role created in [step 3](#step-3-create-a-role-for-kolena-to-assume)                                                                    |
-| Endpoint URL     | The fully qualified endpoint of the webservice. This is only required when using a custom endpoint (for example, when using a local version of S3)     |
-| Region           | The region your buckets will be accessed from (e.g. `us-east-1`)                                                                                       |
-| Force Path Style | Whether to force path style URLs for S3 objects (e.g., `https://s3.amazonaws.com/<bucket>/<key>` instead of `https://<bucket>.s3.amazonaws.com/<key>`) |
+| Field    | Description                                                                         |
+| -------- | ----------------------------------------------------------------------------------- |
+| Role ARN | The ARN of the role created in [step 3](#step-3-create-a-role-for-kolena-to-assume) |
+| Region   | The region your buckets will be accessed from (e.g. `us-east-1`)                    |
 
 ## Appendix
 

--- a/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
+++ b/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
@@ -45,20 +45,22 @@ Copy this JSON.
 
     You will require IAM write permissions within your AWS account to perform the next step.
 
-In your AWS console, navigate to the <a target="_blank" href="https://console.aws.amazon.com/iamv2/home#/policies">IAM policies page</a>.
-Click the "Create Policy" button and select the "JSON" tab.
-Paste the "Access Policy JSON" copied previously.
-Click through the "Next" buttons, adding the desired name, description, and tags.
+In your AWS console, navigate to the <a target="_blank" href="https://console.aws.amazon.com/iamv2/home#/policies">IAM policies page</a> and follow these steps:
+
+1. Click the "Create Policy" button and select the "JSON" tab.
+2. Paste the "Access Policy JSON" copied previously.
+3. Click through the "Next" buttons, adding the desired name, description, and tags.
 
 ### Step 3: Create a Role For Kolena to Assume
 
 Return to Kolena and copy the "Trust Policy JSON".
 
-In your AWS console, navigate to the <a target="_blank" href="https://console.aws.amazon.com/iamv2/home#/roles">IAM roles page</a>.
-Click the "Create role" button and select 'Custom trust policy".
-Paste the "Trust Policy JSON" you copied above and click "Next".
-Search for and select the access policy created in [step 2](#step-2-create-an-access-policy-in-aws).
-Provide a role name and review the permissions, then click "Create role".
+In your AWS console, navigate to the <a target="_blank" href="https://console.aws.amazon.com/iamv2/home#/roles">IAM roles page</a> and follow these steps:
+
+1. Click the "Create role" button and select "Custom trust policy".
+2. Paste the "Trust Policy JSON" you copied above and click "Next".
+3. Search for and select the access policy created in [step 2](#step-2-create-an-access-policy-in-aws).
+4. Provide a role name and review the permissions, then click "Create role".
 
 **Copy the role's ARN for use in the next step.**
 
@@ -66,11 +68,11 @@ Provide a role name and review the permissions, then click "Create role".
 
 Return to Kolena and fill in the remaining fields for the Integration and then click "Save".
 
-| Field            | Description                                                                                                                                        |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Role ARN         | The ARN of the role created in [step 3](#step-3-create-a-role-for-kolena-to-assume)                                                                     |
-| Endpoint URL     | The fully qualified endpoint of the webservice. This is only required when using a custom endpoint (for example, when using a local version of S3) |
-| Region           | The region your buckets will be accessed from (e.g. `us-east-1`)                                                                                   |
+| Field            | Description                                                                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Role ARN         | The ARN of the role created in [step 3](#step-3-create-a-role-for-kolena-to-assume)                                                                    |
+| Endpoint URL     | The fully qualified endpoint of the webservice. This is only required when using a custom endpoint (for example, when using a local version of S3)     |
+| Region           | The region your buckets will be accessed from (e.g. `us-east-1`)                                                                                       |
 | Force Path Style | Whether to force path style URLs for S3 objects (e.g., `https://s3.amazonaws.com/<bucket>/<key>` instead of `https://<bucket>.s3.amazonaws.com/<key>`) |
 
 ## Appendix
@@ -79,9 +81,10 @@ Return to Kolena and fill in the remaining fields for the Integration and then c
 
 In some scenarios, CORS permissions are required for Kolena to render content from your bucket.
 
-To configure CORS access, navigate to your S3 bucket inside your AWS console.
-Click on the "Permissions" tab and navigate to the "Cross-origin resource sharing (CORS)" section.
-Click "Edit" and add the following JSON snippet:
+To configure CORS access, navigate to your S3 bucket inside your AWS console and follow these steps:
+
+1. Click on the "Permissions" tab and navigate to the "Cross-origin resource sharing (CORS)" section.
+2. Click "Edit" and add the following JSON snippet:
 
 ```json
 [

--- a/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
+++ b/docs/advanced-usage/connecting-cloud-storage/amazon-s3.md
@@ -11,19 +11,19 @@ Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization
 
 ### 1. Select Integration Scope
 
-Amazon S3 Integrations load bucket objects by creating an IAM Role for Kolena to assume.
+Amazon S3 Integrations load bucket objects by creating an IAM role for Kolena to assume.
 
-By default, Kolena will assume this Role when loading objects from any permitted bucket.
-Alternatively, if you wish for Kolena to assume this Role only while loading objects from one bucket, uncheck
+By default, Kolena will assume this role when loading objects from any permitted bucket.
+Alternatively, if you wish for Kolena to assume this role only while loading objects from one bucket, uncheck
 "Use role by default for all permitted buckets?" and specify the S3 bucket name.
 
 Click "Next".
 
 !!!note "Note: scoping Integrations"
 
-    If "Use role by default for all permitted buckets?" is selected, Kolena will load any locators beginning with `s3://` by assuming the Role
+    If "Use role by default for all permitted buckets?" is selected, Kolena will load any locators beginning with `s3://` by assuming the role
     configured for this Integration and generating a presigned URL.
-    Scoping the Integration to one bucket (e.g. `my-bucket`) means Kolena will only assume the Role when generating presigned URLs for locators of the form
+    Scoping the Integration to one bucket (e.g. `my-bucket`) means Kolena will only assume the role when generating presigned URLs for locators of the form
     `s3://my-bucket/*`.
 
 ### 2. Create an Access Policy in AWS
@@ -54,7 +54,7 @@ Paste the "Trust Policy JSON" you copied above and click "Next".
 Search for and select the access policy created in [step 2](#2-create-an-access-policy-in-aws).
 Provide a role name and review the permissions, then click "Create role".
 
-**Copy the Role's ARN for use in the next step.**
+**Copy the role's ARN for use in the next step.**
 
 ### 4. Save Integration
 

--- a/docs/advanced-usage/connecting-cloud-storage/google-cloud-storage.md
+++ b/docs/advanced-usage/connecting-cloud-storage/google-cloud-storage.md
@@ -2,30 +2,32 @@
 icon: simple/googlecloud
 ---
 
-# :simple-googlecloud: Google Cloud Storage
+# Connecting Cloud Storage: <nobr>:simple-googlecloud: Google Cloud Storage</nobr>
 
-Integrations can be established to Google Cloud Storage.
+Kolena connects with [Google Cloud Storage S3](https://cloud.google.com/storage) to load files (e.g. images, videos,
+documents) directly into your browser for visualization. In this tutorial, we'll learn how to establish an integration
+between Kolena and Google Cloud Storage.
 
 To get started, ensure you have administrator access within Kolena.
 Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations) page and click "Add Integration", then "Google Cloud Storage".
 
-### 1. Save Integration to Create a Service Account
+### Step 1: Save Integration to Create a Service Account
 
 From the [Integrations tab](https://app.kolena.io/redirect/organization?tab=integrations), saving a Google Cloud Storage
 integration will create a service account.
 Upon creation, the integration's `client_email` will be used to provide Kolena permission to load data from your Google Cloud Storage buckets.
 
-### 2. Grant Service Account Read Access
+### Step 2: Grant Service Account Read Access
 
 Within your Google Cloud Platform console, navigate to the bucket that contains your images.
 Click on the permissions tab.
-Click the "Grant Access" button and grant the service account created in [step 1](#1-save-integration-to-create-a-service-account) the `Storage Object Viewer` role.
+Click the "Grant Access" button and grant the service account created in [step 1](#step-1-save-integration-to-create-a-service-account) the `Storage Object Viewer` role.
 The `Storage Object Viewer` role offers the following permissions:
 
 - Grants access to view objects and their metadata, excluding ACLs.
 - Grants access to list the objects in a bucket.
 
-### 3. Provide CORS Access
+### Step 3: Provide CORS Access
 
 Create a json file `cors.json` with the following content:
 

--- a/docs/advanced-usage/connecting-cloud-storage/http-basic.md
+++ b/docs/advanced-usage/connecting-cloud-storage/http-basic.md
@@ -2,14 +2,16 @@
 icon: kolena/globe-network-16
 ---
 
-# :kolena-globe-network-20: HTTP Basic
+# Connecting Cloud Storage: <nobr>:kolena-globe-network-20: HTTP Basic</nobr>
 
-Integrations can be established using HTTP Basic Auth.
+Kolena connects with systems that utilize HTTP basic authentication to load files (e.g. images, videos, documents) directly
+into your browser for visualization. In this tutorial, we'll learn how to establish an integration between Kolena and a
+file-serving system that utilizes HTTP basic authentication.
 
 To get started, ensure you have administrator access within Kolena.
 Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations) page and click "Add Integration", then "HTTP Basic".
 
-### 1. Save Integration on Kolena
+### Step 1: Save Integration on Kolena
 
 On the [Integrations tab](https://app.kolena.io/redirect/organization?tab=integrations), fill in the fields for the integration and then click "Save".
 

--- a/docs/advanced-usage/connecting-cloud-storage/s3-compatible.md
+++ b/docs/advanced-usage/connecting-cloud-storage/s3-compatible.md
@@ -3,13 +3,17 @@ icon: simple/minio
 subtitle: MinIO, Oracle, Hitachi
 ---
 
-# :simple-minio: S3-Compatible APIs
+# Connecting Cloud Storage: <nobr>:simple-minio: S3-Compatible APIs</nobr>
 
-Integrations can be established to S3-compatible systems. Supported systems include:
+Kolena connects with any S3-compatible system to load files (e.g. images, videos, documents) directly into your browser
+for visualization. Supported systems include:
 
 - [:simple-minio: MinIO](https://min.io)
 - [:simple-oracle: Oracle Object Storage](https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm)
 - [:simple-hitachi: Hitachi Content Platform (HCP) for cloud scale](https://knowledge.hitachivantara.com/Documents/Storage/HCP_for_Cloud_Scale)
+
+In this tutorial, we'll learn how to establish an integration between Kolena and a storage system implementing an
+S3-compatible API.
 
 To get started, ensure you have administrator access within Kolena.
 Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations) page and click "Add Integration", then "MinIO".
@@ -17,7 +21,7 @@ Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization
 Steps performed outside of Kolena are shown for a subset of possible S3-compatible systems.
 You may need to consult documentation for your provider to perform equivalent steps.
 
-### 1. Create a Service User for Kolena
+### Step 1: Create a Service User for Kolena
 
 
 === "`MinIO`"
@@ -26,7 +30,7 @@ You may need to consult documentation for your provider to perform equivalent st
     mc admin user add <deployment_alias> <kolena_user> <secret_access_key>
     ```
 
-### 2. Create an Access Policy
+### Step 2: Create an Access Policy
 
 Create a policy to allow read access for a bucket or set of buckets.
 
@@ -51,11 +55,11 @@ Save the following JSON policy to a file called `/tmp/kolena-policy.json`, repla
 }
 ```
 
-!!!note "Note: bucket names"
+!!!note "Note: Bucket names"
 
     Please note that bucket names must follow [S3 naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
 
-Next, create the policy and attach the policy to the service user created in [step 1](#1-create-a-service-user-for-kolena):
+Next, create the policy and attach the policy to the service user created in [step 1](#step-1-create-a-service-user-for-kolena):
 
 === "`MinIO`"
 
@@ -64,7 +68,7 @@ Next, create the policy and attach the policy to the service user created in [st
     mc admin policy attach <deployment_alias> kolenaread --user <kolena_user>
     ```
 
-### 3. Save Integration on Kolena
+### Step 3: Save Integration on Kolena
 
 Return to the Kolena platform [Integrations tab](https://app.kolena.io/redirect/organization?tab=integrations).
 
@@ -80,8 +84,8 @@ Fill in the fields for the integration and then click "Save".
 
 | Field | Description |
 |---|---|
-| Access Key Id | The username (`<kolena_user>`) of the user created in [step 1](#1-create-a-service-user-for-kolena) |
-| Secret Access Key | The secret key (`<secret_access_key>`) of the user created in [step 1](#1-create-a-service-user-for-kolena) |
-| Endpoint | The hostname or IP address of your S3-compatabile service |
-| Port | The optional port to access your S3-compatabile service |
+| Access Key Id | The username (`<kolena_user>`) of the user created in [step 1](#step-1-create-a-service-user-for-kolena) |
+| Secret Access Key | The secret key (`<secret_access_key>`) of the user created in [step 1](#step-1-create-a-service-user-for-kolena) |
+| Endpoint | The hostname or IP address of your S3-compatible service |
+| Port | The optional port to access your S3-compatible service |
 | Region | The region your buckets will be accessed from |

--- a/docs/advanced-usage/index.md
+++ b/docs/advanced-usage/index.md
@@ -13,11 +13,9 @@ This section contains tutorial documentation for advanced features available in 
 
     ---
 
-    Establish integrations to cloud storage providers.
+    Establish integrations with cloud storage providers such as [<nobr>:simple-amazons3: Amazon S3</nobr>](./connecting-cloud-storage/amazon-s3.md) and
+    [<nobr>:simple-googlecloud: Google Cloud Storage</nobr>](./connecting-cloud-storage/google-cloud-storage.md).
 
-</div>
-
-<div class="grid cards" markdown>
 - [:octicons-container-24: Packaging for Automated Evaluation](./packaging-for-automated-evaluation.md)
 
     ---
@@ -25,9 +23,6 @@ This section contains tutorial documentation for advanced features available in 
     Package [metrics evaluation logic](../reference/workflow/evaluator.md) in a Docker container image to dynamically
     compute metrics on relevant subsets of your test data.
 
-</div>
-
-<div class="grid cards" markdown>
 - [:kolena-diagram-tree-16: Nesting Test Case Metrics](./nesting-test-case-metrics.md)
 
     ---
@@ -35,14 +30,11 @@ This section contains tutorial documentation for advanced features available in 
     Report class-level metrics within a test case and test ensembles and pipelines of models by nesting aggregate
     metrics within your [`MetricsTestCase`][kolena.workflow.MetricsTestCase].
 
-</div>
-
-<div class="grid cards" markdown>
 - [:kolena-heatmap-16: Uploading Activation Maps](./uploading-activation-maps.md)
 
     ---
 
     Upload and visualize your activation map for each [`TestSample`][kolena.workflow.TestSample] along with your model
-    results on the [:kolena-studio-16: Studio](https://app.kolena.io/redirect/studio).
+    results on the [<nobr>:kolena-studio-16: Studio</nobr>](https://app.kolena.io/redirect/studio).
 
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pandas = [
 pandera = ">=0.9.0,<0.16"
 pydantic = ">=1.8,<2"
 dacite = ">=1.6,<2"
-requests = ">=2.20,<2.30" # TODO: revert upper bound when urllib3 situation sorts out: https://github.com/psf/requests/issues/6432
+requests = ">=2.20,<2.30"  # TODO: revert upper bound when urllib3 situation sorts out: https://github.com/psf/requests/issues/6432
 requests-toolbelt = "*"
 importlib-metadata = { version = "*", python = "<3.8" }
 tqdm = ">=4,<5"


### PR DESCRIPTION
### Linked issue(s):

https://linear.app/kolena/issue/KOL-2845/bug-bash-aws-bucket-connector

### What change does this PR introduce and why?

Re-organize the contents of the AWS docs page to reflect the proposed re-structured Integration page. See https://github.com/kolenaIO/marina/pull/2435 for reference

Fixes https://linear.app/kolena/issue/KOL-2856/typo-in-the-doc
Fixes https://linear.app/kolena/issue/KOL-2880/we-should-link-to-various-aws-pages
Fixes https://linear.app/kolena/issue/KOL-2881/should-cors-be-first-step