### PR TITLE
add stratification based on image size to semantic segmentation example

### DIFF
--- a/examples/semantic_segmentation/semantic_segmentation/constants.py
+++ b/examples/semantic_segmentation/semantic_segmentation/constants.py
@@ -14,3 +14,9 @@
 
 BUCKET = "kolena-public-datasets"
 DATASET = "coco-stuff-10k"
+
+SIZE_MAPPING_IMAGES = {
+    "small": (0, 270000),
+    "medium": (270000, 300000),
+    "large": (300000, 10000000),
+}

--- a/examples/semantic_segmentation/semantic_segmentation/seed_test_run.py
+++ b/examples/semantic_segmentation/semantic_segmentation/seed_test_run.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     )
     ap.add_argument(
         "--test_suites",
-        default=[f"{DATASET} [person]"],
+        default=[f"image size :: {DATASET} [person]"],
         nargs="+",
         help="Name(s) of test suite(s) to test.",
     )

--- a/examples/semantic_segmentation/semantic_segmentation/seed_test_suite.py
+++ b/examples/semantic_segmentation/semantic_segmentation/seed_test_suite.py
@@ -48,7 +48,7 @@ def seed_stratified_test_cases(complete_test_case: TestCase, test_suite_name) ->
 
         if len(samples) > 0:
             test_cases.append(
-                TestCase(f"{size_name} x image :: {test_suite_name}", test_samples=samples, reset=True),
+                TestCase(f"{size_name} image :: {test_suite_name}", test_samples=samples, reset=True),
             )
     return test_cases
 
@@ -77,7 +77,7 @@ def seed_complete_test_case(args: Namespace) -> TestCase:
 
 def main(args: Namespace) -> None:
     kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
-    test_suite_name = f"{DATASET} [person]"
+    test_suite_name = f"image size :: {DATASET} [person]"
     complete_test_case = seed_complete_test_case(args)
     stratified_test_cases = seed_stratified_test_cases(complete_test_case, test_suite_name)
     TestSuite(

--- a/examples/semantic_segmentation/semantic_segmentation/seed_test_suite.py
+++ b/examples/semantic_segmentation/semantic_segmentation/seed_test_suite.py
@@ -15,9 +15,12 @@ import os
 from argparse import ArgumentParser
 from argparse import Namespace
 from ast import literal_eval
+from typing import List
+from typing import Tuple
 
 import pandas as pd
 from semantic_segmentation.constants import DATASET
+from semantic_segmentation.constants import SIZE_MAPPING_IMAGES
 from semantic_segmentation.workflow import GroundTruth
 from semantic_segmentation.workflow import Label
 from semantic_segmentation.workflow import TestCase
@@ -27,6 +30,27 @@ from tqdm import tqdm
 
 import kolena
 from kolena.workflow.annotation import SegmentationMask
+
+
+def within_range(area: int, range: Tuple[int, int]) -> bool:
+    return range[0] <= area < range[1]
+
+
+def seed_stratified_test_cases(complete_test_case: TestCase, test_suite_name) -> List[TestCase]:
+    test_samples = complete_test_case.load_test_samples()
+    test_cases = []
+    for size_name, area_range in SIZE_MAPPING_IMAGES.items():
+        samples = []
+        for ts, gt in test_samples:
+            image_size = ts.metadata["width"] * ts.metadata["height"]
+            if within_range(image_size, area_range):
+                samples.append((ts, gt))
+
+        if len(samples) > 0:
+            test_cases.append(
+                TestCase(f"{size_name} x image :: {test_suite_name}", test_samples=samples, reset=True),
+            )
+    return test_cases
 
 
 def seed_complete_test_case(args: Namespace) -> TestCase:
@@ -40,6 +64,8 @@ def seed_complete_test_case(args: Namespace) -> TestCase:
                 annotation_file=record.annotation_file,
                 captions=literal_eval(record.captions),
                 has_person=record.has_person,
+                width=record.image_width,
+                height=record.image_height,
             ),
         )
         ground_truth = GroundTruth(mask=SegmentationMask(locator=record.mask, labels=Label.as_label_map()))
@@ -51,10 +77,12 @@ def seed_complete_test_case(args: Namespace) -> TestCase:
 
 def main(args: Namespace) -> None:
     kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    test_suite_name = f"{DATASET} [person]"
     complete_test_case = seed_complete_test_case(args)
+    stratified_test_cases = seed_stratified_test_cases(complete_test_case, test_suite_name)
     TestSuite(
-        f"{DATASET} [person]",
-        test_cases=[complete_test_case],
+        test_suite_name,
+        test_cases=[complete_test_case] + stratified_test_cases,
         reset=True,
     )
 

--- a/examples/semantic_segmentation/tests/test_semantic_segmentation.py
+++ b/examples/semantic_segmentation/tests/test_semantic_segmentation.py
@@ -28,6 +28,6 @@ def test__semantic_segmentation_seed_test_run__smoke() -> None:
     args = Namespace(
         out_bucket="kolena-public-datasets",
         model="pspnet_r101-d8_4xb4-40k_coco-stuff10k-512x512",
-        test_suites=["coco-stuff-10k [person]"],
+        test_suites=["image size :: coco-stuff-10k [person]"],
     )
     seed_test_run_main(args)


### PR DESCRIPTION
### Linked issue(s):
Roughly split the images into 3 groups based on size of the image

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
