### PR TITLE
Update mkdocs social plugin cache dir to avoid conflicts

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -95,11 +95,11 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          name: Restore poetry cache
+          name: Restore Poetry cache
           key: ci-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
       - restore_cache:
-          name: Restore mkdoc cache
-          key: mkdoc-cache
+          name: Restore MkDocs cache
+          key: mkdocs-cache
       - run:
           name: Install system-level dependencies
           command: |
@@ -119,9 +119,9 @@ jobs:
             ./docs/setup_insiders.sh
             poetry run mkdocs build --config-file mkdocs.insiders.yml
       - save_cache:
-          key: mkdoc-cache
+          key: mkdocs-cache
           paths:
-            - .config
+            - .cache
 
   unit-test:
     parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -95,7 +95,11 @@ jobs:
     steps:
       - checkout
       - restore_cache:
+          name: Restore poetry cache
           key: ci-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
+      - restore_cache:
+          name: Restore mkdoc cache
+          key: mkdoc-cache
       - run:
           name: Install system-level dependencies
           command: |
@@ -114,6 +118,10 @@ jobs:
           command: |
             ./docs/setup_insiders.sh
             poetry run mkdocs build --config-file mkdocs.insiders.yml
+      - save_cache:
+          key: mkdoc-cache
+          paths:
+            - .config
 
   unit-test:
     parameters:

--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -49,6 +49,7 @@ extra:
 
 plugins:
   social:
+    cache_dir: .cache/plugin/social/insiders
     cards_layout: custom
     cards_layout_dir: docs/layouts
   typeset:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,6 +176,7 @@ extra_javascript:
 
 plugins:
   social: # render social media cards for copy+paste
+    cache_dir: .cache/plugin/social/free
   search:
     lang: en
   git-revision-date-localized:


### PR DESCRIPTION
### Linked issue(s):
Fixes KOL-3572

### What change does this PR introduce and why?
- Updates mkdocs social plugin config to use a seperate cache directory for seperate instances of the plugin (free and insiders). This is recommended by the MkDocs maintainer.
- Cache mkdocs resources in circleci to speed up runs and remove the need to download dependencies (eg. fonts).
https://squidfunk.github.io/mkdocs-material/plugins/requirements/caching/

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)