### PR TITLE
Remove redundant passing of `KOLENA_TOKEN` env var to initialize

### DIFF
--- a/docs/advanced-usage/packaging-for-automated-evaluation.md
+++ b/docs/advanced-usage/packaging-for-automated-evaluation.md
@@ -73,7 +73,7 @@ from .workflow import Model, TestSuite
 
 
 def main() -> None:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     model = Model(os.environ["KOLENA_MODEL_NAME"])
     test_suite = TestSuite.load(

--- a/docs/building-a-workflow.md
+++ b/docs/building-a-workflow.md
@@ -17,10 +17,9 @@ With the `kolena` Python client [installed](installing-kolena.md#installation),
 first let's initialize a client session:
 
 ```python
-import os
 import kolena
 
-kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+kolena.initialize(verbose=True)
 ```
 
 The data used in this tutorial is publicly available in the `kolena-public-datasets` S3 bucket in a `metadata.csv` file:

--- a/docs/installing-kolena.md
+++ b/docs/installing-kolena.md
@@ -73,10 +73,9 @@ export KOLENA_TOKEN="********"
 With the `KOLENA_TOKEN` environment variable set, initialize a client session:
 
 ```python
-import os
 import kolena
 
-kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+kolena.initialize(verbose=True)
 ```
 
 By default, sessions have static scope and persist until the interpreter is exited.

--- a/examples/age_estimation/age_estimation/seed_test_run.py
+++ b/examples/age_estimation/age_estimation/seed_test_run.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 from argparse import ArgumentParser
 from argparse import Namespace
@@ -49,7 +48,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
     seed_test_run(args.model, args.test_suites)
     return 0
 

--- a/examples/age_estimation/age_estimation/seed_test_suite.py
+++ b/examples/age_estimation/age_estimation/seed_test_suite.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 from argparse import ArgumentParser
 from argparse import Namespace
@@ -29,7 +28,7 @@ DATASET = "labeled-faces-in-the-wild"
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     df_metadata = pd.read_csv(args.dataset_csv)
 

--- a/examples/classification/scripts/binary/seed_test_run.py
+++ b/examples/classification/scripts/binary/seed_test_run.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 from argparse import ArgumentParser
 from argparse import Namespace
@@ -76,7 +75,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str], multiclass: bool
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
     for model_name in args.models:
         seed_test_run(model_name, args.test_suites, args.multiclass)
     return 0

--- a/examples/classification/scripts/binary/seed_test_suite.py
+++ b/examples/classification/scripts/binary/seed_test_suite.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 from argparse import ArgumentParser
 from argparse import Namespace
@@ -32,7 +31,7 @@ POSITIVE_LABEL = "dog"
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     df_metadata = pd.read_csv(args.dataset_csv)
 

--- a/examples/classification/scripts/multiclass/seed_test_run.py
+++ b/examples/classification/scripts/multiclass/seed_test_run.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 from argparse import ArgumentParser
 from argparse import Namespace
@@ -59,7 +58,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
     for model_name in args.models:
         seed_test_run(model_name, args.test_suites)
     return 0

--- a/examples/classification/scripts/multiclass/seed_test_suite.py
+++ b/examples/classification/scripts/multiclass/seed_test_suite.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 from argparse import ArgumentParser
 from argparse import Namespace
@@ -31,7 +30,7 @@ DATASET = "cifar10/test"
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     df_metadata = pd.read_csv(args.dataset_csv)
 

--- a/examples/keypoint_detection/keypoint_detection/seed_test_run.py
+++ b/examples/keypoint_detection/keypoint_detection/seed_test_run.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from argparse import ArgumentParser
 from argparse import Namespace
 from random import randint
@@ -56,7 +55,7 @@ def main() -> None:
     ap = ArgumentParser()
     ap.add_argument("model_name", type=str, help="Name of model to test.")
     ap.add_argument("test_suite", type=str, default="none", help="Name of the test suite to run.")
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     run(ap.parse_args())
 

--- a/examples/keypoint_detection/keypoint_detection/seed_test_suite.py
+++ b/examples/keypoint_detection/keypoint_detection/seed_test_suite.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import os
 from argparse import ArgumentParser
 from argparse import Namespace
 
@@ -50,7 +49,7 @@ def main() -> None:
     ap = ArgumentParser()
     ap.add_argument("test_suite", type=str, help="Name of the test suite to make.")
 
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     run(ap.parse_args())
 

--- a/examples/object_detection_2d/object_detection_2d/extended/seed_test_run.py
+++ b/examples/object_detection_2d/object_detection_2d/extended/seed_test_run.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from argparse import ArgumentParser
 from argparse import Namespace
 
@@ -51,7 +50,7 @@ def main(args: Namespace) -> None:
     model_full_name = MODEL_LIST[model_alias]
 
     # run evaluation on test suites
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     metadata_by_image = load_results(model_alias)
 

--- a/examples/object_detection_2d/object_detection_2d/extended/seed_test_suite.py
+++ b/examples/object_detection_2d/object_detection_2d/extended/seed_test_suite.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import os
 from argparse import ArgumentParser
 from argparse import Namespace
 from collections import defaultdict
@@ -174,7 +173,7 @@ def seed_test_suite_by_bounding_box_size(test_suite_name: str, complete_test_cas
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     complete_test_case = create_complete_transportation_case(args)
 

--- a/examples/object_detection_2d/object_detection_2d/seed_test_run.py
+++ b/examples/object_detection_2d/object_detection_2d/seed_test_run.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from argparse import ArgumentParser
 from argparse import Namespace
 from typing import Callable
@@ -150,7 +149,7 @@ def main(args: Namespace) -> None:
     model_full_name = MODEL_LIST[model_alias]
 
     # run evaluation on test suites
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     metadata_by_image = load_results(model_alias)
 

--- a/examples/object_detection_2d/object_detection_2d/seed_test_suite.py
+++ b/examples/object_detection_2d/object_detection_2d/seed_test_suite.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import os
 from argparse import ArgumentParser
 from argparse import Namespace
 from collections import defaultdict
@@ -174,7 +173,7 @@ def seed_test_suite_by_bounding_box_size(test_suite_name: str, complete_test_cas
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     complete_test_case = create_complete_transportation_case(args)
 

--- a/examples/object_detection_3d/object_detection_3d/seed_test_run.py
+++ b/examples/object_detection_3d/object_detection_3d/seed_test_run.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import os
 import sys
 from argparse import ArgumentParser
 from argparse import Namespace
@@ -68,7 +67,7 @@ def load_results(path: str) -> Dict[str, Any]:
 
 
 def seed_test_run(test_suite_name: str, model_name: str, results: List[Dict[str, Any]]) -> None:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     inference_by_id = {result["label_id"]: result for result in results}
 

--- a/examples/object_detection_3d/object_detection_3d/seed_test_suite.py
+++ b/examples/object_detection_3d/object_detection_3d/seed_test_suite.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import os
 from argparse import ArgumentParser
 from enum import Enum
 from pathlib import Path
@@ -40,7 +39,7 @@ def parse_args():
 
 
 def seed_test_suite(test_suite_name: str, test_samples: List[Tuple[TestSample, GroundTruth]]):
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     test_cases = TestCase.init_many([(test_suite_name, test_samples)], reset=True)
     test_suite = TestSuite(test_suite_name, test_cases=test_cases, reset=True)

--- a/examples/question_answering/question_answering/seed_test_run.py
+++ b/examples/question_answering/question_answering/seed_test_run.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 from argparse import ArgumentParser
 from argparse import Namespace
@@ -33,7 +32,7 @@ MODELS = ["gpt-3.5-turbo-0301", "gpt-3.5-turbo", "gpt-4-0314", "gpt-4"]
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     inference_mapping = {}
     model_file_path = f"s3://kolena-public-datasets/CoQA/results/{args.model}.csv"

--- a/examples/question_answering/question_answering/seed_test_suite.py
+++ b/examples/question_answering/question_answering/seed_test_suite.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 from argparse import ArgumentParser
 from argparse import Namespace
@@ -91,7 +90,7 @@ def create_test_suite_by_conversation_length(dataset: TestCase, data: List[Tuple
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     df_metadata = pd.read_csv(args.dataset_csv)
     context_dict = defaultdict(list)

--- a/examples/semantic_segmentation/semantic_segmentation/seed_test_run.py
+++ b/examples/semantic_segmentation/semantic_segmentation/seed_test_run.py
@@ -67,7 +67,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str], out_bucket: str)
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
     os.environ["KOLENA_MODEL_NAME"] = str(args.model)
     os.environ["KOLENA_OUT_BUCKET"] = str(args.out_bucket)
     seed_test_run(args.model, args.test_suites, args.out_bucket)

--- a/examples/semantic_segmentation/semantic_segmentation/seed_test_suite.py
+++ b/examples/semantic_segmentation/semantic_segmentation/seed_test_suite.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from argparse import ArgumentParser
 from argparse import Namespace
 from ast import literal_eval
@@ -77,7 +76,7 @@ def seed_complete_test_case(args: Namespace) -> TestCase:
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
     test_suite_name = f"# of people :: {DATASET} [person]"
     complete_test_case = seed_complete_test_case(args)
     stratified_test_cases = seed_stratified_test_cases(complete_test_case, test_suite_name)

--- a/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_run.py
+++ b/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_run.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 from argparse import ArgumentParser
 from argparse import Namespace
@@ -60,7 +59,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
     for model_name in args.models:
         seed_test_run(model_name, args.test_suites)
     return 0

--- a/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_suite.py
+++ b/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_suite.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from argparse import ArgumentParser
 from argparse import Namespace
 
@@ -57,7 +56,7 @@ def seed_complete_test_case(args: Namespace) -> TestCase:
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
     complete_test_case = seed_complete_test_case(args)
     test_suite = TestSuite(
         f"{DATASET}",

--- a/examples/text_summarization/text_summarization/remote_evaluator.py
+++ b/examples/text_summarization/text_summarization/remote_evaluator.py
@@ -27,7 +27,7 @@ test_suite_version = os.environ["KOLENA_TEST_SUITE_VERSION"]
 env_token = "KOLENA_TOKEN"
 
 print(f"initializing with environment variables ${env_token}")
-kolena.initialize(api_token=os.environ[env_token], verbose=True)
+kolena.initialize(verbose=True)
 
 model = Model(model_name)
 print(f"using model: {model}")

--- a/examples/text_summarization/text_summarization/seed_test_run.py
+++ b/examples/text_summarization/text_summarization/seed_test_run.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from argparse import ArgumentParser
 from argparse import Namespace
 from typing import Callable
@@ -139,7 +138,7 @@ def seed_test_run(
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
 
     mod = MODEL_MAP[args.model]
     print("loading inference CSV")

--- a/examples/text_summarization/text_summarization/seed_test_suite.py
+++ b/examples/text_summarization/text_summarization/seed_test_suite.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from argparse import ArgumentParser
 from argparse import Namespace
 from typing import Callable
@@ -192,7 +191,7 @@ def seed_test_suites(
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(verbose=True)
     complete_tc = seed_complete_test_case(args)
 
     test_suite_names: Dict[str, Callable[[str, TestCase], TestSuite]] = {

--- a/kolena/initialize.py
+++ b/kolena/initialize.py
@@ -49,10 +49,9 @@ def initialize(
 
     1. Directly through the `api_token` keyword argument
     ```python
-    import os
     import kolena
 
-    kolena.initialize(api_token=os.environ["KOLENA_TOKEN"], verbose=True)
+    kolena.initialize(api_token=your_token, verbose=True)
     ```
     2. Populate the `KOLENA_TOKEN` environment variable
     ```bash


### PR DESCRIPTION
### What change does this PR introduce and why?
Initialize will default to checking the `KOLENA_TOKEN` environment variable if not explicitly passed an api token. Removing redundant passing of `os.environ["KOLENA_TOKEN"]` to initialize as the method will do as a fallback.

Ref https://github.com/kolenaIO/kolena/pull/272#issuecomment-1768479394

### Please check if the PR fulfills these requirements
- [x] Relevant docs have been added / updated