### PR TITLE
allow use of system preference for dark mode

### DIFF
--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -1,11 +1,28 @@
 INHERIT: mkdocs.yml
 
-strict: false  # allows for missing pages in git-committers (i.e. new or moved pages)
+strict: false # allows for missing pages in git-committers (i.e. new or moved pages)
 watch:
   - kolena
   - mkdocs.yml
 
 theme:
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
   features:
     # copied from mkdocs.yml -- ensure that these are kept in sync
     - announce.dismiss

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,19 +82,22 @@ theme:
   font:
     text: Inter
   palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+
+    # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      accent: cyan
       toggle:
-        icon: kolena/light-mode-20
-        name: "Switch to dark mode"
+        icon: material/brightness-7
+
+    # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      accent: cyan
       toggle:
-        icon: kolena/dark-mode-20
-        name: "Switch to light mode"
-  # NOTE: this list is duplicated in mkdocs.insiders.yml. Any changes must also be made there
+        icon: material/brightness-4
   features:
     - announce.dismiss
     - content.action.edit


### PR DESCRIPTION
### Linked issue(s):

mkdocs allows the user rely on their system preference for dark/light mode (insider feature).

https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode

Fixes https://linear.app/kolena/issue/KOL-3341/automatically-change-lightdark-mode-on-the-doc-based-on-the-kolena (with the caveat that Kolena theme and this theme are not strictly synchronized, but at least they are _more likely_ to be synchronized)