### PR TITLE
Remove 'any and all' redundant wording

### DIFF
--- a/kolena/detection/_internal/test_case.py
+++ b/kolena/detection/_internal/test_case.py
@@ -303,7 +303,7 @@ class BaseTestCase(ABC, Frozen, WithTelemetry):
 
         Changes are committed to Kolena when the context is exited.
 
-        :param reset: Clear any and all test samples currently in the test case.
+        :param reset: Clear all existing test samples in the test case.
         """
         editor = self.Editor(self.description, reset)
         editor._TestImageClass = self._TestImageClass

--- a/kolena/detection/_internal/test_suite.py
+++ b/kolena/detection/_internal/test_suite.py
@@ -283,7 +283,7 @@ class BaseTestSuite(ABC, Frozen, WithTelemetry):
 
         Changes are committed to Kolena when the context is exited.
 
-        :param reset: Clear any and all test cases currently in the test suite.
+        :param reset: Clear all existing test cases in the test suite.
         :return: Context-managed [`TestSuite.Editor`][kolena.detection._internal.test_suite.BaseTestSuite.Editor]
             instance exposing editing functionality for this test suite.
         """

--- a/kolena/fr/test_case.py
+++ b/kolena/fr/test_case.py
@@ -307,7 +307,7 @@ class TestCase(ABC, Frozen, WithTelemetry):
 
         Changes are committed to the Kolena platform when the context is exited.
 
-        :param reset: Clear any and all test samples currently in the test case.
+        :param reset: Clear all existing test samples in the test case.
         """
         editor = self.Editor(self.description, reset)
 

--- a/kolena/workflow/test_case.py
+++ b/kolena/workflow/test_case.py
@@ -330,7 +330,7 @@ class TestCase(Frozen, WithTelemetry, metaclass=ABCMeta):
 
         Changes are committed to the Kolena platform when the context is exited.
 
-        :param reset: Clear any and all test samples currently in the test case.
+        :param reset: Clear all existing test samples in the test case.
         """
         editor = self.Editor(self.description, reset)
 

--- a/kolena/workflow/test_suite.py
+++ b/kolena/workflow/test_suite.py
@@ -316,7 +316,7 @@ class TestSuite(Frozen, WithTelemetry, metaclass=ABCMeta):
 
         Changes are committed to the Kolena platform when the context is exited.
 
-        :param reset: Clear any and all test cases currently in the test suite.
+        :param reset: Clear all existing test cases in the test suite.
         """
         editor = self.Editor(self.test_cases, self.description, self.tags, reset)
 


### PR DESCRIPTION
### Linked issue(s):

Suggested change in Marina PR: https://github.com/kolenaIO/marina/pull/2490#discussion_r1332096036

### What change does this PR introduce and why?

Copy update -- remove redundant grammar

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
