### PR TITLE
semantic segmentation example: commercial use license + recall fix

### DIFF
--- a/examples/semantic_segmentation/README.md
+++ b/examples/semantic_segmentation/README.md
@@ -1,7 +1,10 @@
 # Example Integration: Semantic Segmentation
 
 This example integration uses the [COCO-Stuff 10K](https://github.com/nightrome/cocostuff10k) dataset, specifically
-5,520 images with person label, to demonstrate how to test single class semantic segmentation problems on Kolena.
+5,520 images with person label, to demonstrate how to test single class semantic segmentation problems on Kolena. Only
+images with the [Attribution License](http://creativecommons.org/licenses/by/2.0/),
+[Attribution-ShareAlike License](http://creativecommons.org/licenses/by-sa/2.0/),
+[Attribution-NoDerivs License](http://creativecommons.org/licenses/by-nd/2.0/) are included.
 
 ## Setup
 

--- a/examples/semantic_segmentation/README.md
+++ b/examples/semantic_segmentation/README.md
@@ -1,7 +1,7 @@
 # Example Integration: Semantic Segmentation
 
 This example integration uses the [COCO-Stuff 10K](https://github.com/nightrome/cocostuff10k) dataset, specifically
-5,520 images with person label, to demonstrate how to test single class semantic segmentation problems on Kolena. Only
+1,789 images with person label, to demonstrate how to test single class semantic segmentation problems on Kolena. Only
 images with the [Attribution License](http://creativecommons.org/licenses/by/2.0/),
 [Attribution-ShareAlike License](http://creativecommons.org/licenses/by-sa/2.0/),
 [Attribution-NoDerivs License](http://creativecommons.org/licenses/by-nd/2.0/) are included.
@@ -26,7 +26,7 @@ This project defines two scripts that perform the following operations:
 
 1. [`seed_test_suite.py`](semantic_segmentation/seed_test_suite.py) creates the following test suites:
 
-    - `"# of people :: coco-stuff-10k [person]"`, containing samples of COCO-Stuff 10K data, specifically 5,520 images
+    - `"# of people :: coco-stuff-10k [person]"`, containing samples of COCO-Stuff 10K data, specifically 1,789 images
     with person label, stratified by # of people in the image.
 
 2. [`seed_test_run.py`](semantic_segmentation/seed_test_run.py) tests a specified model,

--- a/examples/semantic_segmentation/semantic_segmentation/data_loader.py
+++ b/examples/semantic_segmentation/semantic_segmentation/data_loader.py
@@ -52,6 +52,7 @@ class DataLoader:
         def load(ts: TestSample, gt: GroundTruth, inf: Inference) -> Tuple[str, np.ndarray, np.ndarray]:
             inf_prob = download_binary_array(inf.prob.locator)
             gt_mask = download_mask(gt.mask.locator)
+            gt_mask[gt_mask != 1] = 0  # binarize gt_mask
             return ts.locator, gt_mask, inf_prob
 
         futures = [self.pool.submit(functools.partial(load, *item)) for item in batch]

--- a/examples/semantic_segmentation/semantic_segmentation/evaluator.py
+++ b/examples/semantic_segmentation/semantic_segmentation/evaluator.py
@@ -23,10 +23,8 @@ from semantic_segmentation.data_loader import DataLoader
 from semantic_segmentation.data_loader import ResultMasks
 from semantic_segmentation.utils import compute_precision_recall_f1
 from semantic_segmentation.utils import compute_sklearn_arrays
-from semantic_segmentation.utils import upload_image
 from semantic_segmentation.workflow import GroundTruth
 from semantic_segmentation.workflow import Inference
-from semantic_segmentation.workflow import Label
 from semantic_segmentation.workflow import SegmentationConfiguration
 from semantic_segmentation.workflow import TestCase
 from semantic_segmentation.workflow import TestCaseMetric
@@ -38,29 +36,11 @@ from kolena._utils.log import progress_bar
 from kolena.workflow import EvaluationResults
 from kolena.workflow import Plot
 from kolena.workflow import TestCases
-from kolena.workflow.annotation import SegmentationMask
 from kolena.workflow.metrics import f1_score as compute_f1_score
 from kolena.workflow.metrics import precision as compute_precision
 from kolena.workflow.metrics import recall as compute_recall
 from kolena.workflow.plot import Curve
 from kolena.workflow.plot import CurvePlot
-
-
-def _upload_sample_result_masks(
-    test_sample: TestSample,
-    gt_mask: np.ndarray,
-    inf_mask: np.ndarray,
-    locator_prefix: str,
-) -> ResultMasks:
-    def upload_result_mask(category: str, mask: np.ndarray) -> SegmentationMask:
-        locator = f"{locator_prefix}/{category}/{test_sample.metadata['basename']}.png"
-        upload_image(locator, mask)
-        return SegmentationMask(locator=locator, labels=Label.as_label_map())
-
-    tp = upload_result_mask("TP", np.where(gt_mask != inf_mask, 0, inf_mask))
-    fp = upload_result_mask("FP", np.where(gt_mask == inf_mask, 0, inf_mask))
-    fn = upload_result_mask("FN", np.where(gt_mask == inf_mask, 0, gt_mask))
-    return tp, fp, fn
 
 
 def load_data(


### PR DESCRIPTION
### Linked issue(s):
KOL-3505

### What change does this PR introduce and why?
 * Fixed the recall issue
 * Updated the annotations_person.csv file so it only seeds images with the right license.

[Example results](https://trunk.kolena.io/yoohee/results?modelIds=694&testSuiteId=1439&workflow=Semantic+Segmentation&evaluators=N4IgjALAzAnCBcoBsMILAJgAxIL66A)

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
