### PR TITLE
Remove redundant `poetry install` following `poetry update`

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -130,7 +130,7 @@ With the repository cloned, let's set up the
 
 ```shell
 cd kolena/examples/age_estimation
-poetry update && poetry install
+poetry update
 ```
 
 Now we're up and running and can start [creating test suites](#create-test-suites) and

--- a/examples/age_estimation/README.md
+++ b/examples/age_estimation/README.md
@@ -9,7 +9,7 @@ This project uses [Poetry](https://python-poetry.org/) for packaging and Python 
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+poetry update
 ```
 
 ## Usage

--- a/examples/classification/README.md
+++ b/examples/classification/README.md
@@ -10,7 +10,7 @@ This project uses [Poetry](https://python-poetry.org/) for packaging and Python 
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+poetry update
 ```
 
 ## Usage

--- a/examples/keypoint_detection/README.md
+++ b/examples/keypoint_detection/README.md
@@ -8,7 +8,7 @@ This project uses [Poetry](https://python-poetry.org/) for packaging and Python 
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+poetry update
 ```
 
 ## Usage

--- a/examples/object_detection_2d/README.md
+++ b/examples/object_detection_2d/README.md
@@ -10,7 +10,7 @@ This project uses [Poetry](https://python-poetry.org/) for packaging and Python 
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+poetry update
 ```
 
 ## Usage

--- a/examples/object_detection_3d/README.md
+++ b/examples/object_detection_3d/README.md
@@ -9,7 +9,7 @@ This project uses [Poetry](https://python-poetry.org/) for packaging and Python 
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+poetry update
 ```
 
 ## Usage

--- a/examples/question_answering/README.md
+++ b/examples/question_answering/README.md
@@ -8,7 +8,7 @@ This project uses [Poetry](https://python-poetry.org/) for packaging and Python 
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+poetry update
 ```
 
 ## Usage

--- a/examples/search_embeddings/README.md
+++ b/examples/search_embeddings/README.md
@@ -15,7 +15,7 @@ data has already been uploaded to your Kolena platform.
 dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+poetry update
 ```
 
 4. [Recommended] Download test images to a local path for faster embeddings extraction:

--- a/examples/semantic_segmentation/README.md
+++ b/examples/semantic_segmentation/README.md
@@ -12,7 +12,7 @@ This project uses [Poetry](https://python-poetry.org/) for packaging and Python 
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+poetry update
 ```
 
 ## Usage

--- a/examples/semantic_textual_similarity/README.md
+++ b/examples/semantic_textual_similarity/README.md
@@ -9,7 +9,7 @@ This project uses [Poetry](https://python-poetry.org/) for packaging and Python 
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+poetry update
 ```
 
 ## Usage

--- a/examples/text_summarization/README.md
+++ b/examples/text_summarization/README.md
@@ -11,7 +11,7 @@ This project uses [Poetry](https://python-poetry.org/) for packaging and Python 
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+poetry update
 ```
 
 ## Usage


### PR DESCRIPTION
### What change does this PR introduce and why?
Shortens `poetry update && poetry install` commands found throughout documentation to `poetry update`.
`poetry update` already runs an install.

Refs:
- https://python-poetry.org/docs/cli/#update
- https://python-poetry.org/docs/basic-usage/#updating-dependencies-to-their-latest-versions