### PR TITLE
[KOL-3748] allow kolena session to have additional headers

### DIFF
--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -169,7 +169,9 @@ def get_token(
 
 @contextlib.contextmanager
 def kolena_session(
-    api_token: str, base_url: Optional[str] = None, additional_request_headers: Optional[Dict[str, Any]] = None
+    api_token: str,
+    base_url: Optional[str] = None,
+    additional_request_headers: Optional[Dict[str, Any]] = None,
 ) -> Iterator[_ClientState]:
     base_url = base_url or _get_api_base_url()
     init_response = get_token(api_token, base_url)

--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -168,7 +168,9 @@ def get_token(
 
 
 @contextlib.contextmanager
-def kolena_session(api_token: str, base_url: Optional[str] = None) -> Iterator[_ClientState]:
+def kolena_session(
+    api_token: str, base_url: Optional[str] = None, additional_request_headers: Optional[Dict[str, Any]] = None
+) -> Iterator[_ClientState]:
     base_url = base_url or _get_api_base_url()
     init_response = get_token(api_token, base_url)
     client_state = _ClientState(
@@ -176,6 +178,7 @@ def kolena_session(api_token: str, base_url: Optional[str] = None) -> Iterator[_
         api_token=api_token,
         jwt_token=init_response.access_token,
         tenant=init_response.tenant,
+        additional_request_headers=additional_request_headers,
     )
     token = CLIENT_STATE.set(client_state)
 

--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -172,6 +172,7 @@ def kolena_session(
     api_token: str,
     base_url: Optional[str] = None,
     additional_request_headers: Optional[Dict[str, Any]] = None,
+    proxies: Optional[Dict[str, str]] = None,
 ) -> Iterator[_ClientState]:
     base_url = base_url or _get_api_base_url()
     init_response = get_token(api_token, base_url)
@@ -181,6 +182,7 @@ def kolena_session(
         jwt_token=init_response.access_token,
         tenant=init_response.tenant,
         additional_request_headers=additional_request_headers,
+        proxies=proxies,
     )
     token = CLIENT_STATE.set(client_state)
 

--- a/tests/unit/test_initialize.py
+++ b/tests/unit/test_initialize.py
@@ -180,6 +180,7 @@ def test__kolena_session() -> None:
     token_2 = "token tenant two"
     additional_headers_1 = {"additional_header_key_one": "additional_header_val_one"}
     additional_headers_2 = {"additional_header_key_two": "additional_header_val_two"}
+    proxies_2 = {"http": "dummy-proxy"}
 
     def check_global_client_state(
         api_token: Optional[str],
@@ -198,16 +199,27 @@ def test__kolena_session() -> None:
             check_global_client_state(None, False)
             assert new_client_state.api_token == token_1
             assert new_client_state.jwt_token == mock_jwt(token_1)
+            assert new_client_state.additional_request_headers is None
+            assert new_client_state.proxies == {}
             _client_state.update(additional_request_headers=additional_headers_1)
             check_global_client_state(None, False, additional_headers_1)
 
-            with kolena_session(token_2, additional_request_headers=additional_headers_2) as inner_state:
+            with kolena_session(
+                token_2,
+                additional_request_headers=additional_headers_2,
+                proxies=proxies_2,
+            ) as inner_state:
                 check_global_client_state(None, False, additional_headers_1)
                 assert inner_state.api_token == token_2
                 assert inner_state.jwt_token == mock_jwt(token_2)
                 assert inner_state.additional_request_headers == additional_headers_2
+                assert inner_state.proxies == proxies_2
+
+                # outer client state should stay the same
                 assert new_client_state.api_token == token_1
                 assert new_client_state.jwt_token == mock_jwt(token_1)
+                assert new_client_state.additional_request_headers is None
+                assert new_client_state.proxies == {}
 
             kolena.initialize(api_token=base_token)
             check_global_client_state(base_token, True, additional_headers_1)

--- a/tests/unit/test_initialize.py
+++ b/tests/unit/test_initialize.py
@@ -178,7 +178,8 @@ def test__kolena_session() -> None:
     base_token = "foobar"
     token_1 = "token tenant one"
     token_2 = "token tenant two"
-    additional_headers = {"additional_header_key": "additional_header_val"}
+    additional_headers_1 = {"additional_header_key_one": "additional_header_val_one"}
+    additional_headers_2 = {"additional_header_key_two": "additional_header_val_two"}
 
     def check_global_client_state(
         api_token: Optional[str],
@@ -197,25 +198,26 @@ def test__kolena_session() -> None:
             check_global_client_state(None, False)
             assert new_client_state.api_token == token_1
             assert new_client_state.jwt_token == mock_jwt(token_1)
-            _client_state.update(additional_request_headers=additional_headers)
-            check_global_client_state(None, False, additional_headers)
+            _client_state.update(additional_request_headers=additional_headers_1)
+            check_global_client_state(None, False, additional_headers_1)
 
-            with kolena_session(token_2) as inner_state:
-                check_global_client_state(None, False, additional_headers)
+            with kolena_session(token_2, additional_request_headers=additional_headers_2) as inner_state:
+                check_global_client_state(None, False, additional_headers_1)
                 assert inner_state.api_token == token_2
                 assert inner_state.jwt_token == mock_jwt(token_2)
+                assert inner_state.additional_request_headers == additional_headers_2
                 assert new_client_state.api_token == token_1
                 assert new_client_state.jwt_token == mock_jwt(token_1)
 
             kolena.initialize(api_token=base_token)
-            check_global_client_state(base_token, True, additional_headers)
+            check_global_client_state(base_token, True, additional_headers_1)
 
             # context-client-state should be used in making SDK requests
             # white-boxy indirect verification
             assert get_client_state() == new_client_state
 
         # verify context closing does not change global client state
-        check_global_client_state(base_token, True, additional_headers)
+        check_global_client_state(base_token, True, additional_headers_1)
         assert get_client_state() == _client_state
 
 


### PR DESCRIPTION
### Linked issue(s):
https://linear.app/kolena/issue/KOL-3748/update-python-sdk-to-take-additional-headers-in-client-state


### What change does this PR introduce and why?
In [a previous PR](https://github.com/kolenaIO/kolena/pull/302), we updated client state to allow `additional_request_headers` in `krequests`. This PR enables `kolena_session` to initialize client states with this argument.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
