### PR TITLE
Reduce ActivationMapUploader workers to 1 for Semantic Segmentation example

### DIFF
--- a/examples/semantic_segmentation/semantic_segmentation/data_loader.py
+++ b/examples/semantic_segmentation/semantic_segmentation/data_loader.py
@@ -101,7 +101,7 @@ class DataLoader:
 
 class ActivationMapUploader:
     def __init__(self):
-        self.pool = ThreadPoolExecutor(max_workers=32)
+        self.pool = ThreadPoolExecutor(max_workers=1)
         self.futures = {}
 
     def wait(self) -> None:

--- a/examples/semantic_segmentation/semantic_segmentation/seed_test_run.py
+++ b/examples/semantic_segmentation/semantic_segmentation/seed_test_run.py
@@ -19,7 +19,7 @@ from typing import List
 
 from semantic_segmentation.constants import BUCKET
 from semantic_segmentation.constants import DATASET
-from semantic_segmentation.data_loader import ActivationMapUploader
+from semantic_segmentation.data_loader import process_activation_map
 from semantic_segmentation.evaluator import evaluate_semantic_segmentation
 from semantic_segmentation.utils import sanitize_model_name
 from semantic_segmentation.workflow import Inference
@@ -37,13 +37,12 @@ from kolena.workflow.test_run import test
 def seed_test_run(model_name: str, test_suite_names: List[str], out_bucket: str) -> None:
     sanitized_model_name = sanitize_model_name(model_name)
     inference_locator_prefix = f"s3://{out_bucket}/{DATASET}/inferences/{sanitized_model_name}"
-    uploader = ActivationMapUploader()  # asynchronously batch and upload activation maps
 
     def infer(test_sample: TestSample) -> Inference:
         basename = test_sample.metadata["basename"]
         prob_array_locator = f"s3://{BUCKET}/{DATASET}/results/{sanitized_model_name}/{basename}_person.npy"
         activation_map_locator = f"{inference_locator_prefix}/activation/{basename}.png"
-        uploader.submit(prob_array_locator, activation_map_locator)
+        process_activation_map(prob_array_locator, activation_map_locator)
 
         return Inference(
             prob=BinaryAsset(prob_array_locator),
@@ -62,8 +61,6 @@ def seed_test_run(model_name: str, test_suite_names: List[str], out_bucket: str)
             configurations=configurations,
             reset=True,
         )
-
-    uploader.wait()
 
 
 def main(args: Namespace) -> int:


### PR DESCRIPTION
### Linked issue(s):
Having 32 workers causes the test_run to hang until the process is manually killed. Having 1 worker allows the run to complete and based on testing is faster than 4 workers. 

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
