### PR TITLE
Add no_op_evaluator function

### DIFF
--- a/kolena/workflow/__init__.py
+++ b/kolena/workflow/__init__.py
@@ -46,7 +46,7 @@ from .evaluator import EvaluatorConfiguration
 from .evaluator_function import BasicEvaluatorFunction
 from .evaluator_function import TestCases
 from .evaluator_function import EvaluationResults
-from .evaluator_function import noop_evaluator
+from .evaluator_function import no_op_evaluator
 from .test_run import TestRun
 from .test_run import test
 from .define_workflow import define_workflow
@@ -85,7 +85,7 @@ __all__ = [
     "BasicEvaluatorFunction",
     "TestCases",
     "EvaluationResults",
-    "noop_evaluator",
+    "no_op_evaluator",
     "TestRun",
     "test",
     "define_workflow",

--- a/kolena/workflow/__init__.py
+++ b/kolena/workflow/__init__.py
@@ -46,6 +46,7 @@ from .evaluator import EvaluatorConfiguration
 from .evaluator_function import BasicEvaluatorFunction
 from .evaluator_function import TestCases
 from .evaluator_function import EvaluationResults
+from .evaluator_function import noop_evaluator
 from .test_run import TestRun
 from .test_run import test
 from .define_workflow import define_workflow
@@ -84,6 +85,7 @@ __all__ = [
     "BasicEvaluatorFunction",
     "TestCases",
     "EvaluationResults",
+    "noop_evaluator",
     "TestRun",
     "test",
     "define_workflow",

--- a/kolena/workflow/evaluator_function.py
+++ b/kolena/workflow/evaluator_function.py
@@ -246,3 +246,20 @@ class _TestCases(TestCases):
 def _is_configured(evaluator: BasicEvaluatorFunction) -> bool:
     param_values = list(signature(evaluator).parameters.values())
     return len(param_values) == 5 and issubclass(param_values[4].annotation, EvaluatorConfiguration)
+
+
+def noop_evaluator(
+    test_samples: List[TestSample],
+    ground_truths: List[GroundTruth],
+    inferences: List[Inference],
+    test_cases: TestCases,
+) -> EvaluationResults:
+    test_sample_metrics = [BaseMetricsTestSample() for _ in test_samples]
+    test_case_metrics = [
+        (tc, MetricsTestCase())
+        for tc, *_ in test_cases.iter(test_samples, ground_truths, inferences, test_sample_metrics)
+    ]
+    return EvaluationResults(
+        metrics_test_sample=list(zip(test_samples, test_sample_metrics)),
+        metrics_test_case=test_case_metrics,
+    )

--- a/kolena/workflow/evaluator_function.py
+++ b/kolena/workflow/evaluator_function.py
@@ -248,7 +248,7 @@ def _is_configured(evaluator: BasicEvaluatorFunction) -> bool:
     return len(param_values) == 5 and issubclass(param_values[4].annotation, EvaluatorConfiguration)
 
 
-def noop_evaluator(
+def no_op_evaluator(
     test_samples: List[TestSample],
     ground_truths: List[GroundTruth],
     inferences: List[Inference],
@@ -259,10 +259,10 @@ def noop_evaluator(
     make [`Inference`][kolena.workflow.Inference]s accessible in the platform.
 
     ```python
-    from kolena.workflow import noop_evaluator
+    from kolena.workflow import no_op_evaluator
     from kolena.workflow import test
 
-    test(model, test_suite, noop_evaluator)
+    test(model, test_suite, no_op_evaluator)
     ```
     """
     test_sample_metrics = [BaseMetricsTestSample() for _ in test_samples]

--- a/kolena/workflow/evaluator_function.py
+++ b/kolena/workflow/evaluator_function.py
@@ -254,6 +254,17 @@ def noop_evaluator(
     inferences: List[Inference],
     test_cases: TestCases,
 ) -> EvaluationResults:
+    """
+    A no-op implementation of the Kolena [`Evaluator`][kolena.workflow.Evaluator] that will bypass evaluation but
+    make [`Inference`][kolena.workflow.Inference]s accessible in the platform.
+
+    ```python
+    from kolena.workflow import noop_evaluator
+    from kolena.workflow import test
+
+    test(model, test_suite, noop_evaluator)
+    ```
+    """
     test_sample_metrics = [BaseMetricsTestSample() for _ in test_samples]
     test_case_metrics = [
         (tc, MetricsTestCase())

--- a/tests/integration/workflow/test_test_run.py
+++ b/tests/integration/workflow/test_test_run.py
@@ -35,7 +35,7 @@ from kolena.workflow import GroundTruth
 from kolena.workflow import Inference
 from kolena.workflow import MetricsTestCase
 from kolena.workflow import MetricsTestSample
-from kolena.workflow import noop_evaluator
+from kolena.workflow import no_op_evaluator
 from kolena.workflow import test
 from kolena.workflow import TestCase
 from kolena.workflow import TestCases
@@ -352,8 +352,8 @@ def test__test__noop_evaluator(
     dummy_model: Model,
     dummy_test_suites: List[TestSuite],
 ) -> None:
-    test(dummy_model, dummy_test_suites[0], noop_evaluator)
-    TestRun(dummy_model, dummy_test_suites[0], noop_evaluator)
+    test(dummy_model, dummy_test_suites[0], no_op_evaluator)
+    TestRun(dummy_model, dummy_test_suites[0], no_op_evaluator)
 
 
 def test__test__function_evaluator__with_skip(

--- a/tests/integration/workflow/test_test_run.py
+++ b/tests/integration/workflow/test_test_run.py
@@ -230,7 +230,6 @@ def test__test__mark_crashed(
 def test__evaluator__unconfigured(
     dummy_model: Model,
     dummy_test_suites: List[TestSuite],
-    dummy_test_samples: List[DummyTestSample],
 ) -> None:
     class UnconfiguredDummyEvaluator(DummyEvaluator):
         def compute_test_suite_metrics(
@@ -344,7 +343,6 @@ def test__handle_nan_inf() -> None:
 def test__test__function_evaluator(
     dummy_model: Model,
     dummy_test_suites: List[TestSuite],
-    dummy_test_samples: List[DummyTestSample],
 ) -> None:
     test(dummy_model, dummy_test_suites[0], dummy_evaluator_function)
     TestRun(dummy_model, dummy_test_suites[0], dummy_evaluator_function)
@@ -353,7 +351,6 @@ def test__test__function_evaluator(
 def test__test__noop_evaluator(
     dummy_model: Model,
     dummy_test_suites: List[TestSuite],
-    dummy_test_samples: List[DummyTestSample],
 ) -> None:
     test(dummy_model, dummy_test_suites[0], noop_evaluator)
     TestRun(dummy_model, dummy_test_suites[0], noop_evaluator)
@@ -362,7 +359,6 @@ def test__test__noop_evaluator(
 def test__test__function_evaluator__with_skip(
     dummy_model: Model,
     dummy_test_suites: List[TestSuite],
-    dummy_test_samples: List[DummyTestSample],
 ) -> None:
     config = [DummyConfiguration(value="skip")]
     test(dummy_model, dummy_test_suites[0], dummy_evaluator_function_with_config, config)

--- a/tests/integration/workflow/test_test_run.py
+++ b/tests/integration/workflow/test_test_run.py
@@ -35,6 +35,7 @@ from kolena.workflow import GroundTruth
 from kolena.workflow import Inference
 from kolena.workflow import MetricsTestCase
 from kolena.workflow import MetricsTestSample
+from kolena.workflow import noop_evaluator
 from kolena.workflow import test
 from kolena.workflow import TestCase
 from kolena.workflow import TestCases
@@ -347,6 +348,15 @@ def test__test__function_evaluator(
 ) -> None:
     test(dummy_model, dummy_test_suites[0], dummy_evaluator_function)
     TestRun(dummy_model, dummy_test_suites[0], dummy_evaluator_function)
+
+
+def test__test__noop_evaluator(
+    dummy_model: Model,
+    dummy_test_suites: List[TestSuite],
+    dummy_test_samples: List[DummyTestSample],
+) -> None:
+    test(dummy_model, dummy_test_suites[0], noop_evaluator)
+    TestRun(dummy_model, dummy_test_suites[0], noop_evaluator)
 
 
 def test__test__function_evaluator__with_skip(


### PR DESCRIPTION
### Linked issue(s):
Related to KOL-3577

### What change does this PR introduce and why?
Add no_op_evaluator function

Provides users with a prebuilt function for bypassing evaluation and viewing inferences only on Kolena.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated

Fixes KOL-3556