### PR TITLE
add telemetry flag to request headers

### DIFF
--- a/kolena/_utils/krequests.py
+++ b/kolena/_utils/krequests.py
@@ -65,6 +65,7 @@ def _with_default_kwargs(**kwargs: Any) -> Dict[str, Any]:
         "Authorization": f"Bearer {client_state.jwt_token}",
         "X-Request-ID": uuid.uuid4().hex,
         "User-Agent": user_agent(client_name, client_version),
+        "X-Kolena-Telemetry": str(client_state.telemetry),
     }
     return {
         **default_kwargs,

--- a/tests/unit/test_initialize.py
+++ b/tests/unit/test_initialize.py
@@ -50,8 +50,18 @@ def mock_get_token(api_token: str, *args: Any, **kwargs: Any) -> ValidateRespons
     )
 
 
+def mock_get_token_with_telemetry(api_token: str, *args: Any, **kwargs: Any) -> ValidateResponse:
+    return ValidateResponse(
+        tenant="mock tenant",
+        access_token=mock_jwt(api_token),
+        token_type="mock token type",
+        tenant_telemetry=True,
+    )
+
+
 MOCK_TOKEN = "mock token"
 FIXED_TOKEN_RESPONSE = mock_get_token(MOCK_TOKEN)
+FIXED_TOKEN_RESPONSE_WITH_TELEMETRY = mock_get_token_with_telemetry(MOCK_TOKEN)
 
 
 @pytest.fixture
@@ -67,6 +77,15 @@ def test__initialize__positional(clean_client_state: None) -> None:
         kolena.initialize("bar")
         assert _client_state.api_token == "bar"
         assert _client_state.jwt_token is not None
+        assert not _client_state.telemetry
+
+
+def test__initialize__telemetry(clean_client_state: None) -> None:
+    with patch("kolena._utils.state.get_token", return_value=FIXED_TOKEN_RESPONSE_WITH_TELEMETRY):
+        kolena.initialize("bar")
+        assert _client_state.api_token == "bar"
+        assert _client_state.jwt_token is not None
+        assert _client_state.telemetry
 
 
 def test__initialize__keyword(clean_client_state: None) -> None:


### PR DESCRIPTION
### Linked issue(s):

Fixes: KOL-3526


### What change does this PR introduce and why?

Currently, the telemetry flag is returned during auth and is saved as a Kolena client state. It is however not used for subsequent requests. As we start work on metrics logging, this PR updates the client to send this back in the request header using key`X-Kolena-Telemetry`.


### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated


### Testing
Using local server and added request header logging, with default setting (telemetry off):
```
'x-request-id': 'd761f5e9c472427db6923f57121b07ee', 'x-kolena-telemetry': 'False', 'content-length': '50'
```


Updated DB to enable telemetry:
```
'x-request-id': 'f6b49885163046588e03580c839473a6', 'x-kolena-telemetry': 'True', 'content-length': '50'
```