### PR TITLE
rename client event names for consistency

### DIFF
--- a/kolena/_api/v1/event.py
+++ b/kolena/_api/v1/event.py
@@ -30,7 +30,7 @@ class EventAPI:
 
     class Event(str, Enum):
         # auth
-        GENERATE_TOKEN = "generate-token"
+        INITIALIZE_SDK_CLIENT = "initialize-sdk-client"
 
         # test case
         CREATE_TEST_CASE = "create-test-case"

--- a/kolena/_api/v1/event.py
+++ b/kolena/_api/v1/event.py
@@ -30,28 +30,28 @@ class EventAPI:
 
     class Event(str, Enum):
         # auth
-        INITIALIZE_SDK_CLIENT = "initialize-sdk-client"
+        INITIALIZE_SDK_CLIENT = "sdk-client-initialized"
 
         # test case
-        CREATE_TEST_CASE = "create-test-case"
-        LOAD_TEST_CASE = "load-test-case"
-        LOAD_TEST_CASE_SAMPLES = "load-test-case-samples"
-        EDIT_TEST_CASE = "edit-test-case"
-        INIT_MANY_TEST_CASES = "initialize-many-test-cases"
+        CREATE_TEST_CASE = "test-case-created"
+        LOAD_TEST_CASE = "test-case-loaded"
+        LOAD_TEST_CASE_SAMPLES = "test-case-samples-loaded"
+        EDIT_TEST_CASE = "test-case-edited"
+        INIT_MANY_TEST_CASES = "many-test-cases-initialized"
 
         # test suite
-        CREATE_TEST_SUITE = "create-test-suite"
-        LOAD_TEST_SUITE = "load-test-suite"
-        LOAD_ALL_TEST_SUITES = "load-all-test-suites"
-        EDIT_TEST_SUITE = "edit-test-suite"
-        LOAD_TEST_SUITE_SAMPLES = "load-test-suite-samples"
+        CREATE_TEST_SUITE = "test-suite-created"
+        LOAD_TEST_SUITE = "test-suite-loaded"
+        LOAD_ALL_TEST_SUITES = "all-test-suites-loaded"
+        EDIT_TEST_SUITE = "test-suite-edited"
+        LOAD_TEST_SUITE_SAMPLES = "test-suite-samples-loaded"
 
         # model
-        CREATE_MODEL = "create-model"
-        LOAD_MODEL = "load-model"
+        CREATE_MODEL = "model-created"
+        LOAD_MODEL = "model-loaded"
 
         # test run
-        EXECUTE_TEST_RUN = "execute-test-run"
+        EXECUTE_TEST_RUN = "test-run-executed"
 
     @dataclass(frozen=True)
     class RecordEventRequest:

--- a/kolena/_api/v1/event.py
+++ b/kolena/_api/v1/event.py
@@ -33,25 +33,25 @@ class EventAPI:
         INITIALIZE_SDK_CLIENT = "sdk-client-initialized"
 
         # test case
-        CREATE_TEST_CASE = "test-case-created"
-        LOAD_TEST_CASE = "test-case-loaded"
-        LOAD_TEST_CASE_SAMPLES = "test-case-samples-loaded"
-        EDIT_TEST_CASE = "test-case-edited"
-        INIT_MANY_TEST_CASES = "many-test-cases-initialized"
+        CREATE_TEST_CASE = "sdk-test-case-created"
+        LOAD_TEST_CASE = "sdk-test-case-loaded"
+        LOAD_TEST_CASE_SAMPLES = "sdk-test-case-samples-loaded"
+        EDIT_TEST_CASE = "sdk-test-case-edited"
+        INIT_MANY_TEST_CASES = "sdk-many-test-cases-initialized"
 
         # test suite
-        CREATE_TEST_SUITE = "test-suite-created"
-        LOAD_TEST_SUITE = "test-suite-loaded"
-        LOAD_ALL_TEST_SUITES = "all-test-suites-loaded"
-        EDIT_TEST_SUITE = "test-suite-edited"
-        LOAD_TEST_SUITE_SAMPLES = "test-suite-samples-loaded"
+        CREATE_TEST_SUITE = "sdk-test-suite-created"
+        LOAD_TEST_SUITE = "sdk-test-suite-loaded"
+        LOAD_ALL_TEST_SUITES = "sdk-all-test-suites-loaded"
+        EDIT_TEST_SUITE = "sdk-test-suite-edited"
+        LOAD_TEST_SUITE_SAMPLES = "sdk-test-suite-samples-loaded"
 
         # model
-        CREATE_MODEL = "model-created"
-        LOAD_MODEL = "model-loaded"
+        CREATE_MODEL = "sdk-model-created"
+        LOAD_MODEL = "sdk-model-loaded"
 
         # test run
-        EXECUTE_TEST_RUN = "test-run-executed"
+        EXECUTE_TEST_RUN = "sdk-test-run-executed"
 
     @dataclass(frozen=True)
     class RecordEventRequest:

--- a/kolena/initialize.py
+++ b/kolena/initialize.py
@@ -137,7 +137,7 @@ def initialize(
 
     if derived_telemetry:
         set_profile()
-        record_event(EventAPI.RecordEventRequest(event_name=EventAPI.Event.GENERATE_TOKEN))
+        record_event(EventAPI.RecordEventRequest(event_name=EventAPI.Event.INITIALIZE_SDK_CLIENT))
 
     log.info("initialized")
     if verbose:


### PR DESCRIPTION
### Linked issue(s):
N/A

### What change does this PR introduce and why?
We added event api in a [previous PR](https://github.com/kolenaIO/kolena/pull/271). One of the events was `generate-token` which represents when the python SDK client authenticates the user and generates an JWT token.

This however is easy to confuse with an existing event name `token-generated` used by the front end which represents when the API token gets refreshed. To avoid confusion, here we rename the event to `sdk-client-initialized` to be explicit.

To be consistent with other events used by the front-end, we also rename all event names to `<noun>-<verb-in-past-tense>`

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
