### PR TITLE
Correct TestSuite `load_all` docstring

### DIFF
--- a/kolena/workflow/test_suite.py
+++ b/kolena/workflow/test_suite.py
@@ -237,12 +237,12 @@ class TestSuite(Frozen, WithTelemetry, metaclass=ABCMeta):
     @with_event(event_name=EventAPI.Event.LOAD_ALL_TEST_SUITES)
     def load_all(cls, *, tags: Optional[Set[str]] = None) -> List["TestSuite"]:
         """
-        Load the latest version of all non-archived test suites with this workflow.
+        Load the latest version of all test suites with this workflow.
 
         :param tags: Optionally specify a set of tags to apply as a filter. The loaded test suites will include only
             test suites with tags matching each of these specified tags, i.e.
             `test_suite.tags.intersection(tags) == tags`.
-        :return: The latest version of all non-archived test suites, with matching tags when specified.
+        :return: The latest version of all test suites, with matching tags when specified.
         """
         cls._validate_workflow()
         request = CoreAPI.LoadAllRequest(workflow=cls.workflow.name, tags=tags)


### PR DESCRIPTION
### What change does this PR introduce and why?
TestSuite.load_all returns both archived and non-archived TestSuites. The archiving feature is currently only possible through the Kolena web app and should be ignored in the client until fully supported.

### Please check if the PR fulfills these requirements
- [x] Relevant docs have been added / updated
