### PR TITLE
Keep column order with persisted data

### DIFF
--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -145,7 +145,7 @@ class DataObject(metaclass=ABCMeta):
             for key, val in vars(self).items():
                 if key not in field_set and not _double_under(key):
                     items.append((key, val))
-        items.append((FIELD_ORDER_FIELD, field_names))
+        items.append((FIELD_ORDER_FIELD, [key for key, _ in items]))
         return OrderedDict([(key, serialize_value(value)) for key, value in items])
 
     @classmethod

--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -229,9 +229,10 @@ class DataObject(metaclass=ABCMeta):
         items = {f.name: deserialize_field(f, obj_dict.get(f.name, None)) for f in dataclasses.fields(cls) if f.init}
         field_names = {f.name for f in dataclasses.fields(cls)}.union(RESERVED_FIELDS)
         if _allow_extra(cls):
-            for key, val in obj_dict.items():
+            keys = obj_dict[FIELD_ORDER_FIELD] if FIELD_ORDER_FIELD in obj_dict else obj_dict.keys()
+            for key in keys:
                 if key not in field_names:
-                    items[key] = _try_deserialize_typed_dataobject(val)
+                    items[key] = _try_deserialize_typed_dataobject(obj_dict[key])
         return cls(**items)
 
     # integrate with pandas json deserialization

--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -140,9 +140,10 @@ class DataObject(metaclass=ABCMeta):
 
         items = [(field.name, getattr(self, field.name)) for field in dataclasses.fields(type(self))]
         field_names = [field.name for field in dataclasses.fields(type(self))]
+        field_set = set(field_names)
         if _allow_extra(type(self)):
             for key, val in vars(self).items():
-                if key not in field_names and not _double_under(key):
+                if key not in field_set and not _double_under(key):
                     items.append((key, val))
         items.append((FIELD_ORDER_FIELD, field_names))
         return OrderedDict([(key, serialize_value(value)) for key, value in items])

--- a/kolena/workflow/io.py
+++ b/kolena/workflow/io.py
@@ -16,6 +16,7 @@ from typing import Any
 from typing import Callable
 from typing import Union
 
+import numpy as np
 import pandas as pd
 
 from kolena.workflow import DataObject
@@ -108,7 +109,7 @@ def _dataframe_object_serde(df, serde_fn: Callable[[Any], Any]):
     df_post = pd.DataFrame(columns=columns)
     for column in columns:
         if df.dtypes[column] == "object":
-            df_post[column] = df[column].apply(serde_fn)
+            df_post[column] = df[column].apply(serde_fn).replace(np.nan, None)
         else:
             df_post[column] = df[column]
     return df_post

--- a/kolena/workflow/io.py
+++ b/kolena/workflow/io.py
@@ -16,7 +16,6 @@ from typing import Any
 from typing import Callable
 from typing import Union
 
-import numpy as np
 import pandas as pd
 
 from kolena.workflow import DataObject
@@ -109,7 +108,7 @@ def _dataframe_object_serde(df, serde_fn: Callable[[Any], Any]):
     df_post = pd.DataFrame(columns=columns)
     for column in columns:
         if df.dtypes[column] == "object":
-            df_post[column] = df[column].apply(serde_fn).replace(np.nan, None)
+            df_post[column] = df[column].apply(serde_fn)
         else:
             df_post[column] = df[column]
     return df_post

--- a/kolena/workflow/test_sample.py
+++ b/kolena/workflow/test_sample.py
@@ -50,6 +50,7 @@ from pydantic.dataclasses import dataclass
 from kolena._utils.validators import ValidatorConfig
 from kolena.workflow._datatypes import _register_data_type
 from kolena.workflow._datatypes import DataType
+from kolena.workflow._datatypes import FIELD_ORDER_FIELD
 from kolena.workflow._datatypes import TypedDataObject
 from kolena.workflow._validators import get_data_object_field_types
 from kolena.workflow._validators import safe_issubclass
@@ -149,6 +150,11 @@ class TestSample(TypedDataObject[_TestSampleType], metaclass=ABCMeta):
     def _to_dict(self) -> Dict[str, Any]:
         base_dict = super()._to_dict()
         base_dict.pop(_METADATA_KEY, None)
+        if FIELD_ORDER_FIELD in base_dict:
+            try:
+                base_dict[FIELD_ORDER_FIELD].remove(_METADATA_KEY)
+            except ValueError:
+                ...
         return base_dict
 
     def _to_metadata_dict(self) -> Metadata:

--- a/tests/integration/_experimental/dataset/test_dataset.py
+++ b/tests/integration/_experimental/dataset/test_dataset.py
@@ -61,20 +61,19 @@ def test__register_dataset() -> None:
         )
         for dp in datapoints
     ]
-    columns = ["locator", "width", "height", "city", "bboxes"]
 
-    register_dataset(name, pd.DataFrame(datapoints[:10], columns=columns))
+    register_dataset(name, pd.DataFrame(datapoints[:10]))
 
-    loaded_datapoints = fetch_dataset(name).sort_values("width", ignore_index=True).reindex(columns=columns)
-    expected = pd.DataFrame(expected_datapoints[:10], columns=columns)
+    loaded_datapoints = fetch_dataset(name).sort_values("width", ignore_index=True)
+    expected = pd.DataFrame(expected_datapoints[:10])
     assert_frame_equal(loaded_datapoints, expected)
 
     # update dataset
-    datapoints_updated = pd.DataFrame(datapoints[:5] + datapoints[7:15], columns=columns)
+    datapoints_updated = pd.DataFrame(datapoints[:5] + datapoints[7:15])
     register_dataset(name, datapoints_updated)
 
-    loaded_datapoints = fetch_dataset(name).sort_values("width", ignore_index=True).reindex(columns=columns)
-    expected = pd.DataFrame(expected_datapoints[:5] + expected_datapoints[7:15], columns=columns)
+    loaded_datapoints = fetch_dataset(name).sort_values("width", ignore_index=True)
+    expected = pd.DataFrame(expected_datapoints[:5] + expected_datapoints[7:15])
     assert_frame_equal(loaded_datapoints, expected)
 
 

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -169,13 +169,15 @@ def test__datapoint_dataframe__serde_locator() -> None:
                 locator=dp["locator"],
                 width=dp["width"],
                 height=dp.get("height", math.nan),
-                category=dp.get("category", None),
+                category=dp.get("category", math.nan),
                 bboxes=[
                     BoundingBox(label=bbox.label, top_left=bbox.top_left, bottom_right=bbox.bottom_right)
                     for bbox in dp["bboxes"]
                 ],
-                label=ClassificationLabel(label=dp["label"].label, score=dp["label"].score) if "label" in dp else None,
-                x=dp.get("x", None),
+                label=ClassificationLabel(label=dp["label"].label, score=dp["label"].score)
+                if "label" in dp
+                else math.nan,
+                x=dp.get("x", math.nan),
             )
             for dp in datapoints_v1 + datapoints_v2
         ],

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -152,7 +152,7 @@ def test__datapoint_dataframe__serde_locator() -> None:
                     bboxes=[bbox._to_dict() for bbox in dp["bboxes"]],
                     x=dp["x"],
                     width=dp["width"],
-                    data_type=TestSampleType.IMAGE,
+                    data_type=DatapointType.IMAGE,
                     _field_order=["locator", "bboxes", "x", "width"],
                 )
                 for dp in datapoints_v2

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -115,6 +115,7 @@ def test__datapoint_dataframe__serde_locator() -> None:
                     bboxes=[bbox._to_dict() for bbox in dp["bboxes"]],
                     label=dp["label"]._to_dict(),
                     data_type=DatapointType.IMAGE,
+                    _field_order=["locator", "width", "height", "category", "bboxes", "label"],
                 )
                 for dp in datapoints
             ],
@@ -157,7 +158,13 @@ def test__datapoint_dataframe__serde_text() -> None:
     df_expected = pd.DataFrame(
         dict(
             datapoint=[
-                dict(text=dp["text"], value=dp["value"], category=dp["category"], data_type=DatapointType.TEXT)
+                dict(
+                    text=dp["text"],
+                    value=dp["value"],
+                    category=dp["category"],
+                    data_type=DatapointType.TEXT,
+                    _field_order=["text", "value", "category"],
+                )
                 for dp in datapoints
             ],
         ),

--- a/tests/unit/workflow/test_annotation.py
+++ b/tests/unit/workflow/test_annotation.py
@@ -25,6 +25,7 @@ import pytest
 
 from kolena.workflow._datatypes import DATA_TYPE_FIELD
 from kolena.workflow._datatypes import DataObject
+from kolena.workflow._datatypes import FIELD_ORDER_FIELD
 from kolena.workflow.annotation import _AnnotationType
 from kolena.workflow.annotation import BitmapMask
 from kolena.workflow.annotation import BoundingBox
@@ -45,6 +46,7 @@ def test__serde__simple() -> None:
         "label": "test",
         "points": [[1, 1], [2, 2], [3, 3]],
         DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.POLYGON.value}",
+        FIELD_ORDER_FIELD: ["points", "label"],
     }
     assert LabeledPolygon._from_dict(obj_dict) == obj
 
@@ -60,6 +62,7 @@ def test__serde__derived() -> None:
         "area": 0,
         "aspect_ratio": 0,
         DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.BOUNDING_BOX.value}",
+        FIELD_ORDER_FIELD: ["top_left", "bottom_right", "width", "height", "area", "aspect_ratio"],
     }
     # deserialization from dict containing all fields, including derived
     assert BoundingBox._from_dict(obj_dict) == obj
@@ -88,6 +91,7 @@ def test__serde__derived__extended(dataclass_decorator: Callable[..., Any]) -> N
         "b": False,
         "c": 0,
         DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.BOUNDING_BOX.value}",
+        FIELD_ORDER_FIELD: ["top_left", "bottom_right", "width", "height", "area", "aspect_ratio", "a", "b", "c"],
     }
     assert ExtendedBoundingBox._from_dict(obj_dict) == obj
 
@@ -132,6 +136,7 @@ def test__serde__nested() -> None:
         "points": [[0, 0], [1, 1], [2, 2], [0, 0]],
         "label": "e",
         DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.POLYGON.value}",
+        FIELD_ORDER_FIELD: ["points", "label"],
     }
     assert Tester._from_dict(obj_dict) == obj
 

--- a/tests/unit/workflow/test_asset.py
+++ b/tests/unit/workflow/test_asset.py
@@ -19,6 +19,7 @@ import pydantic
 import pytest
 
 from kolena.workflow._datatypes import DATA_TYPE_FIELD
+from kolena.workflow._datatypes import FIELD_ORDER_FIELD
 from kolena.workflow.asset import _AssetType
 from kolena.workflow.asset import Asset
 from kolena.workflow.asset import BinaryAsset
@@ -42,7 +43,11 @@ def test__serialize__locator(asset_class: Type[Asset], asset_type: _AssetType) -
     asset = asset_class(locator=locator)  # type: ignore
     asset_dict = asset._to_dict()
 
-    assert asset_dict == {"locator": locator, DATA_TYPE_FIELD: f"{_AssetType._data_category()}/{asset_type.value}"}
+    assert asset_dict == {
+        "locator": locator,
+        DATA_TYPE_FIELD: f"{_AssetType._data_category()}/{asset_type.value}",
+        FIELD_ORDER_FIELD: ["locator"],
+    }
     assert asset == asset_class._from_dict(asset_dict)
 
 
@@ -57,6 +62,7 @@ def test__serialize__video() -> None:
         "thumbnail": None,
         "start": 0,
         "end": 1,
+        FIELD_ORDER_FIELD: ["locator", "thumbnail", "start", "end"],
     }
     assert asset == VideoAsset._from_dict(asset_dict)
 

--- a/tests/unit/workflow/test_data_object.py
+++ b/tests/unit/workflow/test_data_object.py
@@ -97,6 +97,7 @@ def test__data_object__extras_allow() -> None:
     tester = DataclassesTester(z=False, a="foobar", b=0.3, y=["hello"], x=bbox)
     serialized = tester._to_dict()
     assert list(serialized.keys()) == ["b", "a", "z", "y", "x", FIELD_ORDER_FIELD]
+    assert serialized[FIELD_ORDER_FIELD] == ["b", "a", "z", "y", "x"]
 
     bbox_str = str(bbox)
     assert bbox_str == (

--- a/tests/unit/workflow/test_data_object.py
+++ b/tests/unit/workflow/test_data_object.py
@@ -86,6 +86,23 @@ def test__data_object__serialize_order() -> None:
     assert list(serialized.keys()) == ["b", "a", "z", FIELD_ORDER_FIELD]
 
 
+def test__data_object__serde_extra_typed_data_object() -> None:
+    @dataclass(frozen=True, config={"extra": "allow"})
+    class DataclassesTester(DataObject):
+        b: float
+
+    bbox = LabeledBoundingBox(top_left=(1, 1), bottom_right=(10, 10), label="bus", extra=[1, 2, 3])
+    tester = DataclassesTester(b=0.3, x=bbox)
+    serialized = tester._to_dict()
+    assert serialized[FIELD_ORDER_FIELD] == ["b", "x"]
+
+    # verify idempotent
+    deserialized_tester = DataclassesTester._from_dict(serialized)
+    assert deserialized_tester == tester
+    reserialized = deserialized_tester._to_dict()
+    assert reserialized == serialized
+
+
 def test__data_object__extras_allow() -> None:
     @dataclass(frozen=True, config={"extra": "allow"})
     class DataclassesTester(DataObject):

--- a/tests/unit/workflow/test_data_object.py
+++ b/tests/unit/workflow/test_data_object.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import dataclasses
+import json
 import sys
 
 import pydantic
@@ -84,6 +85,22 @@ def test__data_object__serialize_order() -> None:
     tester = DataclassesTester(z=False, a="foobar", b=0.3)
     serialized = tester._to_dict()
     assert list(serialized.keys()) == ["b", "a", "z", FIELD_ORDER_FIELD]
+
+
+def test__data_object__deserialize_order_extra() -> None:
+    @dataclass(frozen=True, config={"extra": "allow"})
+    class DataclassesTester(DataObject):
+        b: float
+        a: str
+
+    tester = DataclassesTester(a="foobar", b=0.3, foo=1, bar=2)
+    serialized = tester._to_dict()
+    assert list(serialized.keys()) == ["b", "a", "foo", "bar", FIELD_ORDER_FIELD]
+
+    # change source dict key order
+    deserialized = DataclassesTester._from_dict(json.loads(json.dumps(serialized, sort_keys=True)))
+    reserialized = deserialized._to_dict()
+    assert reserialized == serialized
 
 
 def test__data_object__serde_extra_typed_data_object() -> None:

--- a/tests/unit/workflow/test_data_object.py
+++ b/tests/unit/workflow/test_data_object.py
@@ -26,6 +26,7 @@ from kolena.workflow import Document
 from kolena.workflow import Image
 from kolena.workflow import PointCloud
 from kolena.workflow import Text
+from kolena.workflow._datatypes import FIELD_ORDER_FIELD
 from kolena.workflow.annotation import BitmapMask
 from kolena.workflow.annotation import BoundingBox
 from kolena.workflow.annotation import BoundingBox3D
@@ -82,7 +83,7 @@ def test__data_object__serialize_order() -> None:
 
     tester = DataclassesTester(z=False, a="foobar", b=0.3)
     serialized = tester._to_dict()
-    assert list(serialized.keys()) == ["b", "a", "z"]
+    assert list(serialized.keys()) == ["b", "a", "z", FIELD_ORDER_FIELD]
 
 
 def test__data_object__extras_allow() -> None:
@@ -95,7 +96,7 @@ def test__data_object__extras_allow() -> None:
     bbox = LabeledBoundingBox(top_left=(1, 1), bottom_right=(10, 10), label="bus", extra=[1, 2, 3])
     tester = DataclassesTester(z=False, a="foobar", b=0.3, y=["hello"], x=bbox)
     serialized = tester._to_dict()
-    assert list(serialized.keys()) == ["b", "a", "z", "y", "x"]
+    assert list(serialized.keys()) == ["b", "a", "z", "y", "x", FIELD_ORDER_FIELD]
 
     bbox_str = str(bbox)
     assert bbox_str == (

--- a/tests/unit/workflow/test_plot.py
+++ b/tests/unit/workflow/test_plot.py
@@ -26,6 +26,7 @@ from kolena.workflow import ConfusionMatrix
 from kolena.workflow import Curve
 from kolena.workflow import CurvePlot
 from kolena.workflow import Histogram
+from kolena.workflow._datatypes import FIELD_ORDER_FIELD
 from kolena.workflow.plot import _PlotType
 from kolena.workflow.plot import NullableNumberSeries
 from kolena.workflow.plot import NumberSeries
@@ -96,10 +97,19 @@ def test__curve_plot__serialize() -> None:
         "title": "test",
         "x_label": "x",
         "y_label": "y",
-        "curves": [{"label": "a", "x": [1, 2, 3], "y": [2, 3, 4], "extra": None}],
+        "curves": [
+            {
+                "label": "a",
+                "x": [1, 2, 3],
+                "y": [2, 3, 4],
+                "extra": None,
+                FIELD_ORDER_FIELD: ["x", "y", "label", "extra"],
+            },
+        ],
         "data_type": f"{_PlotType._data_category()}/{_PlotType.CURVE.value}",
         "x_config": None,
-        "y_config": {"type": "log"},
+        "y_config": {"type": "log", FIELD_ORDER_FIELD: ["type"]},
+        FIELD_ORDER_FIELD: ["title", "x_label", "y_label", "curves", "x_config", "y_config"],
     }
 
 
@@ -150,6 +160,7 @@ def test__confusion_matrix__serialize() -> None:
         labels=["a", "b"],
         matrix=[[90, 10], [20, 80]],
         data_type=f"{_PlotType._data_category()}/{_PlotType.CONFUSION_MATRIX.value}",
+        _field_order=["title", "labels", "matrix", "x_label", "y_label"],
     )
 
     # TODO: list of lists fails to deserialize, but not critical for plots (plots are never pulled down)
@@ -216,8 +227,9 @@ def test__histogram__serialize() -> None:
         "frequency": [[0, 1, 2, 1, 4.4, 0.2], [0, 1, 2, 3, 4, 5]],
         "labels": ["a", "b"],
         "x_config": None,
-        "y_config": {"type": "log"},
+        "y_config": {"type": "log", FIELD_ORDER_FIELD: ["type"]},
         "data_type": f"{_PlotType._data_category()}/{_PlotType.HISTOGRAM.value}",
+        FIELD_ORDER_FIELD: ["title", "x_label", "y_label", "buckets", "frequency", "labels", "x_config", "y_config"],
     }
 
 

--- a/tests/unit/workflow/test_test_sample.py
+++ b/tests/unit/workflow/test_test_sample.py
@@ -336,6 +336,7 @@ def test__serialize() -> None:
         m=BoundingBox(top_left=(0, 0), bottom_right=(10, 10))._to_dict(),
         n=[1, 2, 3],
         data_type=f"{_TestSampleType._data_category()}/{_TestSampleType.CUSTOM.value}",
+        _field_order=[chr(o) for o in range(ord("a"), ord("o"))],
     )
 
     assert Tester._from_dict(obj_dict) == obj
@@ -530,7 +531,7 @@ def test__serialize__metadata(dataclass: Callable) -> None:
     obj = Tester(a=1, metadata=metadata_dict)
     got_dict = obj._to_dict()
     got_metadata_dict = obj._to_metadata_dict()
-    assert len(got_dict) == 2
+    assert len(got_dict) == 3
     assert got_dict["a"] == 1
     assert got_dict["data_type"] == "TEST_SAMPLE/CUSTOM"
     assert got_metadata_dict == metadata_dict
@@ -544,7 +545,7 @@ def test__serialize__metadata__absent() -> None:
     obj = Tester(a=1)
     got_dict = obj._to_dict()
     got_metadata_dict = obj._to_metadata_dict()
-    assert len(got_dict) == 2
+    assert len(got_dict) == 3
     assert got_dict["a"] == 1
     assert got_dict["data_type"] == "TEST_SAMPLE/CUSTOM"
     assert got_metadata_dict == {}


### PR DESCRIPTION
### Linked issue(s):
Add additional info in dataset serialization/deserialization to restore original dataframe column order

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
