### PR TITLE
Run black hook before flake8 hook in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,11 @@ repos:
     -   id: insert-license
         files: ^(kolena|tests|examples)/.*\.py$
         args: [--license-filepath, "LICENSE_HEADER"]
+-   repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+        -   id: black
+            args: [--line-length, "120"]
 -   repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:
@@ -39,11 +44,6 @@ repos:
                 - flake8-typing-imports==1.12.0
                 - flake8-quotes==3.3.1
                 - flake8-picky-parentheses==0.4.0
--   repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-        -   id: black
-            args: [--line-length, "120"]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.910
     hooks:


### PR DESCRIPTION
### What change does this PR introduce and why?
Run black before flake8 so flake8 does not report on issues black formatting resolved
#### Before:
```
Insert license in comments...............................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

kolena/initialize.py:30:1: E303 too many blank lines (3)

black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted kolena/initialize.py

All done! ✨ 🍰 ✨
1 file reformatted, 314 files left unchanged.

Check hooks apply to the repository......................................Passed
```

#### After:
```
Insert license in comments...............................................Passed
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted kolena/initialize.py

All done! ✨ 🍰 ✨
1 file reformatted, 314 files left unchanged.

flake8...................................................................Passed
Check hooks apply to the repository......................................Passed
```