### PR TITLE
Cast DataPoint column labels to str before serialization

### DIFF
--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -90,6 +90,9 @@ def _infer_datatype(df: pd.DataFrame) -> Union[pd.DataFrame, str]:
 
 
 def _to_serialized_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    # Pandas defaults to int column labels if none provided. Cast to sort with added str labels
+    df.rename(mapper=str, axis="columns", copy=False, inplace=True)
+
     object_columns = list(df.select_dtypes(include="object").columns)
     result = df.select_dtypes(exclude="object")
     result[object_columns] = df[object_columns].applymap(_serialize_dataobject)

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -173,6 +173,16 @@ def test__datapoint_dataframe__serde_text() -> None:
     assert_frame_equal(df_deserialized[df_expected.columns], df_expected)
 
 
+def test__datapoint_dataframe__columns_unlabeled() -> None:
+    df_expected = pd.DataFrame([["a", "b", "c"], ["d", "e", "f"]])
+    df_serialized = _to_serialized_dataframe(df_expected.copy())
+    df_deserialized = _to_deserialized_dataframe(df_serialized)
+
+    # Column class mismatch is expected due to json serialization
+    df_expected.rename(mapper=str, axis="columns", inplace=True)
+    assert_frame_equal(df_deserialized, df_expected)
+
+
 def test__datapoint_dataframe__empty() -> None:
     df_serialized = _to_serialized_dataframe(pd.DataFrame())
     assert df_serialized.empty


### PR DESCRIPTION
### Linked issue(s):
Fixes KOL-3544

### What change does this PR introduce and why?
Casts DataPoint column labels to str in order to catch potential type errors during serialization. Pandas defaults to RangeIndex(0,...,n) when column labels are not provided resulting in the aforementioned type error when sorting keys.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added