### PR TITLE
fix: Short circuit local evaluation if remote evaluator is triggered

### DIFF
--- a/kolena/workflow/test_run.py
+++ b/kolena/workflow/test_run.py
@@ -244,6 +244,7 @@ class TestRun(Frozen, WithTelemetry, metaclass=ABCMeta):
         if self.evaluator is None:
             log.info("commencing server side metrics evaluation")
             self._start_server_side_evaluation()
+            return
 
         # TODO: assert that testing is complete?
         t0 = time.time()

--- a/tests/integration/workflow/test_test_run.py
+++ b/tests/integration/workflow/test_test_run.py
@@ -343,10 +343,15 @@ def test__test__function_evaluator__with_skip(
     TestRun(dummy_model, dummy_test_suites[0], dummy_evaluator_function_with_config, config)
 
 
+@pytest.mark.depends(on=["test__test"])
 def test__test__remote_evaluator(
     dummy_model: Model,
     dummy_test_suites: List[TestSuite],
 ) -> None:
-    with patch("kolena.workflow.test_run.TestRun._start_server_side_evaluation") as patched:
-        test(dummy_model, dummy_test_suites[0])
-    patched.assert_called_once()
+    with patch.object(TestRun, "_start_server_side_evaluation") as remote_patched:
+        with patch.object(TestRun, "_perform_evaluation") as eval_patched:
+            with patch.object(TestRun, "_perform_streamlined_evaluation") as streamlined_eval_patched:
+                test(dummy_model, dummy_test_suites[0])
+    remote_patched.assert_called_once()
+    eval_patched.assert_not_called()
+    streamlined_eval_patched.assert_not_called()

--- a/tests/integration/workflow/test_test_run.py
+++ b/tests/integration/workflow/test_test_run.py
@@ -341,3 +341,12 @@ def test__test__function_evaluator__with_skip(
     config = [DummyConfiguration(value="skip")]
     test(dummy_model, dummy_test_suites[0], dummy_evaluator_function_with_config, config)
     TestRun(dummy_model, dummy_test_suites[0], dummy_evaluator_function_with_config, config)
+
+
+def test__test__remote_evaluator(
+    dummy_model: Model,
+    dummy_test_suites: List[TestSuite],
+) -> None:
+    with patch("kolena.workflow.test_run.TestRun._start_server_side_evaluation") as patched:
+        test(dummy_model, dummy_test_suites[0])
+    patched.assert_called_once()


### PR DESCRIPTION
### Linked issue(s):
N/A

### What change does this PR introduce and why?
Short circuits local evaluation if remote evaluator is triggered. This was previously removed in https://github.com/kolenaIO/kolena/pull/186

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
