### PR TITLE
Fix incorrect inference assigned as TP on AP metrics glossary

### DIFF
--- a/docs/metrics/average-precision.md
+++ b/docs/metrics/average-precision.md
@@ -65,15 +65,15 @@ by their confidence score in descending order.
 | Inference | <nobr>Confidence ↓</nobr> | TP/FP | cumsum(TP) | cumsum(FP) | Precision | Recall |
 | --- | --- | --- | --- | --- | --- | --- |
 | H | 0.99 | TP | 1 | 0 | 1.0 | 0.2 |
-| A | 0.88 | TP | 2 | 0 | 1.0 | 0.4 |
-| D | 0.72 | FP | 2 | 1 | 0.667 | 0.4 |
-| B | 0.70 | FP | 2 | 2 | 0.5 | 0.4 |
-| G | 0.54 | FP | 2 | 3 | 0.4 | 0.4 |
-| E | 0.54 | TP | 3 | 3 | 0.5 | 0.6 |
+| B | 0.88 | TP | 2 | 0 | 1.0 | 0.4 |
+| E | 0.72 | FP | 2 | 1 | 0.667 | 0.4 |
+| A | 0.70 | FP | 2 | 2 | 0.5 | 0.4 |
+| J | 0.54 | FP | 2 | 3 | 0.4 | 0.4 |
+| D | 0.54 | TP | 3 | 3 | 0.5 | 0.6 |
 | I | 0.38 | FP | 4 | 3 | 0.571 | 0.8 |
 | C | 0.2 | FP | 4 | 4 | 0.5 | 0.8 |
 | F | 0.2 | FP | 4 | 5 | 0.444 | 0.8 |
-| J | 0.1 | TP | 5 | 5 | 0.5 | 1.0 |
+| G | 0.1 | TP | 5 | 5 | 0.5 | 1.0 |
 
 !!! info inline end "Guides: TP/FP Counts in Object Detection"
 


### PR DESCRIPTION

<img width="681" alt="image" src="https://github.com/kolenaIO/kolena/assets/17771952/38d0b958-0a90-4998-b19d-1b3d4c14bf95">


### Linked issue(s):
N/A

### What change does this PR introduce and why?
Incorrect inferences used in the example on AP metrics doc

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
