### PR TITLE
Generic workflow grabbag datatype with pydantic

### DIFF
--- a/examples/object_detection_3d/pyproject.toml
+++ b/examples/object_detection_3d/pyproject.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 kolena = ">=0.76.0,<1"
-pydantic = ">=1.8,<2.0"
+pydantic = ">=1.10,<2.0"
 openmim = "^0.3.9"
 mmcv-lite = ">=2.0.0rc4"
 mmdet = ">=3.0.0"

--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -119,7 +119,7 @@ class DataObject(metaclass=ABCMeta):
                 for f in fields + extras
             ],
         )
-        return f"""{self.__class__.__qualname__}({value_str})"""
+        return f"{self.__class__.__qualname__}({value_str})"
 
     def _to_dict(self) -> Dict[str, Any]:
         def serialize_value(value: Any) -> Any:

--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -59,7 +59,7 @@ def _allow_extra(cls: Type[T]) -> bool:
 _DATA_TYPE_MAP = {}
 
 
-def get_full_type(obj: "TypedDataObject") -> str:
+def _get_full_type(obj: "TypedDataObject") -> str:
     data_type = obj._data_type()
     return f"{data_type._data_category()}/{data_type.value}"
 
@@ -70,7 +70,7 @@ def _get_data_type(name: str) -> Optional[Type["TypedDataObject"]]:
 
 # used for TypedBaseDataObject to register themselves to be used in dataclass extra fields deserialization
 def _register_data_type(cls) -> None:
-    full_name = get_full_type(cls)
+    full_name = _get_full_type(cls)
     # leverage class inheritance order, only keep base classes of a datatype
     if full_name not in _DATA_TYPE_MAP:
         _DATA_TYPE_MAP[full_name] = cls

--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -84,6 +84,8 @@ def _deserialize_typed_dataobject(value: Dict[Any, Any]) -> Any:
     return data_type._from_dict(value)
 
 
+# best effort to deserialize typed data objects in dataclass extra fields
+# note: since a "data_type" string could map to multiple classes through inheritance, only base case would be used.
 def _try_deserialize_typed_dataobject(value: Any) -> Any:
     if isinstance(value, list):
         # only attempt deserialization when it is likely this is a list of typed data objects

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -41,6 +41,7 @@ from typing import Tuple
 from pydantic.dataclasses import dataclass
 
 from kolena._utils.validators import ValidatorConfig
+from kolena.workflow._datatypes import _register_data_type
 from kolena.workflow._datatypes import DataType
 from kolena.workflow._datatypes import TypedDataObject
 
@@ -63,6 +64,9 @@ class _AnnotationType(DataType):
 @dataclass(frozen=True, config=ValidatorConfig)
 class Annotation(TypedDataObject[_AnnotationType], metaclass=ABCMeta):
     """The base class for all annotation types."""
+
+    def __init_subclass__(cls, **kwargs):
+        _register_data_type(cls)
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/asset.py
+++ b/kolena/workflow/asset.py
@@ -31,6 +31,7 @@ from typing import Optional
 from pydantic.dataclasses import dataclass
 
 from kolena._utils.validators import ValidatorConfig
+from kolena.workflow._datatypes import _register_data_type
 from kolena.workflow._datatypes import DataType
 from kolena.workflow._datatypes import TypedDataObject
 
@@ -50,6 +51,9 @@ class _AssetType(DataType):
 @dataclass(frozen=True, config=ValidatorConfig)
 class Asset(TypedDataObject[_AssetType], metaclass=ABCMeta):
     """Base class for all asset types."""
+
+    def __init_subclass__(cls, **kwargs):
+        _register_data_type(cls)
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/test_sample.py
+++ b/kolena/workflow/test_sample.py
@@ -48,6 +48,7 @@ from pydantic import StrictStr
 from pydantic.dataclasses import dataclass
 
 from kolena._utils.validators import ValidatorConfig
+from kolena.workflow._datatypes import _register_data_type
 from kolena.workflow._datatypes import DataType
 from kolena.workflow._datatypes import TypedDataObject
 from kolena.workflow._validators import get_data_object_field_types
@@ -60,12 +61,14 @@ Metadata = Dict[
     str,
     Union[
         None,
-        # prevent coercion of values in metadata -- see: https://pydantic-docs.helpmanual.io/usage/types/#strict-types
+        # prevent coercion of values in metadata -- see:
+        # https://pydantic-docs.helpmanual.io/usage/types/#strict-types
         StrictStr,
         StrictFloat,
         StrictInt,
         StrictBool,
-        # Pydantic's StrictX doesn't play nicely with deserialization (e.g. isinstance("a string", StrictStr) => False)
+        # Pydantic's StrictX doesn't play nicely with deserialization (e.g. isinstance("a string", StrictStr) =>
+        # False)
         #  -- include base scalar types as fallbacks for this purpose
         str,
         float,
@@ -135,6 +138,9 @@ class TestSample(TypedDataObject[_TestSampleType], metaclass=ABCMeta):
     [`Model`][kolena.workflow.Model] computes inferences, or when an implementation of
     [`Evaluator`][kolena.workflow.Evaluator] evaluates metrics.
     """
+
+    def __init_subclass__(cls, **kwargs):
+        _register_data_type(cls)
 
     @staticmethod
     def _data_type() -> _TestSampleType:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.kolena.io"
 readme = "README.md"
 license = "Apache-2.0"
 keywords = ["Kolena", "ML", "testing"]
-classifiers = [  # classifiers for license, versions set automatically during Poetry build
+classifiers = [# classifiers for license, versions set automatically during Poetry build
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
@@ -35,7 +35,7 @@ pandas = [
     { version = ">=1.5,<1.6", python = ">=3.11" },
 ]
 pandera = ">=0.9.0,<0.16"
-pydantic = ">=1.8,<2"
+pydantic = ">=1.10,<2"
 dacite = ">=1.6,<2"
 requests = ">=2.20,<2.30"  # TODO: revert upper bound when urllib3 situation sorts out: https://github.com/psf/requests/issues/6432
 requests-toolbelt = "*"

--- a/tests/integration/workflow/dummy.py
+++ b/tests/integration/workflow/dummy.py
@@ -14,6 +14,7 @@
 from dataclasses import field
 from typing import Dict
 
+from pydantic import Extra
 from pydantic.dataclasses import dataclass
 
 from kolena.workflow import define_workflow
@@ -41,6 +42,26 @@ class DummyGroundTruth(GroundTruth):
 @dataclass(frozen=True, order=True)
 class DummyInference(Inference):
     score: float
+
+
+class LocalConfig:
+    extra = Extra.allow
+
+
+@dataclass(frozen=True, order=True, config=LocalConfig)
+class GrabbagTestSample(Image):
+    value: int
+
+
+@dataclass(frozen=True, order=True, config=LocalConfig)
+class GrabbagGroundTruth(GroundTruth):
+    label: str
+    value: int
+
+
+@dataclass(frozen=True, order=True, config=LocalConfig)
+class GrabbagInference(Inference):
+    ...
 
 
 DUMMY_WORKFLOW, TestCase, TestSuite, Model = define_workflow(

--- a/tests/integration/workflow/test_test_run.py
+++ b/tests/integration/workflow/test_test_run.py
@@ -424,19 +424,7 @@ def test__dataobject_schema_mismatch() -> None:
 
     loaded_test_samples = test_case.load_test_samples()
 
-    expected = [
-        (
-            GrabbagTestSample(
-                locator=test_sample.locator,
-                value=test_sample.value,
-                bbox=test_sample.bbox._to_dict(),
-            ),
-            GrabbagGroundTruth(label=ground_truth.label, value=ground_truth.value, license=ground_truth.license),
-        )
-        for test_sample, ground_truth in test_samples
-    ]
-
-    assert sorted(loaded_test_samples) == sorted(expected)
+    assert sorted(loaded_test_samples) == sorted(test_samples)
 
     # dataclass without `extra = allow` should also work
     expected_alt_format = [

--- a/tests/integration/workflow/test_test_run.py
+++ b/tests/integration/workflow/test_test_run.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import dataclasses
 import math
+import random
 from typing import Any
 from typing import List
 from typing import Optional
@@ -27,6 +28,7 @@ from kolena._api.v1.generic import TestRun as TestRunAPI
 from kolena._utils import krequests
 from kolena.errors import RemoteError
 from kolena.workflow import define_workflow
+from kolena.workflow import EvaluationResults
 from kolena.workflow import Evaluator
 from kolena.workflow import EvaluatorConfiguration
 from kolena.workflow import GroundTruth
@@ -35,18 +37,30 @@ from kolena.workflow import MetricsTestCase
 from kolena.workflow import MetricsTestSample
 from kolena.workflow import test
 from kolena.workflow import TestCase
+from kolena.workflow import TestCases
 from kolena.workflow import TestRun
 from kolena.workflow import TestSample
+from kolena.workflow.annotation import BoundingBox
+from kolena.workflow.annotation import ClassificationLabel
 from tests.integration.helper import assert_sorted_list_equal
+from tests.integration.helper import fake_locator
 from tests.integration.helper import with_test_prefix
 from tests.integration.workflow.conftest import dummy_evaluator_function
 from tests.integration.workflow.conftest import dummy_evaluator_function_with_config
 from tests.integration.workflow.conftest import DummyConfiguration
 from tests.integration.workflow.conftest import DummyEvaluator
+from tests.integration.workflow.conftest import DummyMetricsTestCase
+from tests.integration.workflow.conftest import DummyMetricsTestSample
 from tests.integration.workflow.conftest import DummyTestSample
 from tests.integration.workflow.conftest import Model
+from tests.integration.workflow.conftest import TestCase as DummyTestCase
 from tests.integration.workflow.conftest import TestSuite
+from tests.integration.workflow.dummy import DUMMY_WORKFLOW
+from tests.integration.workflow.dummy import DummyGroundTruth
 from tests.integration.workflow.dummy import DummyInference
+from tests.integration.workflow.dummy import GrabbagGroundTruth
+from tests.integration.workflow.dummy import GrabbagInference
+from tests.integration.workflow.dummy import GrabbagTestSample
 
 
 def test__init(
@@ -376,3 +390,103 @@ def test__test__remote_evaluator(
     remote_patched.assert_called_once()
     eval_patched.assert_not_called()
     streamlined_eval_patched.assert_not_called()
+
+
+def test__dataobject_schema_mismatch() -> None:
+    test_samples = [
+        (
+            GrabbagTestSample(
+                locator=fake_locator(i, "dataobject"),
+                value=i,
+                bbox=BoundingBox(
+                    top_left=(random.randint(0, 10), random.randint(0, 10)),
+                    bottom_right=(random.randint(11, 20), random.randint(11, 20)),
+                    value=i,
+                    foo="bar",
+                ),
+            ),
+            GrabbagGroundTruth(label=f"ground truth {i}", value=i, license="noncommercial"),
+        )
+        for i in range(10)
+    ]
+    # spotcheck extra field
+    assert test_samples[1][0].bbox.foo == "bar"
+
+    name = with_test_prefix(f"{__file__}::test__dataobject_schema_mismatch")
+    _, GrabbagTestCase, GrabbagTestSuite, GrabbagModel = define_workflow(
+        DUMMY_WORKFLOW.name,
+        GrabbagTestSample,
+        GrabbagGroundTruth,
+        GrabbagInference,
+    )
+    test_case_name = f"{name} test case"
+    test_case = GrabbagTestCase(test_case_name, test_samples=test_samples)
+
+    loaded_test_samples = test_case.load_test_samples()
+
+    expected = [
+        (
+            GrabbagTestSample(
+                locator=test_sample.locator,
+                value=test_sample.value,
+                bbox=test_sample.bbox._to_dict(),
+            ),
+            GrabbagGroundTruth(label=ground_truth.label, value=ground_truth.value, license=ground_truth.license),
+        )
+        for test_sample, ground_truth in test_samples
+    ]
+
+    assert sorted(loaded_test_samples) == sorted(expected)
+
+    # dataclass without `extra = allow` should also work
+    expected_alt_format = [
+        (
+            DummyTestSample(
+                locator=test_sample.locator,
+                value=test_sample.value,
+                bbox=test_sample.bbox,
+            ),
+            DummyGroundTruth(label=ground_truth.label, value=ground_truth.value),
+        )
+        for test_sample, ground_truth in test_samples
+    ]
+    dummy_test_case = DummyTestCase(test_case_name)
+    loaded_dummy_test_samples = dummy_test_case.load_test_samples()
+    assert sorted(loaded_dummy_test_samples) == sorted(expected_alt_format)
+
+    test_suite = GrabbagTestSuite(f"{name} test suite", test_cases=[test_case])
+    dummy_inferences = [GrabbagInference(value=i, mask=ClassificationLabel(label="cat", source=i)) for i in range(10)]
+
+    # match inference to test sample
+    model = GrabbagModel(f"{name} model", infer=lambda sample: dummy_inferences[int(sample.value)])
+
+    def evaluator(
+        test_samples: List[GrabbagTestSample],
+        ground_truths: List[GrabbagGroundTruth],
+        inferences: List[GrabbagInference],
+        test_cases: TestCases,
+    ) -> Optional[EvaluationResults]:
+        fixed_random_value = random.randint(0, 1_000_000_000)
+        test_sample_to_metrics = [
+            (ts, DummyMetricsTestSample(value=fixed_random_value, ignored=False)) for ts in test_samples
+        ]
+        metrics_test_sample = [metrics for _, metrics in test_sample_to_metrics]
+        metrics_test_case: List[Tuple[TestCase, DummyMetricsTestCase]] = []
+        for test_case, tc_test_samples, tc_gts, tc_infs, tc_ts_metrics in test_cases.iter(
+            test_samples,
+            ground_truths,
+            inferences,
+            metrics_test_sample,
+        ):
+            metrics = DummyMetricsTestCase(value=fixed_random_value, summary="foobar")
+            metrics_test_case.append((test_case, metrics))
+
+        return EvaluationResults(
+            metrics_test_sample=test_sample_to_metrics,
+            metrics_test_case=metrics_test_case,
+        )
+
+    TestRun(model, test_suite, evaluator).run()
+
+    inferences = model.load_inferences(test_case)
+    assert_sorted_list_equal(inferences, [(ts, gt, inf) for (ts, gt), inf in zip(test_samples, dummy_inferences)])

--- a/tests/unit/workflow/test_data_object.py
+++ b/tests/unit/workflow/test_data_object.py
@@ -16,6 +16,8 @@ import sys
 
 import pydantic
 import pytest
+from pydantic import Extra
+from pydantic.dataclasses import dataclass
 
 from kolena.workflow._datatypes import DataObject
 
@@ -61,3 +63,85 @@ def test__data_object__serialize_order() -> None:
     tester = DataclassesTester(z=False, a="foobar", b=0.3)
     serialized = tester._to_dict()
     assert list(serialized.keys()) == ["b", "a", "z"]
+
+
+def test__data_object__extras_allow() -> None:
+    @dataclass(frozen=True, config={"extra": "allow"})
+    class DataclassesTester(DataObject):
+        b: float
+        a: str
+        z: bool
+
+    tester = DataclassesTester(z=False, a="foobar", b=0.3, y=["hello"], x="world")
+    serialized = tester._to_dict()
+    assert list(serialized.keys()) == ["b", "a", "z", "y", "x"]
+
+    # pydantic dataclass with `extra = allow` should have additional fields
+    deserialized = DataclassesTester._from_dict(serialized)
+    assert deserialized == tester
+    assert deserialized.x == "world"
+    assert deserialized.y == ["hello"]
+
+
+def test__data_object__extras_allow_invalid() -> None:
+    class Config:
+        extra = Extra.allow
+
+    @dataclass(frozen=True, config=Config)
+    class DataclassesTester(DataObject):
+        b: float
+        a: str
+        z: bool
+
+    @dataclass(frozen=True)
+    class CustomData:
+        foo: str
+
+    # extras should still be checked
+    with pytest.raises(ValueError):
+        DataclassesTester(z=False, a="foobar", b=0.3, y=CustomData(foo="bar"))._to_dict()
+
+
+def test__data_object__extras_stdlib() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class StdlibDataclassesTester(DataObject):
+        a: str
+        b: float
+        z: bool
+
+    serialized = dict(z=False, a="foobar", b=0.3, y=["hello"], x="world")
+
+    # stdlib dataclass should still work
+    stdlib_tester = StdlibDataclassesTester(z=False, a="foobar", b=0.3)
+    stdlib_deserialized = StdlibDataclassesTester._from_dict(serialized)
+    assert stdlib_deserialized == stdlib_tester
+
+
+def test__data_object__extras_strict() -> None:
+    @dataclass(frozen=True)
+    class StrictDataclassesTester(DataObject):
+        b: float
+        a: str
+        z: bool
+
+    serialized = dict(z=False, a="foobar", b=0.3, y=["hello"], x="world")
+
+    # pydantic dataclass without `extra = allow` should still work
+    strict_tester = StrictDataclassesTester(z=False, a="foobar", b=0.3)
+    strict_deserialized = StrictDataclassesTester._from_dict(serialized)
+    assert strict_deserialized == strict_tester
+
+
+def test__data_object__extras_ignore() -> None:
+    @dataclass(frozen=True, config={"extra": "ignore"})
+    class IgnoreExtraTester(DataObject):
+        b: float
+        a: str
+        z: bool
+
+    serialized = dict(z=False, a="foobar", b=0.3, y=["hello"], x="world")
+
+    # pydantic dataclass with `extra = ignore` should still work
+    tester = IgnoreExtraTester(z=False, a="foobar", b=0.3)
+    deserialized = IgnoreExtraTester._from_dict(serialized)
+    assert deserialized == tester

--- a/tests/unit/workflow/test_data_object.py
+++ b/tests/unit/workflow/test_data_object.py
@@ -92,7 +92,6 @@ def test__data_object__extras_allow() -> None:
         a: str
         z: bool
 
-    # bbox = BoundingBox(top_left=(1, 1), bottom_right=(10, 10))
     bbox = LabeledBoundingBox(top_left=(1, 1), bottom_right=(10, 10), label="bus")
     tester = DataclassesTester(z=False, a="foobar", b=0.3, y=["hello"], x=bbox)
     serialized = tester._to_dict()


### PR DESCRIPTION
### Linked issue(s):

Leverage `pydantic` dataclass's [`extra` config](https://docs.pydantic.dev/1.10/usage/dataclasses/#dataclass-config) to implement grabbag-like behavior for `DataObject`.

Limitation:
1. requires users to use pydantic dataclass, not stdlib dataclass, if they extend built-in `DataObject`
2. requires users to use `config=dict(extra="allow")` (or equivalent syntax) if they extend built-in `DataObject`
3. grabbag-ed fields could have mismatched datatypes between serialization and deserialization for non-python-native data objects. For example, kolena `ClassificationLabel` as an extra field, can only be deserialized back to `dict` as there's no type information at deserialization time.
4. other limitation of pydantic's `extra` capability, see docs linked above.
5. raises minimal pydantic version from 1.8 to 1.10

Error and behavior from existing implementation would remain otherwise.

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
