### PR TITLE
Catch potential bad merge key

### DIFF
--- a/kolena/_experimental/dataset/_evaluation.py
+++ b/kolena/_experimental/dataset/_evaluation.py
@@ -22,6 +22,7 @@ from typing import Tuple
 from typing import Union
 
 import pandas as pd
+from pandas.errors import MergeError
 
 from kolena._api.v2.model import LoadResultsRequest
 from kolena._api.v2.model import Path
@@ -194,7 +195,11 @@ def _align_datapoints_results(
         on = [on]
 
     _validate_on(df_datapoints, df_result_input, on)
-    df_result = df_datapoints[on].merge(df_result_input, how="left", on=on, validate="one_to_one")
+    try:
+        df_result = df_datapoints[on].merge(df_result_input, how="left", on=on, validate="one_to_one")
+    except MergeError as e:
+        raise IncorrectUsageError(f"merge key {on} is not unique") from e
+
     return df_result
 
 

--- a/kolena/_experimental/dataset/_evaluation.py
+++ b/kolena/_experimental/dataset/_evaluation.py
@@ -42,7 +42,6 @@ from kolena._utils.consts import BatchSize
 from kolena._utils.state import API_V2
 from kolena.errors import IncorrectUsageError
 
-
 TYPE_EVALUATION_CONFIG = Optional[Dict[str, Any]]
 TEST_ON_TYPE = Optional[Union[str, List[str]]]
 
@@ -183,7 +182,7 @@ def _validate_on(left: pd.DataFrame, right: pd.DataFrame, on: TEST_ON_TYPE) -> N
                 raise IncorrectUsageError(f"column {col} doesn't exist in target dataframe")
 
 
-def _get_single_df_result(
+def _align_datapoints_results(
     df_datapoints: pd.DataFrame,
     df_result_input: pd.DataFrame,
     on: TEST_ON_TYPE,
@@ -195,7 +194,7 @@ def _get_single_df_result(
         on = [on]
 
     _validate_on(df_datapoints, df_result_input, on)
-    df_result = df_datapoints[on].merge(df_result_input, how="left", on=on)
+    df_result = df_datapoints[on].merge(df_result_input, how="left", on=on, validate="one_to_one")
     return df_result
 
 
@@ -228,7 +227,7 @@ def test(
     all_results: List[Tuple[Optional[TYPE_EVALUATION_CONFIG], pd.DataFrame, pd.DataFrame]] = []
     for config, df_result_input in results:
         log.info(f"start evaluation with configuration {config}" if config else "start evaluation")
-        single_result = _get_single_df_result(df_datapoints, df_result_input, on)
+        single_result = _align_datapoints_results(df_datapoints, df_result_input, on)
         _validate_data(df_datapoints, single_result)
         all_results.append((config, single_result, df_result_input))
         log.info(f"completed evaluation with configuration {config}" if config else "completed evaluation")

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -28,6 +28,7 @@ from kolena._experimental.dataset._evaluation import _align_datapoints_results
 from kolena._experimental.dataset._evaluation import _validate_data
 from kolena._experimental.dataset.common import COL_DATAPOINT
 from kolena._experimental.dataset.common import COL_RESULT
+from kolena.errors import IncorrectUsageError
 from kolena.workflow._datatypes import DATA_TYPE_FIELD
 from kolena.workflow.annotation import BoundingBox
 from kolena.workflow.annotation import ClassificationLabel
@@ -227,9 +228,9 @@ def test__dataframe__data_type_field_not_exist() -> None:
 def test__validate_datapoints_results_alignment() -> None:
     df_datapoints = pd.DataFrame(dict(text=["a", "a", "b", "c"], question=["foo", "bar", "cat", "dog"]))
     df_results = pd.DataFrame(
-        dict(text=["a", "a", "b", "c"], question=["foo", "bar", "cat", "dog"], answer=[1, 2, 3, 4]),
+        dict(text=["a", "a", "b"], question=["foo", "bar", "cat"], answer=[1, 2, 3]),
     )
-    with pytest.raises(pd.errors.MergeError):
+    with pytest.raises(IncorrectUsageError):
         _align_datapoints_results(df_datapoints, df_results, on="text")
 
     df_merged = _align_datapoints_results(df_datapoints, df_results, on=["text", "question"])


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?

Use `validate="one-to-one"` to help user catch bad `on` key(s). Hit this issue myself where the `on` columns I provided was not sufficient for uniqueness, leading to validation error. Cost me quite some time to debug it.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
