### PR TITLE
Update average precision score to be based on sampled PR curve

### DIFF
--- a/examples/semantic_segmentation/README.md
+++ b/examples/semantic_segmentation/README.md
@@ -42,9 +42,6 @@ test suite.
     The result masks will be stored under `s3://{args.out_bucket}/coco-stuff-10k/results/{args.model}` directory in
     your bucket.
 
-	> [!WARNING]
-	> This script has high memory usage(>20GB). If this is an issue, look into using https://github.com/grantjenks/python-diskcache
-
 3. An optional script, [`seed_activation_map.py`](semantic_segmentation/seed_activation_map.py) demonstrates how to generate activation maps from
 the aformentioned model inferences. If you wish to generate your own, use the `--out_bucket` argument to provide an AWS S3 bucket
 where the activation maps will be uploaded to.
@@ -54,16 +51,17 @@ Run a script using the `--help` flag for more information:
 
 ```shell
 $ poetry run python3 semantic_segmentation/seed_test_run.py --help
-usage: seed_test_run.py [-h] [--model MODEL]
-                        [--test_suites TEST_SUITES [TEST_SUITES ...]]
-                        --out_bucket OUT_BUCKET
+usage: seed_test_run.py [-h] [--eval_level EVAL_LEVEL] [--model MODEL]
+                        [--test_suites TEST_SUITES [TEST_SUITES ...]] --out_bucket OUT_BUCKET
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
+  --eval_level EVAL_LEVEL
+                        Number of points on precision/recall curve. Higher value will be more
+                        accurate, but require more compute
   --model MODEL         Name of model in directory to test
   --test_suites TEST_SUITES [TEST_SUITES ...]
                         Name(s) of test suite(s) to test.
   --out_bucket OUT_BUCKET
-                        Name of AWS S3 bucket with write access to
-                        upload result masks to.
+                        Name of AWS S3 bucket with write access to upload result masks to.
 ```

--- a/examples/semantic_segmentation/README.md
+++ b/examples/semantic_segmentation/README.md
@@ -51,14 +51,11 @@ Run a script using the `--help` flag for more information:
 
 ```shell
 $ poetry run python3 semantic_segmentation/seed_test_run.py --help
-usage: seed_test_run.py [-h] [--eval_level EVAL_LEVEL] [--model MODEL]
-                        [--test_suites TEST_SUITES [TEST_SUITES ...]] --out_bucket OUT_BUCKET
+usage: seed_test_run.py [-h] [--model MODEL] [--test_suites TEST_SUITES [TEST_SUITES ...]]
+                        --out_bucket OUT_BUCKET
 
 options:
   -h, --help            show this help message and exit
-  --eval_level EVAL_LEVEL
-                        Number of points on precision/recall curve. Higher value will be more
-                        accurate, but require more compute
   --model MODEL         Name of model in directory to test
   --test_suites TEST_SUITES [TEST_SUITES ...]
                         Name(s) of test suite(s) to test.

--- a/examples/semantic_segmentation/semantic_segmentation/evaluator.py
+++ b/examples/semantic_segmentation/semantic_segmentation/evaluator.py
@@ -107,10 +107,9 @@ def evaluate_test_case(
     gt: List[np.ndarray],
     inf: List[np.ndarray],
     tsm: List[TestSampleMetric],
-    eval_level: int,
 ) -> Tuple[TestCaseMetric, List[CurvePlot]]:
     y_true, y_pred = compute_sklearn_arrays(gt, inf)
-    thresholds = list(np.linspace(0.0, 1.0, eval_level))
+    thresholds = list(np.linspace(0.0, 1.0, 100))
     precisions = []
     recalls = []
     f1s = []
@@ -180,7 +179,7 @@ def evaluate_semantic_segmentation(
     all_test_case_plots: List[Tuple[TestCase, List[CurvePlot]]] = []
     for test_case, _, gt, inf, tsm in test_cases.iter(test_samples, gt_masks, inf_probs, test_sample_metrics):
         info(f"computing {test_case.name} test case metrics")
-        test_case_metrics, test_case_plots = evaluate_test_case(gt, inf, tsm, configuration.eval_level)
+        test_case_metrics, test_case_plots = evaluate_test_case(gt, inf, tsm)
         all_test_case_metrics.append((test_case, test_case_metrics))
         all_test_case_plots.append((test_case, test_case_plots))
 

--- a/examples/semantic_segmentation/semantic_segmentation/seed_test_run.py
+++ b/examples/semantic_segmentation/semantic_segmentation/seed_test_run.py
@@ -33,7 +33,7 @@ from kolena.workflow.asset import BinaryAsset
 from kolena.workflow.test_run import test
 
 
-def seed_test_run(model_name: str, test_suite_names: List[str], eval_level: int) -> None:
+def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
     sanitized_model_name = sanitize_model_name(model_name)
     s3_prefix = f"s3://{BUCKET}/{DATASET}"
 
@@ -49,7 +49,7 @@ def seed_test_run(model_name: str, test_suite_names: List[str], eval_level: int)
     model = Model(f"{model_name}", infer=infer)
     for test_suite_name in test_suite_names:
         test_suite = TestSuite.load(test_suite_name)
-        configurations = [SegmentationConfiguration(eval_level=eval_level, threshold=0.5)]
+        configurations = [SegmentationConfiguration(threshold=0.5)]
 
         test(
             model,
@@ -64,17 +64,12 @@ def main(args: Namespace) -> int:
     kolena.initialize(verbose=True)
     os.environ["KOLENA_MODEL_NAME"] = str(args.model)
     os.environ["KOLENA_OUT_BUCKET"] = str(args.out_bucket)
-    seed_test_run(args.model, args.test_suites, args.eval_level)
+    seed_test_run(args.model, args.test_suites)
     return 0
 
 
 if __name__ == "__main__":
     ap = ArgumentParser()
-    ap.add_argument(
-        "--eval_level",
-        default=100,
-        help="Number of points on precision/recall curve. Higher value will be more accurate, but require more compute",
-    )
     ap.add_argument(
         "--model",
         default="pspnet_r101-d8_4xb4-40k_coco-stuff10k-512x512",

--- a/examples/semantic_segmentation/semantic_segmentation/workflow.py
+++ b/examples/semantic_segmentation/semantic_segmentation/workflow.py
@@ -99,6 +99,7 @@ class Label(Enum):
 
 
 class SegmentationConfiguration(EvaluatorConfiguration):
+    eval_level: int
     threshold: float
 
     def display_name(self) -> str:

--- a/examples/semantic_segmentation/semantic_segmentation/workflow.py
+++ b/examples/semantic_segmentation/semantic_segmentation/workflow.py
@@ -99,7 +99,6 @@ class Label(Enum):
 
 
 class SegmentationConfiguration(EvaluatorConfiguration):
-    eval_level: int
     threshold: float
 
     def display_name(self) -> str:


### PR DESCRIPTION
### Linked issue(s):
Fixes KOL-3731

### What change does this PR introduce and why?
Updates the average precision calculation to use the sampled PR curve. This results in a less accurate AP score, but lowers the compute/memory requirements of the script.
The degree of sampling can be modified with the script argument `--eval_level`.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant docs have been added / updated
