### PR TITLE
Update Quickstart guide to reference Object Detection 2D example

### DIFF
--- a/docs/core-concepts/workflow.md
+++ b/docs/core-concepts/workflow.md
@@ -166,8 +166,7 @@ The inference type and ground truth type for a workflow will often look very sim
 
 Consider the example of a detection model that detects labeled bounding boxes when provided an image.
 The [ScoredLabeledBoundingBox][kolena.workflow.annotation.ScoredLabeledBoundingBox] represents a bounding box with a label and a confidence score.
-If you wanted to add fields found in COCO format annotations (area, isCrowd)
-This model's inference type could be defined as follows:
+If you wanted to add fields found in COCO format annotations (area, isCrowd) then this model's inference type could be defined as follows:
 
 ```python
 from dataclasses import dataclass
@@ -183,10 +182,10 @@ class CocoScoredLabeledBoundingBox(ScoredLabeledBoundingBox):
 
     '''
     The following fields are inherited from ScoredLabeledBoundingBox
-    top_left: Tuple[float, float]
-    bottom_right: Tuple[float, float]
-    score: float
-    label: str
+    top_left: Tuple[float, float] # The top left vertex (in `(x, y)` pixel coordinates) of this bounding box.
+    bottom_right: Tuple[float, float] # The bottom right vertex (in `(x, y)` pixel coordinates) of this bounding box.
+    score: float  # The score (e.g. model confidence) associated with this bounding box.
+    label: str  # The label (e.g. model classification) associated with this bounding box.
     '''
 
 

--- a/docs/core-concepts/workflow.md
+++ b/docs/core-concepts/workflow.md
@@ -185,6 +185,7 @@ class ScoredLabeledKeypoints(Keypoints):
 class MyInference(Inference):
     predictions: List[ScoredLabeledKeypoints]
 ```
+
 ### Deduplication
 
 Models are considered deterministic inputs from test samples to inferences. This means that, when testing in Kolena,

--- a/docs/core-concepts/workflow.md
+++ b/docs/core-concepts/workflow.md
@@ -164,36 +164,27 @@ The inference type and ground truth type for a workflow will often look very sim
 
 [Annotation][kolena.workflow.annotation.Annotation] types can be extended to include additional fields, when necessary.
 
-Consider the example of a detection model that detects labeled bounding boxes when provided an image.
-The [ScoredLabeledBoundingBox][kolena.workflow.annotation.ScoredLabeledBoundingBox] represents a bounding box with a label and a confidence score.
-If you wanted to add fields found in COCO format annotations (area, isCrowd) then this model's inference type could be defined as follows:
+Consider the example of a [`Keypoints`][kolena.workflow.annotation.Keypoints] detection model that detects anywhere from
+0 to N keypoints arrays when provided an image. Each keypoints array has an associated class label and confidence value.
+This model's inference type could be defined as follows:
 
 ```python
 from dataclasses import dataclass
 from typing import List
 
 from kolena.workflow import Inference
-from kolena.workflow.annotation import ScoredLabeledBoundingBox
+from kolena.workflow.annotation import Keypoints
 
 @dataclass(frozen=True)
-class CocoScoredLabeledBoundingBox(ScoredLabeledBoundingBox):
-    area: float  # area of bounding box
-    isCrowd: float  # annotation is for a single object or a multiple objects. Either 0 or 1
-
-    '''
-    The following fields are inherited from ScoredLabeledBoundingBox
-    top_left: Tuple[float, float] # The top left vertex (in `(x, y)` pixel coordinates) of this bounding box.
-    bottom_right: Tuple[float, float] # The bottom right vertex (in `(x, y)` pixel coordinates) of this bounding box.
-    score: float  # The score (e.g. model confidence) associated with this bounding box.
-    label: str  # The label (e.g. model classification) associated with this bounding box.
-    '''
-
+class ScoredLabeledKeypoints(Keypoints):
+    # points: List[Tuple[float, float]]  # inherited from Keypoints
+    score: float  # confidence score, between 0 and 1
+    label: str  # predicted class
 
 @dataclass(frozen=True)
 class MyInference(Inference):
-    predictions: List[CocoScoredLabeledBoundingBox]
+    predictions: List[ScoredLabeledKeypoints]
 ```
-
 ### Deduplication
 
 Models are considered deterministic inputs from test samples to inferences. This means that, when testing in Kolena,

--- a/docs/core-concepts/workflow.md
+++ b/docs/core-concepts/workflow.md
@@ -12,7 +12,7 @@ can be tested can be modeled as a workflow in Kolena.
 Examples of workflows include:
 
 <div class="grid cards" markdown>
-- [:kolena-widget-20: Example: Object Detection (2D) ↗](https://github.com/kolenaIO/kolena/tree/trunk/examples/object_detection_2d) using images
+- [:kolena-widget-20: Object Detection (2D)](https://github.com/kolenaIO/kolena/tree/trunk/examples/object_detection_2d) using images
 - [:kolena-text-summarization-20: Text Summarization](https://github.com/kolenaIO/kolena/tree/trunk/examples/text_summarization) using articles/documents
 - [:kolena-age-estimation-20: Age Estimation](https://github.com/kolenaIO/kolena/tree/trunk/examples/age_estimation) (regression) using images
 - [:kolena-video-20: Video Retrieval](https://paperswithcode.com/task/video-retrieval) using text queries on a corpus of videos

--- a/docs/core-concepts/workflow.md
+++ b/docs/core-concepts/workflow.md
@@ -12,7 +12,7 @@ can be tested can be modeled as a workflow in Kolena.
 Examples of workflows include:
 
 <div class="grid cards" markdown>
-- [:kolena-keypoint-detection-20: Keypoint Detection](https://github.com/kolenaIO/kolena/tree/trunk/examples/keypoint_detection) using images
+- [:kolena-widget-20: Example: Object Detection (2D) ↗](https://github.com/kolenaIO/kolena/tree/trunk/examples/object_detection_2d) using images
 - [:kolena-text-summarization-20: Text Summarization](https://github.com/kolenaIO/kolena/tree/trunk/examples/text_summarization) using articles/documents
 - [:kolena-age-estimation-20: Age Estimation](https://github.com/kolenaIO/kolena/tree/trunk/examples/age_estimation) (regression) using images
 - [:kolena-video-20: Video Retrieval](https://paperswithcode.com/task/video-retrieval) using text queries on a corpus of videos

--- a/docs/core-concepts/workflow.md
+++ b/docs/core-concepts/workflow.md
@@ -164,8 +164,9 @@ The inference type and ground truth type for a workflow will often look very sim
 
 [Annotation][kolena.workflow.annotation.Annotation] types can be extended to include additional fields, when necessary.
 
-Consider the example of a [`Keypoints`][kolena.workflow.annotation.Keypoints] detection model that detects anywhere from
-0 to N keypoints arrays when provided an image. Each keypoints array has an associated class label and confidence value.
+Consider the example of a detection model that detects labeled bounding boxes when provided an image.
+The [ScoredLabeledBoundingBox][kolena.workflow.annotation.ScoredLabeledBoundingBox] represents a bounding box with a label and a confidence score.
+If you wanted to add fields found in COCO format annotations (area, isCrowd)
 This model's inference type could be defined as follows:
 
 ```python
@@ -173,17 +174,25 @@ from dataclasses import dataclass
 from typing import List
 
 from kolena.workflow import Inference
-from kolena.workflow.annotation import Keypoints
+from kolena.workflow.annotation import ScoredLabeledBoundingBox
 
 @dataclass(frozen=True)
-class ScoredLabeledKeypoints(Keypoints):
-    # points: List[Tuple[float, float]]  # inherited from Keypoints
-    score: float  # confidence score, between 0 and 1
-    label: str  # predicted class
+class CocoScoredLabeledBoundingBox(ScoredLabeledBoundingBox):
+    area: float  # area of bounding box
+    isCrowd: float  # annotation is for a single object or a multiple objects. Either 0 or 1
+
+    '''
+    The following fields are inherited from ScoredLabeledBoundingBox
+    top_left: Tuple[float, float]
+    bottom_right: Tuple[float, float]
+    score: float
+    label: str
+    '''
+
 
 @dataclass(frozen=True)
 class MyInference(Inference):
-    predictions: List[ScoredLabeledKeypoints]
+    predictions: List[CocoScoredLabeledBoundingBox]
 ```
 
 ### Deduplication

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -170,8 +170,10 @@ poetry run python3 object_detection_2d/seed_test_suite.py
 After this script has completed, we can visit the [:kolena-test-suite-16: Test Suites](https://app.kolena.io/redirect/testing)
 page to view our newly created test suites.
 
-In this `object_detection_2d` example, we've created test suites stratifying the COCO dataset (which is stored as a CSV in
-S3) into test cases by brightness and bounding box size.
+In this `object_detection_2d` example, we've created test suites stratifying the [COCO](https://cocodataset.org/#overview) 2014 validation set (which is stored as a CSV in
+S3) into test cases by brightness and bounding box size. In this example will be looking at the following labels:
+
+`["bicycle", "car","motorcycle", "bus", "train", "truck", "traffic light", "fire hydrant", "stop sign" ]`
 
 ## Test a Model
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -173,12 +173,12 @@ page to view our newly created test suites.
 In this `object_detection_2d` example, we've created test suites stratifying the [COCO](https://cocodataset.org/#overview) 2014 validation set (which is stored as a CSV in
 S3) into test cases by brightness and bounding box size. In this example will be looking at the following labels:
 
-`["bicycle", "car","motorcycle", "bus", "train", "truck", "traffic light", "fire hydrant", "stop sign" ]`
+`["bicycle", "car", "motorcycle", "bus", "train", "truck", "traffic light", "fire hydrant", "stop sign"]`
 
 ## Test a Model
 
 After we've created test suites, the final step is to test models on these test suites. The `object_detection_2d` example
-provides the following models to choose from `{yolo_r,yolo_x,mask_rcnn,faster_rcnn,yolo_v4s,yolo_v3}` for this step:
+provides the following models to choose from `{yolo_r, yolo_x, mask_rcnn, faster_rcnn, yolo_v4s, yolo_v3}` for this step:
 
 ```shell
 poetry run python3 object_detection_2d/seed_test_run.py "yolo_v4s"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -178,7 +178,7 @@ S3) into test cases by brightness and bounding box size. In this example will be
 ## Test a Model
 
 After we've created test suites, the final step is to test models on these test suites. The `object_detection_2d` example
-provides the following models to choose from `{yolo_r,yolo_x,mask_cnn,faster_rcnn,yolo_v4s,yolo_v3}` for this step:
+provides the following models to choose from `{yolo_r,yolo_x,mask_rcnn,faster_rcnn,yolo_v4s,yolo_v3}` for this step:
 
 ```shell
 poetry run python3 object_detection_2d/seed_test_run.py "yolo_v4s"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ icon: kolena/flame-16
 Install Kolena to set up rigorous and repeatable model testing in minutes.
 
 In this quickstart guide, we'll use the
-[`age_estimation`](https://github.com/kolenaIO/kolena/tree/trunk/examples/age_estimation) example integration to
+[`object_detection_2d`](https://github.com/kolenaIO/kolena/tree/trunk/examples/object_detection_2d) example integration to
 demonstrate the how to curate test data and test models in Kolena.
 
 ## Install `kolena`
@@ -135,10 +135,10 @@ git clone https://github.com/kolenaIO/kolena.git
 ```
 
 With the repository cloned, let's set up the
-[`age_estimation`](https://github.com/kolenaIO/kolena/tree/trunk/examples/age_estimation) example:
+[`object_detection_2d`](https://github.com/kolenaIO/kolena/tree/trunk/examples/object_detection_2d) example:
 
 ```shell
-cd kolena/examples/age_estimation
+cd kolena/examples/object_detection_2d
 poetry update && poetry install
 ```
 
@@ -152,7 +152,7 @@ Each of the example integrations comes with scripts for two flows:
 1. `seed_test_suite.py`: Create test cases and test suite(s) from a source dataset
 2. `seed_test_run.py`: Test model(s) on the created test suites
 
-Before running [`seed_test_suite.py`](https://github.com/kolenaIO/kolena/blob/trunk/examples/age_estimation/age_estimation/seed_test_suite.py),
+Before running [`seed_test_suite.py`](https://github.com/kolenaIO/kolena/blob/trunk/examples/object_detection_2d/object_detection_2d/seed_test_suite.py),
 let's first configure our environment by populating the `KOLENA_TOKEN`
 environment variable. Visit the [:kolena-developer-16: Developer](https://app.kolena.io/redirect/developer) page to
 generate an API token and copy and paste the code snippet into your environment:
@@ -164,31 +164,27 @@ export KOLENA_TOKEN="********"
 We can now create test suites using the provided seeding script:
 
 ```shell
-poetry run python3 age_estimation/seed_test_suite.py
+poetry run python3 object_detection_2d/seed_test_suite.py
 ```
 
 After this script has completed, we can visit the [:kolena-test-suite-16: Test Suites](https://app.kolena.io/redirect/testing)
 page to view our newly created test suites.
 
-In this `age_estimation` example, we've created test suites stratifying the LFW dataset (which is stored as a CSV in
-S3) into test cases by age, estimated race, and estimated gender.
+In this `object_detection_2d` example, we've created test suites stratifying the COCO dataset (which is stored as a CSV in
+S3) into test cases by brightness and bounding box size.
 
 ## Test a Model
 
-After we've created test suites, the final step is to test models on these test suites. The `age_estimation` example
-provides the `ssrnet` model for this step:
+After we've created test suites, the final step is to test models on these test suites. The `object_detection_2d` example
+provides the following models to choose from `{yolo_r,yolo_x,mask_cnn,faster_rcnn,yolo_v4s,yolo_v3}` for this step:
 
 ```shell
-poetry run python3 age_estimation/seed_test_run.py \
-  "ssrnet" \
-  "age :: labeled-faces-in-the-wild [age estimation]" \
-  "race :: labeled-faces-in-the-wild [age estimation]" \
-  "gender :: labeled-faces-in-the-wild [age estimation]"
+poetry run python3 object_detection_2d/seed_test_run.py "yolo_v4s"
 ```
 
 !!! note "Note: Testing additional models"
     In this example, model results have already been extracted and are stored in CSV files in S3. To run a new model,
-    plug it into the `infer` method in [`seed_test_run.py`](https://github.com/kolenaIO/kolena/blob/trunk/examples/age_estimation/age_estimation/seed_test_run.py).
+    plug it into the `infer` method in [`seed_test_run.py`](https://github.com/kolenaIO/kolena/blob/trunk/examples/object_detection_2d/object_detection_2d/seed_test_run.py).
 
 Once this script has completed, click the results link in your console or visit
 [:kolena-results-16: Results](https://app.kolena.io/redirect/results) to view the test results for this newly tested model.
@@ -196,8 +192,8 @@ Once this script has completed, click the results link in your console or visit
 ## Conclusion
 
 In this quickstart, we used an example integration from [kolenaIO/kolena](https://github.com/kolenaIO/kolena) to create
-test suites from the [Labeled Faces in the Wild (LFW)](http://vis-www.cs.umass.edu/lfw/) dataset and test the
-open-source `ssrnet` model on these test suites.
+test suites from the [COCO](https://cocodataset.org/#overview) dataset and test the
+open-source `yolo_v4s` model on these test suites.
 
 This example shows us how to define an ML problem as a workflow for testing in Kolena, and can be arbitrarily extended
 with additional metrics, plots, visualizations, and data.

--- a/examples/object_detection_2d/README.md
+++ b/examples/object_detection_2d/README.md
@@ -30,7 +30,7 @@ This project defines two scripts that perform the following operations:
         `small`, `medium` and `large`.
 
 2. [`seed_test_run.py`](object_detection_2d/seed_test_run.py) tests the following models on the above test suites:
-  `yolo_r`, `yolo_x`, `mask_cnn`, `faster_rcnn`, `yolo_v4s`, and `yolo_v3`. Information about these models can be
+  `yolo_r`, `yolo_x`, `mask_rcnn`, `faster_rcnn`, `yolo_v4s`, and `yolo_v3`. Information about these models can be
   found in [`constants.py`](object_detection_2d/constants.py).
 
 Command line arguments are defined within each script to specify what model to use and what test suite to
@@ -38,7 +38,7 @@ Command line arguments are defined within each script to specify what model to u
 
 ```shell
 $ poetry run python3 object_detection_2d/seed_test_run.py --help
-usage: seed_test_run.py [-h] [--test_suite TEST_SUITE] {yolo_r,yolo_x,mask_cnn,faster_rcnn,yolo_v4s,yolo_v3}
+usage: seed_test_run.py [-h] [--test_suite TEST_SUITE] {yolo_r,yolo_x,mask_rcnn,faster_rcnn,yolo_v4s,yolo_v3}
 
 positional arguments:
   {yolo_r,yolo_x,mask_cnn,faster_rcnn,yolo_v4s,yolo_v3}

--- a/examples/object_detection_2d/object_detection_2d/constants.py
+++ b/examples/object_detection_2d/object_detection_2d/constants.py
@@ -121,7 +121,7 @@ YOLO_V3 = {
 MODEL_METADATA: Dict[str, Dict[str, str]] = {
     "yolo_r": YOLO_R,
     "yolo_x": YOLO_X,
-    "mask_cnn": MASK_RCNN,
+    "mask_rcnn": MASK_RCNN,
     "faster_rcnn": FAST_RCNN,
     "yolo_v4s": YOLO_V4,
     "yolo_v3": YOLO_V3,

--- a/examples/object_detection_2d/object_detection_2d/seed_test_run.py
+++ b/examples/object_detection_2d/object_detection_2d/seed_test_run.py
@@ -37,7 +37,7 @@ from kolena.workflow.test_run import test
 MODEL_LIST: Dict[str, str] = {
     "yolo_r": f"YOLOR-D6 (modified CSP, {WORKFLOW})",
     "yolo_x": f"YOLOX (modified CSP-v5, {WORKFLOW})",
-    "mask_cnn": f"Mask R-CNN (Inception-ResNet-v2, {WORKFLOW})",
+    "mask_rcnn": f"Mask R-CNN (Inception-ResNet-v2, {WORKFLOW})",
     "faster_rcnn": f"Faster R-CNN (Inception-ResNet-v2, {WORKFLOW})",
     "yolo_v4s": f"Scaled YOLOv4 (CSP-DarkNet-53, {WORKFLOW})",
     "yolo_v3": f"YOLOv3 (DarkNet-53, {WORKFLOW})",


### PR DESCRIPTION
### Linked issue(s):
KOL-2798

### What change does this PR introduce and why?
Replaces the Age Estimation example currently referenced in the Quickstart guide with the Object Detection 2D example. This PR also adds a link to the Object Detection 2D example in https://docs.kolena.io/core-concepts/workflow/


### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated


Fixes: KOL-2798