### PR TITLE
Add JWTAuth to krequests to bypass netrc auth priority

### DIFF
--- a/kolena/_utils/krequests.py
+++ b/kolena/_utils/krequests.py
@@ -52,11 +52,17 @@ CONNECTION_READ_TIMEOUT = 60 * 60  # Give kolena server 1 hour to respond to cli
 # Using the Retry object to configure a backoff which is not supported by using an int here.
 MAX_RETRIES = Retry(total=3, connect=3, read=0, redirect=0, status=0, backoff_factor=2)
 
+class NoOpAuth(requests.auth.AuthBase):
+    """Force requests to bypass `netrc` auth"""
+    def __call__(self, r):
+        return r
+
 
 @kolena_initialized
 def _with_default_kwargs(**kwargs: Any) -> Dict[str, Any]:
     client_state = get_client_state()
     default_kwargs = {
+        "auth": NoOpAuth(),
         "timeout": (CONNECTION_CONNECT_TIMEOUT, CONNECTION_READ_TIMEOUT),
         "proxies": client_state.proxies,
     }

--- a/kolena/_utils/krequests.py
+++ b/kolena/_utils/krequests.py
@@ -15,7 +15,6 @@ import uuid
 from http import HTTPStatus
 from typing import Any
 from typing import Dict
-from typing import Optional
 
 import requests
 from requests import HTTPError

--- a/kolena/_utils/krequests.py
+++ b/kolena/_utils/krequests.py
@@ -57,7 +57,7 @@ MAX_RETRIES = Retry(total=3, connect=3, read=0, redirect=0, status=0, backoff_fa
 class JWTAuth(requests.auth.AuthBase):
     """Attaches JWT Authorization to the given Request object"""
 
-    def __init__(self, jwt: Optional[str]):
+    def __init__(self, jwt: str):
         self.jwt = jwt
 
     def __call__(self, r):


### PR DESCRIPTION
### What change does this PR introduce and why?
A fix for https://github.com/kolenaIO/kolena/pull/256 netrc fallback. If no auth class is passed to [requests](https://github.com/psf/requests) it will attempt to get the authorization credentials from the users netrc file and use HTTP Basic Auth https://requests.readthedocs.io/en/latest/user/authentication/#netrc-authentication.
This is undesirable for Kolena client since it is using a JWT token to sign requests https://github.com/kolenaIO/kolena/blob/trunk/kolena/_utils/krequests.py#L65. Adds an Auth class which has a JWT and attaches it to Request objects.

### Please check if the PR fulfills these requirements
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
