### PR TITLE
Remove parallelism from ci integration tests

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -335,7 +335,6 @@ workflows:
               pytest-group: [ detection, fr, classification, workflow ]
               extras: ["none"]
           enabled: true
-          parallelism: 3
           requires:
             - ci-base-<< matrix.python-version >>-<< matrix.extras >>
       - integration-test:
@@ -346,7 +345,6 @@ workflows:
               extras: ["metrics"]
           pytest-group: _experimental
           enabled: true
-          parallelism: 1
           requires:
             - ci-base-<< matrix.python-version >>-<< matrix.extras >>
       - integration-test:


### PR DESCRIPTION
### Linked issue(s):
Fixes KOL-3383

### What change does this PR introduce and why?
Removes parallelism from integration test steps in circleci. Integration tests are prone to [failing due to hitting snowflakes concurrent write limit](https://app.circleci.com/pipelines/github/kolenaIO/kolena/1832/workflows/7f414715-5b19-4cc3-aaf3-d9b0c18efded/jobs/34457/parallel-runs/1?filterBy=FAILED).
By reducing parallelism from 3 to 1, we are effectively reducing concurrent writes by a factor of 3 and will be less likely to trigger this CI flake. The downside is that test runs now take longer. 
- [Before: 14m 53s](https://app.circleci.com/pipelines/github/kolenaIO/kolena/2321/workflows/0c147b2e-c03c-4a6e-89cc-7cacd48b36c5)
- [After: 23m 11s](https://app.circleci.com/pipelines/github/kolenaIO/kolena/2324/workflows/409382e4-9942-4cf2-a767-43f04bd487e0)

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)