### PR TITLE
Revert "Upgrade pillow for security"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,7 @@ requests = ">=2.20,<2.30"  # TODO: revert upper bound when urllib3 situation sor
 requests-toolbelt = "*"
 importlib-metadata = { version = "*", python = "<3.8" }
 tqdm = ">=4,<5"
-Pillow = [
-    { version = "^9.1.1", python = "<3.8" },
-    { version = "^10.0.1", python = ">=3.8" },
-]
+Pillow = "^9.1.1"
 retrying = "^1.3.3"
 Shapely = "^1.8.5"
 deprecation = "^2.1.0"


### PR DESCRIPTION
Reverts kolenaIO/kolena#305

Encountered issues with our existing services/libraries that uses kolena, which some of them adopted old version ceiling.