### PR TITLE
remove ci step that publishes docs to github pages and auto publish docs to s3 during release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,3 +64,6 @@ jobs:
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io"
+        env:
+          DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
+          DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,13 +64,3 @@ jobs:
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io"
-
-      - name: Publish 'kolena' documentation to production (docs.kolena.io)
-        if: inputs.environment == 'production'
-        run: |
-          git config user.name 'kolenabot'
-          git config user.email 'bot@kolena.io'
-          poetry run mkdocs gh-deploy --verbose --strict --remote-branch release/docs --config-file mkdocs.insiders.yml
-        env:
-          DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
-          DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io"
+        env:
+          DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
+          DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}
 
       - name: Push 'kolena' dist to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,15 +49,10 @@ jobs:
       - name: Build 'kolena' Python package
         run: poetry build --format=sdist
 
-      - name: Build 'kolena' documentation and push to GitHub Pages
+      - name: Publish 'kolena' documentation to production (S3)
         run: |
-          git config user.name 'kolenabot'
-          git config user.email 'bot@kolena.io'
-          ./docs/setup_insiders.sh
-          poetry run mkdocs gh-deploy --verbose --strict --remote-branch release/docs --config-file mkdocs.insiders.yml
-        env:
-          DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
-          DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}
+          poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
+          aws s3 sync ./site "s3://docs.kolena.io"
 
       - name: Push 'kolena' dist to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
