### PR TITLE
Preserve dataframe column order for relevant client operations

### DIFF
--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import dataclasses
-import json
 from abc import ABCMeta
 from abc import abstractmethod
 from collections import OrderedDict
@@ -257,54 +256,6 @@ def _deserialize_dataobject(x: Any) -> Any:
             return typed_dataobject._from_dict(data)
 
     return x
-
-
-_serialize_series = np.vectorize(_serialize_dataobject)
-_deserialize_series = np.vectorize(_deserialize_dataobject)
-
-
-def _serialize_json(x: Any) -> Any:
-    if isinstance(x, list) or isinstance(x, dict):
-        return json.dumps(x)
-
-    return x
-
-
-def _deserialize_json(x: Any) -> Any:
-    if isinstance(x, str):
-        try:
-            return json.loads(x)
-        except Exception:
-            ...
-
-    return x
-
-
-def dataframe_to_csv(df: pd.DataFrame, *args, **kwargs) -> Union[str, None]:
-    columns = list(df.select_dtypes(include="object").columns)
-    df_post = df.select_dtypes(exclude="object")
-    df_post[columns] = df[columns].apply(_serialize_series)
-    df_post[columns] = df_post[columns].apply(np.vectorize(_serialize_json))
-    return df_post.to_csv(*args, **kwargs)
-
-
-def dataframe_from_csv(*args, **kwargs) -> pd.DataFrame:
-    df = pd.read_csv(*args, **kwargs)
-    columns = list(df.select_dtypes(include="object").columns)
-    df_post = df.select_dtypes(exclude="object")
-    df_post[columns] = df[columns].apply(np.vectorize(_deserialize_json))
-    df_post[columns] = df_post[columns].apply(_deserialize_series)
-
-    return df_post
-
-
-def dataframe_from_json(*args, **kwargs) -> pd.DataFrame:
-    df = pd.read_json(*args, **kwargs)
-    columns = list(df.select_dtypes(include="object").columns)
-    df_post = df.select_dtypes(exclude="object")
-    df_post[columns] = df[columns].apply(_deserialize_series)
-
-    return df_post
 
 
 class DataType(str, Enum):

--- a/tests/unit/workflow/test_io.py
+++ b/tests/unit/workflow/test_io.py
@@ -25,12 +25,12 @@ from kolena.workflow.io import dataframe_to_csv
 NAN = float("nan")
 DF_TEST = pd.DataFrame.from_dict(
     {
-        "id": list(range(10)),
         "z": [dict(value=i + 0.3) for i in range(10)],
         "partial": [None, ""] + ["fan"] * 8,
         "data": [
             LabeledBoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)
         ],
+        "id": list(range(10)),
         "bad actor": [
             "{",
             dict(value="box"),
@@ -52,10 +52,10 @@ def test__dataframe_json() -> None:
 
     df_expected = pd.DataFrame.from_dict(
         {
-            "id": list(range(10)),
             "z": [dict(value=i + 0.3) for i in range(10)],
             "partial": [None, ""] + ["fan"] * 8,
             "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
+            "id": list(range(10)),
             "bad actor": [
                 "{",
                 dict(value="box"),
@@ -79,10 +79,10 @@ def test__dataframe_csv() -> None:
 
     df_expected = pd.DataFrame.from_dict(
         {
-            "id": list(range(10)),
             "z": [dict(value=i + 0.3) for i in range(10)],
             "partial": [NAN, NAN] + ["fan"] * 8,
             "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
+            "id": list(range(10)),
             "bad actor": [
                 "{",
                 dict(value="box"),


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?

Preserve dataframe column order for relevant operations that client sdk perform for users. The one piece where order cannot be preserved is when snowflake is involved. Admittedly this impacts most of the meaningful operations in client sdk, however I think it still has value to maintain order as much as we can.

Also introduced some small refactor to reduce serde boilerplates.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
