### PR TITLE
Bump min Kolena version in examples to 0.94.0

### DIFF
--- a/examples/age_estimation/pyproject.toml
+++ b/examples/age_estimation/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = ">=0.76.0,<1"
+kolena = ">=0.94.0,<1"
 s3fs = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"
 

--- a/examples/automatic_speech_recognition/pyproject.toml
+++ b/examples/automatic_speech_recognition/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = ">=0.92.0,<1"
+kolena = ">=0.94.0,<1"
 s3fs = "^2023.5.0"
 jiwer = "^3.0.3"
 langid = "^1.1.6"

--- a/examples/classification/pyproject.toml
+++ b/examples/classification/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = ">=0.81.0,<1"
+kolena = ">=0.94.0,<1"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/keypoint_detection/pyproject.toml
+++ b/examples/keypoint_detection/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = ">=0.76.0,<1"
+kolena = ">=0.94.0,<1"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/object_detection_2d/pyproject.toml
+++ b/examples/object_detection_2d/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = {extras = ["metrics"], version = ">=0.84.0,<1"}
+kolena = {extras = ["metrics"], version = ">=0.94.0,<1"}
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 

--- a/examples/object_detection_3d/pyproject.toml
+++ b/examples/object_detection_3d/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = ">=0.76.0,<1"
+kolena = ">=0.94.0,<1"
 pydantic = ">=1.10,<2.0"
 openmim = "^0.3.9"
 mmcv-lite = ">=2.0.0rc4"

--- a/examples/object_detection_3d/pyproject.toml
+++ b/examples/object_detection_3d/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Kolena Engineering <eng@kolena.io>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8,<3.11"
 kolena = ">=0.94.0,<1"
 pydantic = ">=1.10,<2.0"
 openmim = "^0.3.9"

--- a/examples/question_answering/pyproject.toml
+++ b/examples/question_answering/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-kolena = ">=0.82.0,<1"
+kolena = ">=0.94.0,<1"
 s3fs = "^2022.7.1"
 torch = [
   {markers = "sys_platform == 'darwin' and platform_machine == 'arm64'", url = "https://download.pytorch.org/whl/cpu/torch-2.0.1-cp39-none-macosx_11_0_arm64.whl"},

--- a/examples/search_embeddings/pyproject.toml
+++ b/examples/search_embeddings/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = ">=0.76.0,<1"
+kolena = ">=0.94.0,<1"
 s3fs = "^2023.5.0"
 kolena-embeddings = {path = "local_packages/kolena_embeddings.tar.gz"}
 

--- a/examples/semantic_segmentation/pyproject.toml
+++ b/examples/semantic_segmentation/pyproject.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 opencv-python-headless = ">=4.6.0.66,<4.7"
-kolena = ">=0.87.0,<1"
+kolena = ">=0.94.0,<1"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"
@@ -21,6 +21,7 @@ scikit-image = "^0.19.3"
 pre-commit = "^2.17"
 pytest = "^7"
 pytest-depends = "^1.0.1"
+memray = "^1.10.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/semantic_segmentation/pyproject.toml
+++ b/examples/semantic_segmentation/pyproject.toml
@@ -21,7 +21,6 @@ scikit-image = "^0.19.3"
 pre-commit = "^2.17"
 pytest = "^7"
 pytest-depends = "^1.0.1"
-memray = "^1.10.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/semantic_textual_similarity/pyproject.toml
+++ b/examples/semantic_textual_similarity/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = ">=0.76.0,<1"
+kolena = ">=0.94.0,<1"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/text_summarization/pyproject.toml
+++ b/examples/text_summarization/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-kolena = ">=0.76.0,<1"
+kolena = ">=0.94.0,<1"
 s3fs = "^2022.7.1"
 scikit-learn = "^1.1.2"
 numba = "^0.56.0"


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?
Bumps the minimum Kolena version for examples up to 0.94.0 to pull to recent `kolena.initialize` API updates.

### Please check if the PR fulfills these requirements

- [ ] Relevant tests for the changes have been added