### PR TITLE
invalidate doc cdn cache on deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,6 +64,3 @@ jobs:
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io"
-        env:
-          DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
-          DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,3 +64,6 @@ jobs:
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io"
+        env:
+          DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
+          DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io"
+          aws lambda invoke --function-name docs-cdn-invalidation-lambda --invocation-type RequestResponse --no-cli-pager --region us-west-2 /dev/stdout
         env:
           DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
           DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io"
-          aws lambda invoke --function-name docs-cdn-invalidation-lambda --invocation-type RequestResponse --no-cli-pager --region us-west-2 /dev/stdout
+          aws cloudfront create-invalidation --no-cli-pager --distribution-id ${{ secret.doc_distribution_id }} --paths "/*"
         env:
           DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
           DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io"
-          aws cloudfront create-invalidation --no-cli-pager --distribution-id ${{ secret.doc_distribution_id }} --paths "/*"
+          aws cloudfront create-invalidation --no-cli-pager --distribution-id ${{ var.DOC_DISTRIBUTION_ID }} --paths "/*"
         env:
           DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
           DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io"
+          aws lambda invoke --function-name docs-cdn-invalidation-lambda --invocation-type RequestResponse --no-cli-pager --region us-west-2 /dev/stdout
         env:
           DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
           DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io"
-          aws lambda invoke --function-name docs-cdn-invalidation-lambda --invocation-type RequestResponse --no-cli-pager --region us-west-2 /dev/stdout
+          aws cloudfront create-invalidation --no-cli-pager --distribution-id ${{ secret.doc_distribution_id }} --paths "/*"
         env:
           DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
           DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io"
-          aws cloudfront create-invalidation --no-cli-pager --distribution-id ${{ secret.doc_distribution_id }} --paths "/*"
+          aws cloudfront create-invalidation --no-cli-pager --distribution-id ${{ var.DOC_DISTRIBUTION_ID }} --paths "/*"
         env:
           DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}
           DD_RUM_APPLICATION_ID: ${{ vars.DD_RUM_APPLICATION_ID }}


### PR DESCRIPTION

- invoke a lambda function to invalidate cdn cache when doing prod doc deploy

### Linked issue(s):

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
