### PR TITLE
Disallow empty configurations when using configured evaluator function

### DIFF
--- a/kolena/workflow/test_run.py
+++ b/kolena/workflow/test_run.py
@@ -106,6 +106,11 @@ class TestRun(Frozen, WithTelemetry, metaclass=ABCMeta):
         if configurations is None:
             configurations = []
 
+        is_evaluator_class = isinstance(evaluator, Evaluator)
+        is_evaluator_function = evaluator is not None and not is_evaluator_class
+        if is_evaluator_function and _is_configured(evaluator) and len(configurations) == 0:
+            raise ValueError("evaluator requires configuration but no configurations provided")
+
         if model.workflow != test_suite.workflow:
             raise WorkflowMismatchError(
                 f"model workflow ({model.workflow}) does not match test suite workflow ({test_suite.workflow})",
@@ -119,15 +124,11 @@ class TestRun(Frozen, WithTelemetry, metaclass=ABCMeta):
         self.model = model
         self.test_suite = test_suite
         self.evaluator = evaluator
-        self.configurations = self.evaluator.configurations if isinstance(evaluator, Evaluator) else configurations
+        self.configurations = self.evaluator.configurations if is_evaluator_class else configurations
         self.reset = reset
 
         evaluator_display_name = (
-            None
-            if evaluator is None
-            else evaluator.display_name()
-            if isinstance(evaluator, Evaluator)
-            else evaluator.__name__
+            None if evaluator is None else evaluator.display_name() if is_evaluator_class else evaluator.__name__
         )
         api_configurations = (
             [_maybe_evaluator_configuration_to_api(config) for config in self.configurations]

--- a/tests/integration/workflow/test_test_run.py
+++ b/tests/integration/workflow/test_test_run.py
@@ -94,6 +94,14 @@ def test__init(
     assert test_run0._id != test_run5._id
 
 
+def test__init__missing_configuration(dummy_model: Model, dummy_test_suites: List[TestSuite]) -> None:
+    with pytest.raises(ValueError):
+        test(dummy_model, dummy_test_suites[0], dummy_evaluator_function_with_config)
+
+    with pytest.raises(ValueError):
+        test(dummy_model, dummy_test_suites[0], dummy_evaluator_function_with_config, configurations=[])
+
+
 def test__load_test_samples(
     dummy_model: Model,
     dummy_test_suites: List[TestSuite],


### PR DESCRIPTION
Previously, if using a configured evaluator function (i.e. function accepting a fifth `configuration` parameter), unless at least one config was provided to `test`, the test run would conclude without actually computing or uploading metrics. This PR updates TestRun init to eagerly fail with a useful error message in this scenario.

Fixes KOL-3571