### PR TITLE
Move initialize `api_token` from positional to keyword argument

### DIFF
--- a/docs/advanced-usage/packaging-for-automated-evaluation.md
+++ b/docs/advanced-usage/packaging-for-automated-evaluation.md
@@ -73,7 +73,7 @@ from .workflow import Model, TestSuite
 
 
 def main() -> None:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     model = Model(os.environ["KOLENA_MODEL_NAME"])
     test_suite = TestSuite.load(

--- a/docs/building-a-workflow.md
+++ b/docs/building-a-workflow.md
@@ -20,7 +20,7 @@ first let's initialize a client session:
 import os
 import kolena
 
-kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 ```
 
 The data used in this tutorial is publicly available in the `kolena-public-datasets` S3 bucket in a `metadata.csv` file:

--- a/docs/installing-kolena.md
+++ b/docs/installing-kolena.md
@@ -61,7 +61,7 @@ Certain metrics computation functionality depends on additional packages like
 
 ## Initialization
 
-Once you have `kolena` installed, initialize a session with `kolena.initialize(token)`.
+Once you have `kolena` installed, initialize a session with `kolena.initialize(api_token=token)`.
 
 From the [:kolena-developer-16: Developer](https://app.kolena.io/redirect/developer) page, generate an API token and set
 the `KOLENA_TOKEN` environment variable:
@@ -76,7 +76,7 @@ With the `KOLENA_TOKEN` environment variable set, initialize a client session:
 import os
 import kolena
 
-kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 ```
 
 By default, sessions have static scope and persist until the interpreter is exited.

--- a/examples/age_estimation/age_estimation/seed_test_run.py
+++ b/examples/age_estimation/age_estimation/seed_test_run.py
@@ -49,7 +49,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
     seed_test_run(args.model, args.test_suites)
     return 0
 

--- a/examples/age_estimation/age_estimation/seed_test_suite.py
+++ b/examples/age_estimation/age_estimation/seed_test_suite.py
@@ -29,7 +29,7 @@ DATASET = "labeled-faces-in-the-wild"
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     df_metadata = pd.read_csv(args.dataset_csv)
 

--- a/examples/classification/scripts/binary/seed_test_run.py
+++ b/examples/classification/scripts/binary/seed_test_run.py
@@ -76,7 +76,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str], multiclass: bool
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
     for model_name in args.models:
         seed_test_run(model_name, args.test_suites, args.multiclass)
     return 0

--- a/examples/classification/scripts/binary/seed_test_suite.py
+++ b/examples/classification/scripts/binary/seed_test_suite.py
@@ -32,7 +32,7 @@ POSITIVE_LABEL = "dog"
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     df_metadata = pd.read_csv(args.dataset_csv)
 

--- a/examples/classification/scripts/multiclass/seed_test_run.py
+++ b/examples/classification/scripts/multiclass/seed_test_run.py
@@ -59,7 +59,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
     for model_name in args.models:
         seed_test_run(model_name, args.test_suites)
     return 0

--- a/examples/classification/scripts/multiclass/seed_test_suite.py
+++ b/examples/classification/scripts/multiclass/seed_test_suite.py
@@ -31,7 +31,7 @@ DATASET = "cifar10/test"
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     df_metadata = pd.read_csv(args.dataset_csv)
 

--- a/examples/keypoint_detection/keypoint_detection/seed_test_run.py
+++ b/examples/keypoint_detection/keypoint_detection/seed_test_run.py
@@ -56,7 +56,7 @@ def main() -> None:
     ap = ArgumentParser()
     ap.add_argument("model_name", type=str, help="Name of model to test.")
     ap.add_argument("test_suite", type=str, default="none", help="Name of the test suite to run.")
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     run(ap.parse_args())
 

--- a/examples/keypoint_detection/keypoint_detection/seed_test_suite.py
+++ b/examples/keypoint_detection/keypoint_detection/seed_test_suite.py
@@ -50,7 +50,7 @@ def main() -> None:
     ap = ArgumentParser()
     ap.add_argument("test_suite", type=str, help="Name of the test suite to make.")
 
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     run(ap.parse_args())
 

--- a/examples/object_detection_2d/object_detection_2d/extended/seed_test_run.py
+++ b/examples/object_detection_2d/object_detection_2d/extended/seed_test_run.py
@@ -51,7 +51,7 @@ def main(args: Namespace) -> None:
     model_full_name = MODEL_LIST[model_alias]
 
     # run evaluation on test suites
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     metadata_by_image = load_results(model_alias)
 

--- a/examples/object_detection_2d/object_detection_2d/extended/seed_test_suite.py
+++ b/examples/object_detection_2d/object_detection_2d/extended/seed_test_suite.py
@@ -174,7 +174,7 @@ def seed_test_suite_by_bounding_box_size(test_suite_name: str, complete_test_cas
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     complete_test_case = create_complete_transportation_case(args)
 

--- a/examples/object_detection_2d/object_detection_2d/seed_test_run.py
+++ b/examples/object_detection_2d/object_detection_2d/seed_test_run.py
@@ -150,7 +150,7 @@ def main(args: Namespace) -> None:
     model_full_name = MODEL_LIST[model_alias]
 
     # run evaluation on test suites
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     metadata_by_image = load_results(model_alias)
 

--- a/examples/object_detection_2d/object_detection_2d/seed_test_suite.py
+++ b/examples/object_detection_2d/object_detection_2d/seed_test_suite.py
@@ -174,7 +174,7 @@ def seed_test_suite_by_bounding_box_size(test_suite_name: str, complete_test_cas
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     complete_test_case = create_complete_transportation_case(args)
 

--- a/examples/object_detection_3d/object_detection_3d/seed_test_run.py
+++ b/examples/object_detection_3d/object_detection_3d/seed_test_run.py
@@ -68,7 +68,7 @@ def load_results(path: str) -> Dict[str, Any]:
 
 
 def seed_test_run(test_suite_name: str, model_name: str, results: List[Dict[str, Any]]) -> None:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     inference_by_id = {result["label_id"]: result for result in results}
 

--- a/examples/object_detection_3d/object_detection_3d/seed_test_suite.py
+++ b/examples/object_detection_3d/object_detection_3d/seed_test_suite.py
@@ -40,7 +40,7 @@ def parse_args():
 
 
 def seed_test_suite(test_suite_name: str, test_samples: List[Tuple[TestSample, GroundTruth]]):
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     test_cases = TestCase.init_many([(test_suite_name, test_samples)], reset=True)
     test_suite = TestSuite(test_suite_name, test_cases=test_cases, reset=True)

--- a/examples/question_answering/question_answering/seed_test_run.py
+++ b/examples/question_answering/question_answering/seed_test_run.py
@@ -33,7 +33,7 @@ MODELS = ["gpt-3.5-turbo-0301", "gpt-3.5-turbo", "gpt-4-0314", "gpt-4"]
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     inference_mapping = {}
     model_file_path = f"s3://kolena-public-datasets/CoQA/results/{args.model}.csv"

--- a/examples/question_answering/question_answering/seed_test_suite.py
+++ b/examples/question_answering/question_answering/seed_test_suite.py
@@ -91,7 +91,7 @@ def create_test_suite_by_conversation_length(dataset: TestCase, data: List[Tuple
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     df_metadata = pd.read_csv(args.dataset_csv)
     context_dict = defaultdict(list)

--- a/examples/semantic_segmentation/semantic_segmentation/seed_test_run.py
+++ b/examples/semantic_segmentation/semantic_segmentation/seed_test_run.py
@@ -67,7 +67,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str], out_bucket: str)
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
     os.environ["KOLENA_MODEL_NAME"] = str(args.model)
     os.environ["KOLENA_OUT_BUCKET"] = str(args.out_bucket)
     seed_test_run(args.model, args.test_suites, args.out_bucket)

--- a/examples/semantic_segmentation/semantic_segmentation/seed_test_suite.py
+++ b/examples/semantic_segmentation/semantic_segmentation/seed_test_suite.py
@@ -77,7 +77,7 @@ def seed_complete_test_case(args: Namespace) -> TestCase:
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
     test_suite_name = f"# of people :: {DATASET} [person]"
     complete_test_case = seed_complete_test_case(args)
     stratified_test_cases = seed_stratified_test_cases(complete_test_case, test_suite_name)

--- a/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_run.py
+++ b/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_run.py
@@ -60,7 +60,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
     for model_name in args.models:
         seed_test_run(model_name, args.test_suites)
     return 0

--- a/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_suite.py
+++ b/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_suite.py
@@ -57,7 +57,7 @@ def seed_complete_test_case(args: Namespace) -> TestCase:
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
     complete_test_case = seed_complete_test_case(args)
     test_suite = TestSuite(
         f"{DATASET}",

--- a/examples/text_summarization/text_summarization/remote_evaluator.py
+++ b/examples/text_summarization/text_summarization/remote_evaluator.py
@@ -27,7 +27,7 @@ test_suite_version = os.environ["KOLENA_TEST_SUITE_VERSION"]
 env_token = "KOLENA_TOKEN"
 
 print(f"initializing with environment variables ${env_token}")
-kolena.initialize(os.environ[env_token], verbose=True)
+kolena.initialize(api_token=os.environ[env_token], verbose=True)
 
 model = Model(model_name)
 print(f"using model: {model}")

--- a/examples/text_summarization/text_summarization/seed_test_run.py
+++ b/examples/text_summarization/text_summarization/seed_test_run.py
@@ -139,7 +139,7 @@ def seed_test_run(
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
 
     mod = MODEL_MAP[args.model]
     print("loading inference CSV")

--- a/examples/text_summarization/text_summarization/seed_test_suite.py
+++ b/examples/text_summarization/text_summarization/seed_test_suite.py
@@ -192,7 +192,7 @@ def seed_test_suites(
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
     complete_tc = seed_complete_test_case(args)
 
     test_suite_names: Dict[str, Callable[[str, TestCase], TestSuite]] = {

--- a/kolena/_utils/cli.py
+++ b/kolena/_utils/cli.py
@@ -114,7 +114,7 @@ def evaluator_register(
     aws_assume_role: Optional[str] = None,
     api_token: Optional[str] = None,
 ) -> None:
-    kolena.initialize(api_token)
+    kolena.initialize(api_token=api_token)
     evaluator = kolena.workflow.workflow.register_evaluator(workflow, evaluator_name, image, secret, aws_assume_role)
     print(f"Image {image} successfully registered for workflow {workflow} evaluator {evaluator_name}.")
     print(json.dumps(dataclasses.asdict(evaluator), indent=2))
@@ -124,7 +124,7 @@ def evaluator_register(
 @add_options(_shared_options)
 @add_options(_shared_evaluator_options)
 def evaluator_list(workflow: str, api_token: Optional[str] = None) -> None:
-    kolena.initialize(api_token)
+    kolena.initialize(api_token=api_token)
     evaluators = kolena.workflow.workflow.list_evaluators(workflow)
     for evaluator in evaluators:
         print(f"evaluator_name='{evaluator.name}', image='{evaluator.image}', created='{evaluator.created}'")
@@ -146,7 +146,7 @@ def evaluator_list(workflow: str, api_token: Optional[str] = None) -> None:
     default=False,
 )
 def evaluator_get(workflow: str, evaluator_name: str, include_secret: bool, api_token: Optional[str] = None) -> None:
-    kolena.initialize(api_token)
+    kolena.initialize(api_token=api_token)
     try:
         evaluator = kolena.workflow.workflow.get_evaluator(workflow, evaluator_name, include_secret)
     except NotFoundError:
@@ -166,7 +166,7 @@ def evaluator_get(workflow: str, evaluator_name: str, include_secret: bool, api_
     help="repository name",
 )
 def repository_create(name: str, api_token: Optional[str] = None) -> None:
-    kolena.initialize(api_token)
+    kolena.initialize(api_token=api_token)
     try:
         repository.create(name)
     except Exception as e:

--- a/kolena/initialize.py
+++ b/kolena/initialize.py
@@ -32,8 +32,8 @@ from kolena.errors import MissingTokenError
 
 
 def initialize(
-    api_token: Optional[str] = None,
     *args: Any,
+    api_token: Optional[str] = None,
     verbose: bool = False,
     proxies: Optional[Dict[str, str]] = None,
     **kwargs: Any,
@@ -47,12 +47,12 @@ def initialize(
     make it available through one of the following options before initializing:
 
 
-    1. Directly through the optional `api_token` argument
+    1. Directly through the `api_token` keyword argument
     ```python
     import os
     import kolena
 
-    kolena.initialize(os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
     ```
     2. Populate the `KOLENA_TOKEN` environment variable
     ```bash
@@ -96,26 +96,28 @@ def initialize(
     :raises InputValidationError: The provided combination or number of args is not valid.
     :raises MissingTokenError: An API token could not be found.
     """
-    used_deprecated_signature = False
+    used_deprecated_signature = "entity" in kwargs
 
-    if len(args) > 1:
+    if len(args) > 2:
         raise InputValidationError(
-            f"Too many args. Expected 0 or 1 but got {len(args)} Check docs for usage.",
-        )
-    elif len(args) == 1:
-        # overwrite the originally passed api_token since we are supporting backward compatability with entity
-        api_token = args[0]
-    if len(args) == 1 or "entity" in kwargs:
-        used_deprecated_signature = True
-        warnings.warn(
-            "The signature initialize(entity, token) is deprecated. Please update to initialize(token).",
-            category=DeprecationWarning,
-            stacklevel=2,
+            f"Too many args. Expected 0..2 but got {len(args)} Check docs for usage.",
         )
 
     if not api_token:
-        # Attempt fallback options for retrieving api token
-        api_token = _find_token()
+        if len(args) == 1:
+            api_token = args[0]
+        elif len(args) == 2:
+            api_token = args[1]
+            used_deprecated_signature = True
+        else:
+            api_token = _find_token()
+
+    if used_deprecated_signature:
+        warnings.warn(
+            "The signature initialize(entity, token) is deprecated.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
 
     init_response = state.get_token(api_token, proxies=proxies)
     derived_telemetry = init_response.tenant_telemetry

--- a/tests/integration/test_initialize.py
+++ b/tests/integration/test_initialize.py
@@ -22,7 +22,7 @@ from kolena.errors import InvalidTokenError
 from kolena.errors import RemoteError
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def clean_client_state() -> Iterator[None]:
     try:
         yield
@@ -30,13 +30,13 @@ def clean_client_state() -> Iterator[None]:
         _client_state.reset()
 
 
-def test__initialize(clean_client_state: None, kolena_token: str) -> None:
-    kolena.initialize(kolena_token)
+def test__initialize(kolena_token: str) -> None:
+    kolena.initialize(api_token=kolena_token)
     assert _client_state.api_token == kolena_token
     assert _client_state.jwt_token is not None
 
 
-def test__initialize__deprecated_old_client(clean_client_state: None, kolena_token: str) -> None:
+def test__initialize__deprecated_old_client(kolena_token: str) -> None:
     """Manually test acceptance of 'entity' with raw request for client versions prior to 0.29.0"""
     url = _client_state.base_url + "/v1/token/login"
     payload = {"entity": "ignored", "version": "0.28.0", "api_token": kolena_token}
@@ -46,16 +46,16 @@ def test__initialize__deprecated_old_client(clean_client_state: None, kolena_tok
     assert resp.json()["access_token"] is not None
 
 
-def test__initialize__invalid_version(clean_client_state: None, kolena_token: str) -> None:
+def test__initialize__invalid_version(kolena_token: str) -> None:
     version = kolena.__version__
     try:
         kolena.__version__ = "0.0.0"
         with pytest.raises(RemoteError):
-            kolena.initialize(kolena_token)
+            kolena.initialize(api_token=kolena_token)
     finally:
         kolena.__version__ = version
 
 
-def test__initialize__bad_token(clean_client_state: None) -> None:
+def test__initialize__bad_token() -> None:
     with pytest.raises(InvalidTokenError):
-        kolena.initialize("bad_token")
+        kolena.initialize(api_token="bad_token")

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -23,8 +23,8 @@ from kolena._utils.cli import base_command
 TEST_API_TOKEN = "XXXX"
 
 
-def mock_initialize(tok: str):
-    if tok != TEST_API_TOKEN:
+def mock_initialize(api_token: str):
+    if api_token != TEST_API_TOKEN:
         raise RuntimeError("bad token")
 
 


### PR DESCRIPTION
Context from prior PR https://github.com/kolenaIO/kolena/pull/256#discussion_r1357095496

### What change does this PR introduce and why?
Updates `kolena.initialize()` to prefer `api_token` as a keyword argument while maintaining backwards compatibility.

### Please check if the PR fulfills these requirements
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated