### PR TITLE
Add Kolena logo to 'Supported Python Versions' table

### DIFF
--- a/docs/installing-kolena.md
+++ b/docs/installing-kolena.md
@@ -90,11 +90,11 @@ Additional logging can be configured by specifying `initialize(..., verbose=True
 
 `kolena` is compatible with all active Python versions.
 
-| :fontawesome-brands-python: Python Version                        | Compatible `kolena` Versions |
-| ----------------------------------------------------------------- | ---------------------------- |
-| 3.11                                                              | ≥0.69                        |
-| 3.10                                                              | _All Versions_               |
-| 3.9                                                               | _All Versions_               |
-| 3.8                                                               | _All Versions_               |
-| 3.7                                                               | _All Versions_               |
-| 3.6 (EOL: [December 2021](https://devguide.python.org/versions/)) | ≤0.46                        |
+| :fontawesome-brands-python: Python Version                        | :kolena-logo: Compatible `kolena` Versions   |
+| ----------------------------------------------------------------- |-------------------------------------------------|
+| 3.11                                                              | ≥0.69                                           |
+| 3.10                                                              | _All Versions_                                  |
+| 3.9                                                               | _All Versions_                                  |
+| 3.8                                                               | _All Versions_                                  |
+| 3.7                                                               | _All Versions_                                  |
+| 3.6 (EOL: [December 2021](https://devguide.python.org/versions/)) | ≤0.46                                           |


### PR DESCRIPTION
Makes for nice symmetry between the Python and `kolena` column headers:

![Screenshot 2023-10-26 at 11 35 00 AM](https://github.com/kolenaIO/kolena/assets/9648886/5d0eb077-6d86-41ae-9a1f-7f7556492636)
