### PR TITLE
Average precision doc example fix with graphics update

### DIFF
--- a/docs/assets/images/metrics-ap-od-example-dark.svg
+++ b/docs/assets/images/metrics-ap-od-example-dark.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a802ce3053f6ae04a8b3319f2b16e920829e0f956c152c614938ad47a0dba68c
-size 14244
+oid sha256:15e23590ba416d3410ed06cb261daa03602b48256ef3d1d919b5d10d03f50f58
+size 13638

--- a/docs/assets/images/metrics-ap-od-example-light.svg
+++ b/docs/assets/images/metrics-ap-od-example-light.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26f74ca5c752c42f9a87fbecaa650e044d7cf948352e0f772a4c86dbff474feb
-size 13998
+oid sha256:2abd63f5c0f3ade20d57bbe913d213d2df25c3e73ef570dcebf3303827e0b037
+size 13388

--- a/docs/assets/images/metrics-bbox-legend-gt-dark.svg
+++ b/docs/assets/images/metrics-bbox-legend-gt-dark.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9db08c6f879d1731f729c0ff30b5f25ed3f1d3453e52cd71846321932c723805
+size 18734

--- a/docs/assets/images/metrics-bbox-legend-gt-light.svg
+++ b/docs/assets/images/metrics-bbox-legend-gt-light.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48200e9632037c83b2bd1c6172c052833fc019e7b7f24fe52ed9d1372288dd01
+size 18437

--- a/docs/metrics/average-precision.md
+++ b/docs/metrics/average-precision.md
@@ -52,9 +52,8 @@ slightly differently for both.
 
 Let’s consider the following simple example:
 
-![example legends](../assets/images/metrics-bbox-legend-light.svg#only-light)
-![example legends](../assets/images/metrics-bbox-legend-dark.svg#only-dark)
-
+![example legends](../assets/images/metrics-bbox-legend-gt-light.svg#only-light)
+![example legends](../assets/images/metrics-bbox-legend-gt-dark.svg#only-dark)
 ![object detection example](../assets/images/metrics-ap-od-example-light.svg#only-light)
 ![object detection example](../assets/images/metrics-ap-od-example-dark.svg#only-dark)
 
@@ -70,7 +69,7 @@ by their confidence score in descending order.
 | A | 0.70 | FP | 2 | 2 | 0.5 | 0.4 |
 | J | 0.54 | FP | 2 | 3 | 0.4 | 0.4 |
 | D | 0.54 | TP | 3 | 3 | 0.5 | 0.6 |
-| I | 0.38 | FP | 4 | 3 | 0.571 | 0.8 |
+| I | 0.38 | TP | 4 | 3 | 0.571 | 0.8 |
 | C | 0.2 | FP | 4 | 4 | 0.5 | 0.8 |
 | F | 0.2 | FP | 4 | 5 | 0.444 | 0.8 |
 | G | 0.1 | TP | 5 | 5 | 0.5 | 1.0 |


### PR DESCRIPTION
### Linked issue(s):
N/A

### What change does this PR introduce and why?
* Updated graphics to fix the example on the average precision doc. 

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
