### PR TITLE
add helper functions to export kolena data

### DIFF
--- a/docs/reference/workflow/io-tools.md
+++ b/docs/reference/workflow/io-tools.md
@@ -1,0 +1,3 @@
+# `kolena.workflow.io`
+
+::: kolena.workflow.io

--- a/kolena/workflow/__init__.py
+++ b/kolena/workflow/__init__.py
@@ -14,9 +14,6 @@
 
 # noreorder
 from ._datatypes import DataObject
-from ._datatypes import dataframe_from_csv
-from ._datatypes import dataframe_from_json
-from ._datatypes import dataframe_to_csv
 from .test_sample import Metadata
 from .test_sample import Image
 from .test_sample import ImagePair
@@ -55,9 +52,6 @@ from .define_workflow import define_workflow
 
 __all__ = [
     "DataObject",
-    "dataframe_from_csv",
-    "dataframe_from_json",
-    "dataframe_to_csv",
     "Metadata",
     "Image",
     "ImagePair",

--- a/kolena/workflow/__init__.py
+++ b/kolena/workflow/__init__.py
@@ -14,6 +14,9 @@
 
 # noreorder
 from ._datatypes import DataObject
+from ._datatypes import dataframe_from_csv
+from ._datatypes import dataframe_from_json
+from ._datatypes import dataframe_to_csv
 from .test_sample import Metadata
 from .test_sample import Image
 from .test_sample import ImagePair
@@ -52,6 +55,9 @@ from .define_workflow import define_workflow
 
 __all__ = [
     "DataObject",
+    "dataframe_from_csv",
+    "dataframe_from_json",
+    "dataframe_to_csv",
     "Metadata",
     "Image",
     "ImagePair",

--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import dataclasses
-import json
 from abc import ABCMeta
 from abc import abstractmethod
 from collections import OrderedDict
@@ -235,96 +234,6 @@ class DataObject(metaclass=ABCMeta):
     # integrate with pandas json deserialization
     def toDict(self) -> Dict:
         return self._to_dict()
-
-
-def _serialize_dataobject(x: Any) -> Any:
-    if isinstance(x, list):
-        return [item._to_dict() if isinstance(item, DataObject) else item for item in x]
-
-    return x._to_dict() if isinstance(x, DataObject) else x
-
-
-def _deserialize_dataobject(x: Any) -> Any:
-    if isinstance(x, list):
-        return [_deserialize_dataobject(item) for item in x]
-
-    if isinstance(x, dict) and DATA_TYPE_FIELD in x:
-        data = {**x}
-        data_type = data.pop(DATA_TYPE_FIELD)
-        typed_dataobject = _DATA_TYPE_MAP.get(data_type, None)
-        if typed_dataobject:
-            return typed_dataobject._from_dict(data)
-
-    return x
-
-
-_serialize_series = np.vectorize(_serialize_dataobject)
-_deserialize_series = np.vectorize(_deserialize_dataobject)
-
-
-def _serialize_json(x: Any) -> Any:
-    if isinstance(x, list) or isinstance(x, dict):
-        return json.dumps(x)
-
-    return x
-
-
-def _deserialize_json(x: Any) -> Any:
-    if isinstance(x, str):
-        try:
-            return json.loads(x)
-        except Exception:
-            ...
-
-    return x
-
-
-def dataframe_to_csv(df: pd.DataFrame, *args, **kwargs) -> Union[str, None]:
-    """
-    Helper function to export pandas DataFrame containing annotation or asset to CSV format.
-
-    :param args: positional arguments to `pandas.DataFrame.to_csv`.
-    :param kwargs: keyword arguments to `pandas.DataFrame.to_csv`.
-    :return: None or str.
-    """
-    columns = list(df.select_dtypes(include="object").columns)
-    df_post = df.select_dtypes(exclude="object")
-    df_post[columns] = df[columns].apply(_serialize_series)
-    df_post[columns] = df_post[columns].apply(np.vectorize(_serialize_json))
-    return df_post.to_csv(*args, **kwargs)
-
-
-def dataframe_from_csv(*args, **kwargs) -> pd.DataFrame:
-    """
-    Helper function to load pandas DataFrame exported to CSV with `dataframe_to_csv`.
-
-    :param args: positional arguments to `pandas.DataFrame.read_csv`.
-    :param kwargs: keyword arguments to `pandas.DataFrame.read_csv`.
-    :return: DataFrame.
-    """
-    df = pd.read_csv(*args, **kwargs)
-    columns = list(df.select_dtypes(include="object").columns)
-    df_post = df.select_dtypes(exclude="object")
-    df_post[columns] = df[columns].apply(np.vectorize(_deserialize_json))
-    df_post[columns] = df_post[columns].apply(_deserialize_series)
-
-    return df_post
-
-
-def dataframe_from_json(*args, **kwargs) -> pd.DataFrame:
-    """
-    Helper function to load pandas DataFrame containing annotation or asset from JSON file or string.
-
-    :param args: positional arguments to `pandas.DataFrame.read_json`.
-    :param kwargs: keyword arguments to `pandas.DataFrame.read_json`.
-    :return: DataFrame.
-    """
-    df = pd.read_json(*args, **kwargs)
-    columns = list(df.select_dtypes(include="object").columns)
-    df_post = df.select_dtypes(exclude="object")
-    df_post[columns] = df[columns].apply(_deserialize_series)
-
-    return df_post
 
 
 class DataType(str, Enum):

--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import dataclasses
+import json
 from abc import ABCMeta
 from abc import abstractmethod
 from collections import OrderedDict
@@ -230,6 +231,79 @@ class DataObject(metaclass=ABCMeta):
                 if key not in field_names:
                     items[key] = _try_deserialize_typed_dataobject(val)
         return cls(**items)
+
+    # integrate with pandas json deserialization
+    def toDict(self) -> Dict:
+        return self._to_dict()
+
+
+def _serialize_dataobject(x: Any) -> Any:
+    if isinstance(x, list):
+        return [item._to_dict() if isinstance(item, DataObject) else item for item in x]
+
+    return x._to_dict() if isinstance(x, DataObject) else x
+
+
+def _deserialize_dataobject(x: Any) -> Any:
+    if isinstance(x, list):
+        return [_deserialize_dataobject(item) for item in x]
+
+    if isinstance(x, dict) and DATA_TYPE_FIELD in x:
+        data = {**x}
+        data_type = data.pop(DATA_TYPE_FIELD)
+        typed_dataobject = _DATA_TYPE_MAP.get(data_type, None)
+        if typed_dataobject:
+            return typed_dataobject._from_dict(data)
+
+    return x
+
+
+_serialize_series = np.vectorize(_serialize_dataobject)
+_deserialize_series = np.vectorize(_deserialize_dataobject)
+
+
+def _serialize_json(x: Any) -> Any:
+    if isinstance(x, list) or isinstance(x, dict):
+        return json.dumps(x)
+
+    return x
+
+
+def _deserialize_json(x: Any) -> Any:
+    if isinstance(x, str):
+        try:
+            return json.loads(x)
+        except Exception:
+            ...
+
+    return x
+
+
+def dataframe_to_csv(df: pd.DataFrame, *args, **kwargs) -> Union[str, None]:
+    columns = list(df.select_dtypes(include="object").columns)
+    df_post = df.select_dtypes(exclude="object")
+    df_post[columns] = df[columns].apply(_serialize_series)
+    df_post[columns] = df_post[columns].apply(np.vectorize(_serialize_json))
+    return df_post.to_csv(*args, **kwargs)
+
+
+def dataframe_from_csv(*args, **kwargs) -> pd.DataFrame:
+    df = pd.read_csv(*args, **kwargs)
+    columns = list(df.select_dtypes(include="object").columns)
+    df_post = df.select_dtypes(exclude="object")
+    df_post[columns] = df[columns].apply(np.vectorize(_deserialize_json))
+    df_post[columns] = df_post[columns].apply(_deserialize_series)
+
+    return df_post
+
+
+def dataframe_from_json(*args, **kwargs) -> pd.DataFrame:
+    df = pd.read_json(*args, **kwargs)
+    columns = list(df.select_dtypes(include="object").columns)
+    df_post = df.select_dtypes(exclude="object")
+    df_post[columns] = df[columns].apply(_deserialize_series)
+
+    return df_post
 
 
 class DataType(str, Enum):

--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -232,6 +232,7 @@ class DataObject(metaclass=ABCMeta):
         return cls(**items)
 
     # integrate with pandas json deserialization
+    # https://pandas.pydata.org/docs/user_guide/io.html#fallback-behavior
     def toDict(self) -> Dict:
         return self._to_dict()
 

--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -280,6 +280,13 @@ def _deserialize_json(x: Any) -> Any:
 
 
 def dataframe_to_csv(df: pd.DataFrame, *args, **kwargs) -> Union[str, None]:
+    """
+    Helper function to export pandas DataFrame containing annotation or asset to CSV format.
+
+    :param args: positional arguments to `pandas.DataFrame.to_csv`.
+    :param kwargs: keyword arguments to `pandas.DataFrame.to_csv`.
+    :return: None or str.
+    """
     columns = list(df.select_dtypes(include="object").columns)
     df_post = df.select_dtypes(exclude="object")
     df_post[columns] = df[columns].apply(_serialize_series)
@@ -288,6 +295,13 @@ def dataframe_to_csv(df: pd.DataFrame, *args, **kwargs) -> Union[str, None]:
 
 
 def dataframe_from_csv(*args, **kwargs) -> pd.DataFrame:
+    """
+    Helper function to load pandas DataFrame exported to CSV with `dataframe_to_csv`.
+
+    :param args: positional arguments to `pandas.DataFrame.read_csv`.
+    :param kwargs: keyword arguments to `pandas.DataFrame.read_csv`.
+    :return: DataFrame.
+    """
     df = pd.read_csv(*args, **kwargs)
     columns = list(df.select_dtypes(include="object").columns)
     df_post = df.select_dtypes(exclude="object")
@@ -298,6 +312,13 @@ def dataframe_from_csv(*args, **kwargs) -> pd.DataFrame:
 
 
 def dataframe_from_json(*args, **kwargs) -> pd.DataFrame:
+    """
+    Helper function to load pandas DataFrame containing annotation or asset from JSON file or string.
+
+    :param args: positional arguments to `pandas.DataFrame.read_json`.
+    :param kwargs: keyword arguments to `pandas.DataFrame.read_json`.
+    :return: DataFrame.
+    """
     df = pd.read_json(*args, **kwargs)
     columns = list(df.select_dtypes(include="object").columns)
     df_post = df.select_dtypes(exclude="object")

--- a/kolena/workflow/io.py
+++ b/kolena/workflow/io.py
@@ -1,0 +1,113 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+from typing import Any
+from typing import Union
+
+import numpy as np
+import pandas as pd
+
+from kolena.workflow import DataObject
+from kolena.workflow._datatypes import _DATA_TYPE_MAP
+from kolena.workflow._datatypes import DATA_TYPE_FIELD
+
+
+def _serialize_dataobject(x: Any) -> Any:
+    if isinstance(x, list):
+        return [item._to_dict() if isinstance(item, DataObject) else item for item in x]
+
+    return x._to_dict() if isinstance(x, DataObject) else x
+
+
+def _deserialize_dataobject(x: Any) -> Any:
+    if isinstance(x, list):
+        return [_deserialize_dataobject(item) for item in x]
+
+    if isinstance(x, dict) and DATA_TYPE_FIELD in x:
+        data = {**x}
+        data_type = data.pop(DATA_TYPE_FIELD)
+        typed_dataobject = _DATA_TYPE_MAP.get(data_type, None)
+        if typed_dataobject:
+            return typed_dataobject._from_dict(data)
+
+    return x
+
+
+_serialize_series = np.vectorize(_serialize_dataobject)
+_deserialize_series = np.vectorize(_deserialize_dataobject)
+
+
+def _serialize_json(x: Any) -> Any:
+    if isinstance(x, list) or isinstance(x, dict):
+        return json.dumps(x)
+
+    return x
+
+
+def _deserialize_json(x: Any) -> Any:
+    if isinstance(x, str):
+        try:
+            return json.loads(x)
+        except Exception:
+            ...
+
+    return x
+
+
+def dataframe_to_csv(df: pd.DataFrame, *args, **kwargs) -> Union[str, None]:
+    """
+    Helper function to export pandas DataFrame containing annotation or asset to CSV format.
+
+    :param args: positional arguments to `pandas.DataFrame.to_csv`.
+    :param kwargs: keyword arguments to `pandas.DataFrame.to_csv`.
+    :return: None or str.
+    """
+    columns = list(df.select_dtypes(include="object").columns)
+    df_post = df.select_dtypes(exclude="object")
+    df_post[columns] = df[columns].apply(_serialize_series)
+    df_post[columns] = df_post[columns].apply(np.vectorize(_serialize_json))
+    return df_post.to_csv(*args, **kwargs)
+
+
+def dataframe_from_csv(*args, **kwargs) -> pd.DataFrame:
+    """
+    Helper function to load pandas DataFrame exported to CSV with `dataframe_to_csv`.
+
+    :param args: positional arguments to `pandas.DataFrame.read_csv`.
+    :param kwargs: keyword arguments to `pandas.DataFrame.read_csv`.
+    :return: DataFrame.
+    """
+    df = pd.read_csv(*args, **kwargs)
+    columns = list(df.select_dtypes(include="object").columns)
+    df_post = df.select_dtypes(exclude="object")
+    df_post[columns] = df[columns].apply(np.vectorize(_deserialize_json))
+    df_post[columns] = df_post[columns].apply(_deserialize_series)
+
+    return df_post
+
+
+def dataframe_from_json(*args, **kwargs) -> pd.DataFrame:
+    """
+    Helper function to load pandas DataFrame containing annotation or asset from JSON file or string.
+
+    :param args: positional arguments to `pandas.DataFrame.read_json`.
+    :param kwargs: keyword arguments to `pandas.DataFrame.read_json`.
+    :return: DataFrame.
+    """
+    df = pd.read_json(*args, **kwargs)
+    columns = list(df.select_dtypes(include="object").columns)
+    df_post = df.select_dtypes(exclude="object")
+    df_post[columns] = df[columns].apply(_deserialize_series)
+
+    return df_post

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
               - Plots: reference/workflow/plot.md
               - <code>define_workflow</code>: reference/workflow/define-workflow.md
               - <code>metrics</code>: reference/workflow/metrics.md
+              - <code>io-tools</code>: reference/workflow/io-tools.md
               - <code>visualization</code>: reference/workflow/visualization.md
       - Pre-built Workflows:
           - Pre-built Workflows: reference/pre-built/index.md
@@ -196,5 +197,5 @@ extra:
       link: https://app.kolena.io
       name: Kolena Platform
   dd_rum:
-    client_token: !ENV [DD_RUM_CLIENT_TOKEN, blank]
-    application_id: !ENV [DD_RUM_APPLICATION_ID, blank]
+    client_token: !ENV [ DD_RUM_CLIENT_TOKEN, blank ]
+    application_id: !ENV [ DD_RUM_APPLICATION_ID, blank ]

--- a/tests/unit/workflow/test_data_object.py
+++ b/tests/unit/workflow/test_data_object.py
@@ -13,20 +13,14 @@
 # limitations under the License.
 import dataclasses
 import sys
-from io import StringIO
 
-import pandas as pd
 import pydantic
 import pytest
-from pandas._testing import assert_frame_equal
 from pydantic import Extra
 from pydantic.dataclasses import dataclass
 
 from kolena.workflow import BaseVideo
 from kolena.workflow import Composite
-from kolena.workflow import dataframe_from_csv
-from kolena.workflow import dataframe_from_json
-from kolena.workflow import dataframe_to_csv
 from kolena.workflow import DataObject
 from kolena.workflow import Document
 from kolena.workflow import Image
@@ -240,52 +234,3 @@ def test__data_object__extras_deserialize_builtins(data_object) -> None:
     assert deserialized.a.extra == "foo"
     assert deserialized.b == [data_object, data_object]
     assert deserialized.b[1].extra == "foo"
-
-
-def test__dataframe_json() -> None:
-    df = pd.DataFrame.from_dict(
-        {
-            "id": list(range(10)),
-            "z": [dict(value=i + 0.3) for i in range(10)],
-            "data": [
-                LabeledBoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)
-            ],
-        },
-    )
-    df_expected = pd.DataFrame.from_dict(
-        {
-            "id": list(range(10)),
-            "z": [dict(value=i + 0.3) for i in range(10)],
-            "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
-        },
-    )
-    json_str = df.to_json()
-    df_deserialized = dataframe_from_json(json_str)
-    assert_frame_equal(df_deserialized, df_expected)
-    assert df_deserialized.iloc[0]["data"].label == "foo-0"
-
-
-def test__dataframe_export() -> None:
-    df = pd.DataFrame.from_dict(
-        {
-            "id": list(range(10)),
-            "z": [dict(value=i + 0.3) for i in range(10)],
-            "data": [
-                LabeledBoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)
-            ],
-        },
-    )
-
-    csv_str = dataframe_to_csv(df, index=False)
-    df_deserialized = dataframe_from_csv(StringIO(csv_str))
-
-    df_expected = pd.DataFrame.from_dict(
-        {
-            "id": list(range(10)),
-            "z": [dict(value=i + 0.3) for i in range(10)],
-            "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
-        },
-    )
-    assert_frame_equal(df_deserialized, df_expected)
-    assert df_deserialized.iloc[0]["id"] == 0
-    assert df_deserialized.iloc[0]["data"].label == "foo-0"

--- a/tests/unit/workflow/test_data_object.py
+++ b/tests/unit/workflow/test_data_object.py
@@ -13,19 +13,25 @@
 # limitations under the License.
 import dataclasses
 import sys
+from io import StringIO
 
+import pandas as pd
 import pydantic
 import pytest
+from pandas._testing import assert_frame_equal
 from pydantic import Extra
 from pydantic.dataclasses import dataclass
 
 from kolena.workflow import BaseVideo
 from kolena.workflow import Composite
+from kolena.workflow import dataframe_from_csv
+from kolena.workflow import dataframe_from_json
+from kolena.workflow import dataframe_to_csv
+from kolena.workflow import DataObject
 from kolena.workflow import Document
 from kolena.workflow import Image
 from kolena.workflow import PointCloud
 from kolena.workflow import Text
-from kolena.workflow._datatypes import DataObject
 from kolena.workflow.annotation import BitmapMask
 from kolena.workflow.annotation import BoundingBox
 from kolena.workflow.annotation import BoundingBox3D
@@ -234,3 +240,52 @@ def test__data_object__extras_deserialize_builtins(data_object) -> None:
     assert deserialized.a.extra == "foo"
     assert deserialized.b == [data_object, data_object]
     assert deserialized.b[1].extra == "foo"
+
+
+def test__dataframe_json() -> None:
+    df = pd.DataFrame.from_dict(
+        {
+            "id": list(range(10)),
+            "z": [dict(value=i + 0.3) for i in range(10)],
+            "data": [
+                LabeledBoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)
+            ],
+        },
+    )
+    df_expected = pd.DataFrame.from_dict(
+        {
+            "id": list(range(10)),
+            "z": [dict(value=i + 0.3) for i in range(10)],
+            "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
+        },
+    )
+    json_str = df.to_json()
+    df_deserialized = dataframe_from_json(json_str)
+    assert_frame_equal(df_deserialized, df_expected)
+    assert df_deserialized.iloc[0]["data"].label == "foo-0"
+
+
+def test__dataframe_export() -> None:
+    df = pd.DataFrame.from_dict(
+        {
+            "id": list(range(10)),
+            "z": [dict(value=i + 0.3) for i in range(10)],
+            "data": [
+                LabeledBoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)
+            ],
+        },
+    )
+
+    csv_str = dataframe_to_csv(df, index=False)
+    df_deserialized = dataframe_from_csv(StringIO(csv_str))
+
+    df_expected = pd.DataFrame.from_dict(
+        {
+            "id": list(range(10)),
+            "z": [dict(value=i + 0.3) for i in range(10)],
+            "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
+        },
+    )
+    assert_frame_equal(df_deserialized, df_expected)
+    assert df_deserialized.iloc[0]["id"] == 0
+    assert df_deserialized.iloc[0]["data"].label == "foo-0"

--- a/tests/unit/workflow/test_io.py
+++ b/tests/unit/workflow/test_io.py
@@ -22,6 +22,7 @@ from kolena.workflow.io import dataframe_from_csv
 from kolena.workflow.io import dataframe_from_json
 from kolena.workflow.io import dataframe_to_csv
 
+NAN = float("nan")
 DF_TEST = pd.DataFrame.from_dict(
     {
         "id": list(range(10)),
@@ -30,6 +31,17 @@ DF_TEST = pd.DataFrame.from_dict(
         "data": [
             LabeledBoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)
         ],
+        "bad actor": [
+            "{",
+            dict(value="box"),
+            15,
+            None,
+            "foo",
+            [1, "3", "5"],
+            LabeledBoundingBox(label="cat", top_left=[3, 5], bottom_right=[10, 15]),
+            "",
+        ]
+        + ["car"] * 2,
     },
 )
 
@@ -44,6 +56,17 @@ def test__dataframe_json() -> None:
             "z": [dict(value=i + 0.3) for i in range(10)],
             "partial": [None, ""] + ["fan"] * 8,
             "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
+            "bad actor": [
+                "{",
+                dict(value="box"),
+                15,
+                None,
+                "foo",
+                [1, "3", "5"],
+                BoundingBox(label="cat", top_left=[3, 5], bottom_right=[10, 15]),
+                "",
+            ]
+            + ["car"] * 2,
         },
     )
     assert_frame_equal(df_deserialized, df_expected)
@@ -58,8 +81,19 @@ def test__dataframe_csv() -> None:
         {
             "id": list(range(10)),
             "z": [dict(value=i + 0.3) for i in range(10)],
-            "partial": [float("nan"), float("nan")] + ["fan"] * 8,
+            "partial": [NAN, NAN] + ["fan"] * 8,
             "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
+            "bad actor": [
+                "{",
+                dict(value="box"),
+                15,
+                NAN,
+                "foo",
+                [1, "3", "5"],
+                BoundingBox(label="cat", top_left=[3, 5], bottom_right=[10, 15]),
+                NAN,
+            ]
+            + ["car"] * 2,
         },
     )
 

--- a/tests/unit/workflow/test_io.py
+++ b/tests/unit/workflow/test_io.py
@@ -1,0 +1,72 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from io import StringIO
+
+import pandas as pd
+from pandas._testing import assert_frame_equal
+
+from kolena.workflow.annotation import BoundingBox
+from kolena.workflow.annotation import LabeledBoundingBox
+from kolena.workflow.io import dataframe_from_csv
+from kolena.workflow.io import dataframe_from_json
+from kolena.workflow.io import dataframe_to_csv
+
+
+def test__dataframe_json() -> None:
+    df = pd.DataFrame.from_dict(
+        {
+            "id": list(range(10)),
+            "z": [dict(value=i + 0.3) for i in range(10)],
+            "data": [
+                LabeledBoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)
+            ],
+        },
+    )
+    df_expected = pd.DataFrame.from_dict(
+        {
+            "id": list(range(10)),
+            "z": [dict(value=i + 0.3) for i in range(10)],
+            "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
+        },
+    )
+    json_str = df.to_json()
+    df_deserialized = dataframe_from_json(json_str)
+    assert_frame_equal(df_deserialized, df_expected)
+    assert df_deserialized.iloc[0]["data"].label == "foo-0"
+
+
+def test__dataframe_csv() -> None:
+    df = pd.DataFrame.from_dict(
+        {
+            "id": list(range(10)),
+            "z": [dict(value=i + 0.3) for i in range(10)],
+            "data": [
+                LabeledBoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)
+            ],
+        },
+    )
+
+    csv_str = dataframe_to_csv(df, index=False)
+    df_deserialized = dataframe_from_csv(StringIO(csv_str))
+
+    df_expected = pd.DataFrame.from_dict(
+        {
+            "id": list(range(10)),
+            "z": [dict(value=i + 0.3) for i in range(10)],
+            "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
+        },
+    )
+    assert_frame_equal(df_deserialized, df_expected)
+    assert df_deserialized.iloc[0]["id"] == 0
+    assert df_deserialized.iloc[0]["data"].label == "foo-0"

--- a/tests/unit/workflow/test_io.py
+++ b/tests/unit/workflow/test_io.py
@@ -100,3 +100,17 @@ def test__dataframe_csv() -> None:
     assert_frame_equal(df_deserialized, df_expected)
     assert df_deserialized.iloc[0]["id"] == 0
     assert df_deserialized.iloc[0]["data"].label == "foo-0"
+
+
+def test__dataframe_csv__malformed_input() -> None:
+    input_str = "A,B,C,D\n" """1,"foo","[""a"",""b"",""c""]",false\n""" """2,"{bar}","[1,2,3",tru\n""" """,,,\n"""
+    df = dataframe_from_csv(StringIO(input_str))
+    df_expected = pd.DataFrame(
+        dict(
+            A=[1, 2, NAN],
+            B=["foo", "{bar}", NAN],
+            C=[["a", "b", "c"], "[1,2,3", NAN],
+            D=[False, "tru", NAN],
+        ),
+    )
+    assert_frame_equal(df, df_expected)


### PR DESCRIPTION
### Linked issue(s):
Add helper functions to export kolena data to csv/json through pandas dataframe.
1. dataframe_from_csv
2. dataframe_from_json
3. dataframe_to_csv

no `dataframe_to_json` as implementing `toDict` to our `DataObject` integrates with pandas' serialization.

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
