### PR TITLE
[KOL-3748] allow additional headers in client state

### DIFF
--- a/kolena/_utils/krequests.py
+++ b/kolena/_utils/krequests.py
@@ -78,6 +78,8 @@ def _with_default_kwargs(**kwargs: Any) -> Dict[str, Any]:
         "User-Agent": user_agent(client_name, client_version),
         "X-Kolena-Telemetry": str(client_state.telemetry),
     }
+    if client_state.additional_request_headers:
+        default_headers.update(client_state.additional_request_headers)
     return {
         **default_kwargs,
         **kwargs,

--- a/kolena/_utils/krequests.py
+++ b/kolena/_utils/krequests.py
@@ -81,6 +81,9 @@ def _with_default_kwargs(**kwargs: Any) -> Dict[str, Any]:
             "X-Kolena-Telemetry": str(client_state.telemetry),
         },
     )
+    # allow requests to override Content-Type as needed by for example file uploads
+    if "Content-Type" in kwargs.get("headers", {}):
+        default_headers["Content-Type"] = kwargs.get("headers")["Content-Type"]
     return {
         **kwargs,
         **default_kwargs,

--- a/kolena/_utils/krequests.py
+++ b/kolena/_utils/krequests.py
@@ -72,18 +72,19 @@ def _with_default_kwargs(**kwargs: Any) -> Dict[str, Any]:
         "timeout": (CONNECTION_CONNECT_TIMEOUT, CONNECTION_READ_TIMEOUT),
         "proxies": client_state.proxies,
     }
-    default_headers = {
-        "Content-Type": "application/json",
-        "X-Request-ID": uuid.uuid4().hex,
-        "User-Agent": user_agent(client_name, client_version),
-        "X-Kolena-Telemetry": str(client_state.telemetry),
-    }
-    if client_state.additional_request_headers:
-        default_headers.update(client_state.additional_request_headers)
+    default_headers = client_state.additional_request_headers or {}
+    default_headers.update(
+        {
+            "Content-Type": "application/json",
+            "X-Request-ID": uuid.uuid4().hex,
+            "User-Agent": user_agent(client_name, client_version),
+            "X-Kolena-Telemetry": str(client_state.telemetry),
+        },
+    )
     return {
-        **default_kwargs,
         **kwargs,
-        "headers": {**default_headers, **kwargs.get("headers", {})},
+        **default_kwargs,
+        "headers": {**kwargs.get("headers", {}), **default_headers},
     }
 
 

--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -51,6 +51,7 @@ class _ClientState:
         verbose: bool = False,
         telemetry: bool = False,
         proxies: Optional[Dict[str, str]] = None,
+        additional_request_headers: Optional[Dict[str, Any]] = None,
     ):
         self.base_url: Optional[str] = None
         self.api_token: Optional[str] = None
@@ -59,6 +60,7 @@ class _ClientState:
         self.verbose: bool = False
         self.telemetry: bool = False
         self.proxies: Dict[str, str] = {}
+        self.additional_request_headers: Optional[Dict[str, Any]] = None
         self.update(
             base_url=base_url,
             api_token=api_token,
@@ -67,6 +69,7 @@ class _ClientState:
             verbose=verbose,
             telemetry=telemetry,
             proxies=proxies,
+            additional_request_headers=additional_request_headers,
         )
 
     def update(
@@ -78,6 +81,7 @@ class _ClientState:
         verbose: bool = False,
         telemetry: bool = False,
         proxies: Optional[Dict[str, str]] = None,
+        additional_request_headers: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.base_url = base_url or self.base_url
         self.api_token = api_token or self.api_token
@@ -86,6 +90,7 @@ class _ClientState:
         self.verbose = verbose
         self.telemetry = telemetry
         self.proxies = proxies or {}
+        self.additional_request_headers = additional_request_headers or self.additional_request_headers
 
     def assert_initialized(self) -> None:
         if self.base_url is None:
@@ -102,6 +107,7 @@ class _ClientState:
         self.tenant = None
         self.verbose = False
         self.telemetry = False
+        self.additional_request_headers = None
 
 
 def _get_api_base_url() -> str:

--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -89,7 +89,7 @@ class _ClientState:
         self.tenant = tenant or self.tenant
         self.verbose = verbose
         self.telemetry = telemetry
-        self.proxies = proxies or {}
+        self.proxies = proxies or self.proxies
         self.additional_request_headers = additional_request_headers or self.additional_request_headers
 
     def assert_initialized(self) -> None:
@@ -108,6 +108,7 @@ class _ClientState:
         self.verbose = False
         self.telemetry = False
         self.additional_request_headers = None
+        self.proxies = {}
 
 
 def _get_api_base_url() -> str:

--- a/tests/unit/test_krequests.py
+++ b/tests/unit/test_krequests.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from typing import Any
 from typing import Dict
+from typing import Iterator
 from typing import Optional
 from unittest.mock import patch
 
@@ -31,6 +32,14 @@ DEFAULT_HEADERS = {
     "X-Kolena-Telemetry": "False",
 }
 DEFAULT_KWARGS = {"auth": None, "timeout": (15.05, 3600), "proxies": {}}
+
+
+@pytest.fixture(autouse=True)
+def clean_client_state() -> Iterator[None]:
+    try:
+        yield
+    finally:
+        _client_state.reset()
 
 
 @pytest.mark.parametrize(
@@ -58,7 +67,6 @@ def test__with_default_kwargs(
             assert dictionary[expected_key] == expected_val
 
     with patch("kolena._utils.state.get_token", return_value=FIXED_TOKEN_RESPONSE):
-        _client_state.reset()
         kolena.initialize("bar")
         # default kwargs should take priority and cannot be overriden by kwargs
         expected_kwargs = {**{key: kwargs[key] for key in kwargs if key != "headers"}, **DEFAULT_KWARGS}

--- a/tests/unit/test_krequests.py
+++ b/tests/unit/test_krequests.py
@@ -1,0 +1,61 @@
+from typing import Dict, Any, Optional
+from unittest.mock import patch
+
+import pytest
+
+import kolena
+from kolena._utils import krequests
+from kolena._utils.state import _client_state
+from tests.unit.test_initialize import FIXED_TOKEN_RESPONSE
+
+
+DEFAULT_HEADERS = {"Content-Type": "application/json", "X-Request-ID": None, "User-Agent": None, "X-Kolena-Telemetry": "False"}
+DEFAULT_KWARGS = {"auth": None, "timeout": (15.05, 3600), "proxies": {}}
+
+
+@pytest.mark.parametrize(
+    "kwargs, proxies, additional_request_headers",
+    [
+     ({}, None, None),
+     ({}, {}, {}),
+     ({"url": "some-url", "data": {"key": "value"}}, None, None),
+     ({"timeout": (1, 60)}, None, None),  # attempt to override default args
+     ({}, {"http": "dummy-proxy"}, {}),
+     ({}, {}, {"some-header-key": "some-header-val"}),
+     ({}, {}, {"X-Kolena-Telemetry": "off"}),  # attempt to override default headers with client state
+     ({"headers": {"X-Kolena-Telemetry": "off"}}, {}, {}),  # attempt to override default headers with kwargs
+     ({"url": "some-url", "data": {"key": "value"}}, {"http": "dummy-proxy"}, {"X-Kolena-Telemetry": "off"})
+    ]
+)
+def test__with_default_kwargs(kwargs: Dict[str, Any], proxies: Optional[Dict[str, str]], additional_request_headers: Optional[Dict[str, Any]]) -> None:
+    def _assert_dict_key_val(dictionary: Dict[str, Any], expected_key: str, expected_val: Optional[Any]) -> None:
+        assert expected_key in dictionary
+        if expected_val is not None:
+            assert dictionary[expected_key] == expected_val
+
+    with patch("kolena._utils.state.get_token", return_value=FIXED_TOKEN_RESPONSE):
+        _client_state.reset()
+        kolena.initialize("bar")
+        # default kwargs should take priority and cannot be overriden by kwargs
+        expected_kwargs = {**{key: kwargs[key] for key in kwargs if key != "headers"}, **DEFAULT_KWARGS}
+        if proxies is not None:
+            _client_state.update(proxies=proxies)
+            expected_kwargs["proxies"] = proxies
+
+        expected_headers = DEFAULT_HEADERS
+        if additional_request_headers is not None:
+            _client_state.update(additional_request_headers=additional_request_headers)
+            # default headers should take priority and cannot be overriden by additional headers
+            expected_headers = {**additional_request_headers, **DEFAULT_HEADERS}
+
+        # values passed by kwargs should not override default args
+        if "headers" in kwargs:
+            for key in kwargs.get("headers"):
+                if key not in expected_headers:
+                    expected_headers[key] = kwargs.get("headers")[key]
+
+        default_kwargs = krequests._with_default_kwargs(**kwargs)
+        for key in expected_kwargs:
+            _assert_dict_key_val(default_kwargs, key, expected_kwargs[key])
+        for key in expected_headers:
+            _assert_dict_key_val(default_kwargs.get("headers"), key, expected_headers[key])

--- a/tests/unit/test_krequests.py
+++ b/tests/unit/test_krequests.py
@@ -1,4 +1,19 @@
-from typing import Dict, Any, Optional
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any
+from typing import Dict
+from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -9,25 +24,34 @@ from kolena._utils.state import _client_state
 from tests.unit.test_initialize import FIXED_TOKEN_RESPONSE
 
 
-DEFAULT_HEADERS = {"Content-Type": "application/json", "X-Request-ID": None, "User-Agent": None, "X-Kolena-Telemetry": "False"}
+DEFAULT_HEADERS = {
+    "Content-Type": "application/json",
+    "X-Request-ID": None,
+    "User-Agent": None,
+    "X-Kolena-Telemetry": "False",
+}
 DEFAULT_KWARGS = {"auth": None, "timeout": (15.05, 3600), "proxies": {}}
 
 
 @pytest.mark.parametrize(
     "kwargs, proxies, additional_request_headers",
     [
-     ({}, None, None),
-     ({}, {}, {}),
-     ({"url": "some-url", "data": {"key": "value"}}, None, None),
-     ({"timeout": (1, 60)}, None, None),  # attempt to override default args
-     ({}, {"http": "dummy-proxy"}, {}),
-     ({}, {}, {"some-header-key": "some-header-val"}),
-     ({}, {}, {"X-Kolena-Telemetry": "off"}),  # attempt to override default headers with client state
-     ({"headers": {"X-Kolena-Telemetry": "off"}}, {}, {}),  # attempt to override default headers with kwargs
-     ({"url": "some-url", "data": {"key": "value"}}, {"http": "dummy-proxy"}, {"X-Kolena-Telemetry": "off"})
-    ]
+        ({}, None, None),
+        ({}, {}, {}),
+        ({"url": "some-url", "data": {"key": "value"}}, None, None),
+        ({"timeout": (1, 60)}, None, None),  # attempt to override default args
+        ({}, {"http": "dummy-proxy"}, {}),
+        ({}, {}, {"some-header-key": "some-header-val"}),
+        ({}, {}, {"X-Kolena-Telemetry": "off"}),  # attempt to override default headers with client state
+        ({"headers": {"X-Kolena-Telemetry": "off"}}, {}, {}),  # attempt to override default headers with kwargs
+        ({"url": "some-url", "data": {"key": "value"}}, {"http": "dummy-proxy"}, {"X-Kolena-Telemetry": "off"}),
+    ],
 )
-def test__with_default_kwargs(kwargs: Dict[str, Any], proxies: Optional[Dict[str, str]], additional_request_headers: Optional[Dict[str, Any]]) -> None:
+def test__with_default_kwargs(
+    kwargs: Dict[str, Any],
+    proxies: Optional[Dict[str, str]],
+    additional_request_headers: Optional[Dict[str, Any]],
+) -> None:
     def _assert_dict_key_val(dictionary: Dict[str, Any], expected_key: str, expected_val: Optional[Any]) -> None:
         assert expected_key in dictionary
         if expected_val is not None:

--- a/tests/unit/test_krequests.py
+++ b/tests/unit/test_krequests.py
@@ -53,6 +53,7 @@ def clean_client_state() -> Iterator[None]:
         ({}, {}, {"some-header-key": "some-header-val"}),
         ({}, {}, {"X-Kolena-Telemetry": "off"}),  # attempt to override default headers with client state
         ({"headers": {"X-Kolena-Telemetry": "off"}}, {}, {}),  # attempt to override default headers with kwargs
+        ({"headers": {"Content-Type": "application/octet-stream"}}, {}, {}),  # should allow overriding Content-Type
         ({"url": "some-url", "data": {"key": "value"}}, {"http": "dummy-proxy"}, {"X-Kolena-Telemetry": "off"}),
     ],
 )
@@ -83,7 +84,7 @@ def test__with_default_kwargs(
         # values passed by kwargs should not override default args
         if "headers" in kwargs:
             for key in kwargs.get("headers"):
-                if key not in expected_headers:
+                if key not in expected_headers or key == "Content-Type":
                     expected_headers[key] = kwargs.get("headers")[key]
 
         default_kwargs = krequests._with_default_kwargs(**kwargs)


### PR DESCRIPTION
### Linked issue(s):
https://linear.app/kolena/issue/KOL-3748/update-python-sdk-to-take-additional-headers-in-client-state

### What change does this PR introduce and why?
Add `additional_request_headers` to client state that is used to pass in customized headers for each request.


### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
