### PR TITLE
Add optional `tags` field to Model

### DIFF
--- a/kolena/_api/v1/core.py
+++ b/kolena/_api/v1/core.py
@@ -16,6 +16,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Set
 
 from pydantic.dataclasses import dataclass
 
@@ -28,6 +29,7 @@ class Model:
         name: str
         metadata: Dict[str, Any]
         workflow: str
+        tags: Optional[List[str]] = None
 
     @dataclass(frozen=True)
     class LoadByNameRequest:
@@ -38,6 +40,7 @@ class Model:
         id: int
         name: str
         metadata: Dict[str, Any]
+        tags: Set[str]
         workflow: str
 
     @dataclass(frozen=True)

--- a/tests/integration/workflow/test_model.py
+++ b/tests/integration/workflow/test_model.py
@@ -30,17 +30,19 @@ from tests.integration.workflow.dummy import Model
 from tests.integration.workflow.dummy import TestSuite
 
 META_DATA = {"a": "b"}
+TAGS = {"c", "d"}
 
 
 def assert_model(model: Model, name: str) -> None:
     assert model.workflow == DUMMY_WORKFLOW
     assert model.name == name
     assert model.metadata == META_DATA
+    assert model.tags == TAGS
 
 
 def test__create() -> None:
     name = with_test_prefix(f"{__file__}::test__create model")
-    assert_model(Model.create(name=name, infer=lambda x: None, metadata=META_DATA), name)
+    assert_model(Model.create(name=name, infer=lambda x: None, metadata=META_DATA, tags=TAGS), name)
 
     with pytest.raises(Exception):
         Model.create(name)
@@ -52,7 +54,7 @@ def test__load() -> None:
     with pytest.raises(Exception):
         Model.load(name)
 
-    Model.create(name, infer=lambda x: None, metadata=META_DATA)
+    Model.create(name, infer=lambda x: None, metadata=META_DATA, tags=TAGS)
     assert_model(Model.load(name, infer=lambda x: None), name)
 
 
@@ -65,22 +67,22 @@ def test__load__mismatching_workflows() -> None:
 
 def test__init() -> None:
     name = with_test_prefix(f"{__file__}::test__init model")
-    model = Model(name=name, infer=lambda x: None, metadata=META_DATA)
+    model = Model(name=name, infer=lambda x: None, metadata=META_DATA, tags=TAGS)
     assert_model(model, name)
 
     with pytest.raises(Exception):
         Model.create(name)
 
-    Model(name=name, infer=lambda x: None, metadata=META_DATA)
+    Model(name=name, infer=lambda x: None, metadata=META_DATA, tags=TAGS)
 
     assert_model(Model.load(name, infer=lambda x: None), name)
 
-    updated_model = Model(name=name, infer=lambda x: None, metadata={"a": 13})
+    updated_model = Model(name=name, infer=lambda x: None, metadata={"a": 13}, tags={"e"})
     assert_model(updated_model, name)
 
 
-def test__init_no_meta() -> None:
-    name = with_test_prefix(f"{__file__}::test__init_no_meta")
+def test__init_no_optionals() -> None:
+    name = with_test_prefix(f"{__file__}::test__init_no_optionals")
     model = Model(name=name, infer=lambda x: None)
     loaded = Model.load(name, infer=lambda x: None)
 

--- a/tests/integration/workflow/test_model.py
+++ b/tests/integration/workflow/test_model.py
@@ -66,7 +66,16 @@ def test__load__mismatching_workflows() -> None:
 
 
 def test__init() -> None:
-    name = with_test_prefix(f"{__file__}::test__init model")
+    name = with_test_prefix(f"{__file__}::test__init")
+    model = Model(name=name, infer=lambda x: None)
+    loaded = Model.load(name, infer=lambda x: None)
+
+    assert model.name == loaded.name
+    assert model.metadata == loaded.metadata
+
+
+def test__init_with_optionals() -> None:
+    name = with_test_prefix(f"{__file__}::test__init_with_optionals")
     model = Model(name=name, infer=lambda x: None, metadata=META_DATA, tags=TAGS)
     assert_model(model, name)
 
@@ -78,16 +87,7 @@ def test__init() -> None:
     assert_model(Model.load(name, infer=lambda x: None), name)
 
     updated_model = Model(name=name, infer=lambda x: None, metadata={"a": 13}, tags={"e"})
-    assert_model(updated_model, name)
-
-
-def test__init_no_optionals() -> None:
-    name = with_test_prefix(f"{__file__}::test__init_no_optionals")
-    model = Model(name=name, infer=lambda x: None)
-    loaded = Model.load(name, infer=lambda x: None)
-
-    assert model.name == loaded.name
-    assert model.metadata == loaded.metadata
+    assert_model(updated_model, name)  # Model metadata and tags don't update
 
 
 def test__init__validate_name() -> None:


### PR DESCRIPTION
### Linked issue(s):
Fixes KOL-2315 

### What change does this PR introduce and why?
Adds an optional `tags` field to `Model`. This allows tags to be associated with a Model at creation time via the client.
Prior tags could only be attached to Models via the Kolena web app.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
