### PR TITLE
Add experimental prebuilt Instance Segmentation workflow

### DIFF
--- a/kolena/_experimental/instance_segmentation/__init__.py
+++ b/kolena/_experimental/instance_segmentation/__init__.py
@@ -1,0 +1,47 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# noreorder
+from .workflow import ClassMetricsPerTestCase
+from .workflow import GroundTruth
+from .workflow import Inference
+from .workflow import Model
+from .workflow import TestCase
+from .workflow import TestCaseMetrics
+from .workflow import TestCaseMetricsSingleClass
+from .workflow import TestSample
+from .workflow import TestSampleMetrics
+from .workflow import TestSampleMetricsSingleClass
+from .workflow import TestSuite
+from .workflow import TestSuiteMetrics
+from .workflow import ThresholdConfiguration
+
+from .evaluator import InstanceSegmentationEvaluator
+
+__all__ = [
+    "TestSample",
+    "GroundTruth",
+    "Inference",
+    "TestCase",
+    "TestSuite",
+    "Model",
+    "TestSampleMetricsSingleClass",
+    "TestCaseMetricsSingleClass",
+    "TestSampleMetrics",
+    "ClassMetricsPerTestCase",
+    "TestCaseMetrics",
+    "TestSuiteMetrics",
+    "ThresholdConfiguration",
+    "InstanceSegmentationEvaluator",
+]

--- a/kolena/_experimental/instance_segmentation/evaluator.py
+++ b/kolena/_experimental/instance_segmentation/evaluator.py
@@ -1,0 +1,121 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+from kolena._experimental.instance_segmentation import GroundTruth
+from kolena._experimental.instance_segmentation import Inference
+from kolena._experimental.instance_segmentation import TestCase
+from kolena._experimental.instance_segmentation import TestCaseMetrics
+from kolena._experimental.instance_segmentation import TestCaseMetricsSingleClass
+from kolena._experimental.instance_segmentation import TestSample
+from kolena._experimental.instance_segmentation import TestSampleMetrics
+from kolena._experimental.instance_segmentation import TestSampleMetricsSingleClass
+from kolena._experimental.instance_segmentation import TestSuite
+from kolena._experimental.instance_segmentation import TestSuiteMetrics
+from kolena._experimental.instance_segmentation import ThresholdConfiguration
+from kolena._experimental.instance_segmentation.evaluator_multiclass import MulticlassInstanceSegmentationEvaluator
+from kolena._experimental.instance_segmentation.evaluator_single_class import SingleClassInstanceSegmentationEvaluator
+from kolena.workflow import Evaluator
+from kolena.workflow import Plot
+
+
+class InstanceSegmentationEvaluator(Evaluator):
+    """
+    This `InstanceSegmentationEvaluator` transforms inferences into metrics for the instance segmentation workflow for
+    single class or multiple classes.
+
+    When a [`ThresholdConfiguration`][kolena._experimental.instance_segmentation.workflow.ThresholdConfiguration] is
+    configured to use an F1-Optimal threshold strategy, the evaluator requires that the first test case retrieved for
+    a test suite contains the complete sample set.
+
+    For additional functionality, see the associated [base class documentation][kolena.workflow.evaluator.Evaluator].
+    """
+
+    # The evaluator class to use for single or multiclass instance segmentation
+    evaluator: Optional[
+        Union[
+            SingleClassInstanceSegmentationEvaluator,
+            MulticlassInstanceSegmentationEvaluator,
+        ]
+    ] = None
+
+    def compute_test_sample_metrics(
+        self,
+        test_case: TestCase,
+        inferences: List[Tuple[TestSample, GroundTruth, Inference]],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> List[Tuple[TestSample, Union[TestSampleMetrics, TestSampleMetricsSingleClass]]]:
+        assert configuration is not None, "must specify configuration"
+
+        # Use complete test case to determine workflow, single class or multiclass
+        if self.evaluator is None:
+            labels = {gt.label for _, gts, _ in inferences for gt in gts.polygons} | {
+                inf.label for _, _, infs in inferences for inf in infs.polygons
+            }
+            if len(labels) >= 2:
+                self.evaluator = MulticlassInstanceSegmentationEvaluator()
+            else:
+                self.evaluator = SingleClassInstanceSegmentationEvaluator()
+
+        return self.evaluator.compute_test_sample_metrics(
+            test_case=test_case,
+            inferences=inferences,
+            configuration=configuration,
+        )
+
+    def compute_test_case_metrics(
+        self,
+        test_case: TestCase,
+        inferences: List[Tuple[TestSample, GroundTruth, Inference]],
+        metrics: List[Union[TestSampleMetrics, TestSampleMetricsSingleClass]],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> Union[TestCaseMetrics, TestCaseMetricsSingleClass]:
+        assert configuration is not None, "must specify configuration"
+        return self.evaluator.compute_test_case_metrics(
+            test_case=test_case,
+            inferences=inferences,
+            metrics=metrics,
+            configuration=configuration,
+        )
+
+    def compute_test_case_plots(
+        self,
+        test_case: TestCase,
+        inferences: List[Tuple[TestSample, GroundTruth, Inference]],
+        metrics: List[Union[TestSampleMetrics, TestSampleMetricsSingleClass]],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> Optional[List[Plot]]:
+        assert configuration is not None, "must specify configuration"
+        return self.evaluator.compute_test_case_plots(
+            test_case=test_case,
+            inferences=inferences,
+            metrics=metrics,
+            configuration=configuration,
+        )
+
+    def compute_test_suite_metrics(
+        self,
+        test_suite: TestSuite,
+        metrics: List[Tuple[TestCase, Union[TestCaseMetrics, TestCaseMetricsSingleClass]]],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> TestSuiteMetrics:
+        assert configuration is not None, "must specify configuration"
+        return self.evaluator.compute_test_suite_metrics(
+            test_suite=test_suite,
+            metrics=metrics,
+            configuration=configuration,
+        )

--- a/kolena/_experimental/instance_segmentation/evaluator_multiclass.py
+++ b/kolena/_experimental/instance_segmentation/evaluator_multiclass.py
@@ -1,0 +1,413 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import defaultdict
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+
+import numpy as np
+
+from kolena._experimental.instance_segmentation import ClassMetricsPerTestCase
+from kolena._experimental.instance_segmentation import GroundTruth
+from kolena._experimental.instance_segmentation import Inference
+from kolena._experimental.instance_segmentation import TestCase
+from kolena._experimental.instance_segmentation import TestCaseMetrics
+from kolena._experimental.instance_segmentation import TestSample
+from kolena._experimental.instance_segmentation import TestSampleMetrics
+from kolena._experimental.instance_segmentation import TestSuite
+from kolena._experimental.instance_segmentation import TestSuiteMetrics
+from kolena._experimental.instance_segmentation import ThresholdConfiguration
+from kolena._experimental.instance_segmentation.utils import filter_inferences
+from kolena._experimental.object_detection.utils import compute_average_precision
+from kolena._experimental.object_detection.utils import compute_confusion_matrix_plot
+from kolena._experimental.object_detection.utils import compute_f1_plot_multiclass
+from kolena._experimental.object_detection.utils import compute_optimal_f1_threshold_multiclass
+from kolena._experimental.object_detection.utils import compute_pr_curve
+from kolena._experimental.object_detection.utils import compute_pr_plot_multiclass
+from kolena.workflow import Evaluator
+from kolena.workflow import Plot
+from kolena.workflow.annotation import ScoredLabel
+from kolena.workflow.metrics import f1_score as compute_f1_score
+from kolena.workflow.metrics import match_inferences_multiclass
+from kolena.workflow.metrics import MulticlassInferenceMatches
+from kolena.workflow.metrics import precision as compute_precision
+from kolena.workflow.metrics import recall as compute_recall
+
+
+class MulticlassInstanceSegmentationEvaluator(Evaluator):
+    """
+    The `MulticlassInstanceSegmentationEvaluator` transforms inferences into metrics for the instance segmentation workflow for
+    multiple classes.
+
+    When a [`ThresholdConfiguration`][kolena._experimental.instance_segmentation.workflow.ThresholdConfiguration] is
+    configured to use an F1-Optimal threshold strategy, the evaluator requires that the first test case retrieved for
+    a test suite contains the complete sample set.
+
+    For additional functionality, see the associated [base class documentation][kolena.workflow.evaluator.Evaluator].
+    """
+
+    threshold_cache: Dict[str, Dict[str, float]] = {}  # configuration -> label -> threshold
+    """
+    Assumes that the first test case retrieved for the test suite contains the complete sample set to be used for
+    F1-Optimal threshold computation. Subsequent requests for a given threshold strategy (for other test cases) will
+    hit this cache and use the previously computed population level confidence thresholds.
+    """
+
+    locators_by_test_case: Dict[str, List[str]] = {}
+    """
+    Keeps track of test sample locators for each test case (used for total # of image count in aggregated metrics).
+    """
+
+    matchings_by_test_case: Dict[str, Dict[str, List[MulticlassInferenceMatches]]] = defaultdict(
+        lambda: defaultdict(list),
+    )
+    """
+    Caches matchings per configuration and test case for faster test case metric and plot computation.
+    """
+
+    def test_sample_metrics_ignored(
+        self,
+    ) -> TestSampleMetrics:
+        return TestSampleMetrics(
+            TP=[],
+            FP=[],
+            FN=[],
+            Confused=[],
+            count_TP=0,
+            count_FP=0,
+            count_FN=0,
+            count_Confused=0,
+            has_TP=False,
+            has_FP=False,
+            has_FN=False,
+            has_Confused=False,
+            ignored=True,
+            max_confidence_above_t=None,
+            min_confidence_above_t=None,
+            thresholds=[],
+        )
+
+    def test_sample_metrics(
+        self,
+        polygon_matches: MulticlassInferenceMatches,
+        thresholds: Dict[str, float],
+    ) -> TestSampleMetrics:
+        tp = [inf for _, inf in polygon_matches.matched if inf.score >= thresholds[inf.label]]
+        fp = [inf for inf in polygon_matches.unmatched_inf if inf.score >= thresholds[inf.label]]
+        fn = [gt for gt, _ in polygon_matches.unmatched_gt] + [
+            gt for gt, inf in polygon_matches.matched if inf.score < thresholds[inf.label]
+        ]
+        confused = [
+            inf for _, inf in polygon_matches.unmatched_gt if inf is not None and inf.score >= thresholds[inf.label]
+        ]
+        non_ignored_inferences = tp + fp
+        scores = [inf.score for inf in non_ignored_inferences]
+        inference_labels = {inf.label for _, inf in polygon_matches.matched} | {
+            inf.label for inf in polygon_matches.unmatched_inf
+        }
+        fields = [
+            ScoredLabel(label=label, score=thresholds[label])
+            for label in sorted(thresholds.keys())
+            if label in inference_labels
+        ]
+        return TestSampleMetrics(
+            TP=tp,
+            FP=fp,
+            FN=fn,
+            Confused=confused,
+            count_TP=len(tp),
+            count_FP=len(fp),
+            count_FN=len(fn),
+            count_Confused=len(confused),
+            has_TP=len(tp) > 0,
+            has_FP=len(fp) > 0,
+            has_FN=len(fn) > 0,
+            has_Confused=len(confused) > 0,
+            ignored=False,
+            max_confidence_above_t=max(scores) if len(scores) > 0 else None,
+            min_confidence_above_t=min(scores) if len(scores) > 0 else None,
+            thresholds=fields,
+        )
+
+    def compute_image_metrics(
+        self,
+        ground_truth: GroundTruth,
+        inference: Inference,
+        configuration: ThresholdConfiguration,
+        test_case_name: str,
+    ) -> TestSampleMetrics:
+        assert configuration is not None, "must specify configuration"
+        thresholds = self.get_confidence_thresholds(configuration)
+        if inference.ignored:
+            return self.test_sample_metrics_ignored()
+
+        filtered_inferences = filter_inferences(
+            inferences=inference.polygons,
+            confidence_score=configuration.min_confidence_score,
+        )
+        polygon_matches: MulticlassInferenceMatches = match_inferences_multiclass(
+            ground_truth.polygons,
+            filtered_inferences,
+            ignored_ground_truths=ground_truth.ignored_polygons,
+            mode="pascal",
+            iou_threshold=configuration.iou_threshold,
+        )
+        self.matchings_by_test_case[configuration.display_name()][test_case_name].append(polygon_matches)
+
+        return self.test_sample_metrics(polygon_matches, thresholds)
+
+    def compute_and_cache_f1_optimal_thresholds(
+        self,
+        configuration: ThresholdConfiguration,
+        inferences: List[Tuple[TestSample, GroundTruth, Inference]],
+    ) -> None:
+        if configuration.threshold_strategy != "F1-Optimal":
+            return
+
+        if configuration.display_name() in self.threshold_cache.keys():
+            return
+
+        all_polygon_matches = [
+            match_inferences_multiclass(
+                ground_truth.polygons,
+                filter_inferences(inferences=inference.polygons, confidence_score=configuration.min_confidence_score),
+                ignored_ground_truths=ground_truth.ignored_polygons,
+                mode="pascal",
+                iou_threshold=configuration.iou_threshold,
+            )
+            for _, ground_truth, inference in inferences
+            if not inference.ignored
+        ]
+        optimal_thresholds = compute_optimal_f1_threshold_multiclass(all_polygon_matches)
+        self.threshold_cache[configuration.display_name()] = defaultdict(
+            lambda: configuration.min_confidence_score,
+            optimal_thresholds,
+        )
+
+    def compute_test_sample_metrics(
+        self,
+        test_case: TestCase,
+        inferences: List[Tuple[TestSample, GroundTruth, Inference]],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> List[Tuple[TestSample, TestSampleMetrics]]:
+        assert configuration is not None, "must specify configuration"
+        # compute thresholds to cache values for subsequent steps
+        self.compute_and_cache_f1_optimal_thresholds(configuration, inferences)
+        return [(ts, self.compute_image_metrics(gt, inf, configuration, test_case.name)) for ts, gt, inf in inferences]
+
+    def polygon_matches_and_count_for_one_label(
+        self,
+        matchings: List[MulticlassInferenceMatches],
+        label: str,
+    ) -> Tuple[MulticlassInferenceMatches, int]:
+        match_matched = []
+        match_unmatched_gt = []
+        match_unmatched_inf = []
+        samples_count = 0
+        # filter the matching to only consider one class
+        for match in matchings:
+            sample_flag = False
+            for gt, inf in match.matched:
+                if gt.label == label:
+                    sample_flag = True
+                    match_matched.append((gt, inf))
+            for gt, inf in match.unmatched_gt:
+                if gt.label == label:
+                    sample_flag = True
+                    match_unmatched_gt.append((gt, inf))
+            for inf in match.unmatched_inf:
+                if inf.label == label:
+                    match_unmatched_inf.append(inf)
+            if sample_flag:
+                samples_count += 1
+
+        polygon_matches_for_one_label = MulticlassInferenceMatches(
+            matched=match_matched,
+            unmatched_gt=match_unmatched_gt,
+            unmatched_inf=match_unmatched_inf,
+        )
+
+        return polygon_matches_for_one_label, samples_count
+
+    def class_metrics_per_test_case(
+        self,
+        label: str,
+        thresholds: Dict[str, float],
+        class_matches: MulticlassInferenceMatches,
+        samples_count: int,
+        average_precision: float,
+    ) -> ClassMetricsPerTestCase:
+        matched = class_matches.matched
+        unmatched_gt = class_matches.unmatched_gt
+        unmatched_inf = class_matches.unmatched_inf
+
+        tp = [inf for _, inf in matched if inf.score >= thresholds[inf.label]]
+        fp = [inf for inf in unmatched_inf if inf.score >= thresholds[inf.label]]
+        fn = [gt for gt, _ in unmatched_gt] + [gt for gt, inf in matched if inf.score < thresholds[inf.label]]
+        tp_count = len(tp)
+        fp_count = len(fp)
+        fn_count = len(fn)
+        precision = compute_precision(tp_count, fp_count)
+        recall = compute_recall(tp_count, fn_count)
+        f1_score = compute_f1_score(tp_count, fp_count, fn_count)
+
+        return ClassMetricsPerTestCase(
+            Class=label,
+            nImages=samples_count,
+            Threshold=thresholds[label],
+            Objects=tp_count + fn_count,
+            Inferences=tp_count + fp_count,
+            TP=tp_count,
+            FN=fn_count,
+            FP=fp_count,
+            Precision=precision,
+            Recall=recall,
+            F1=f1_score,
+            AP=average_precision,
+        )
+
+    def compute_aggregate_label_metrics(
+        self,
+        matchings: List[MulticlassInferenceMatches],
+        label: str,
+        thresholds: Dict[str, float],
+    ) -> ClassMetricsPerTestCase:
+        class_matches, samples_count = self.polygon_matches_and_count_for_one_label(matchings, label)
+
+        average_precision = 0.0
+        baseline_pr_curve = compute_pr_curve([class_matches])
+        if baseline_pr_curve is not None:
+            average_precision = compute_average_precision(baseline_pr_curve.y, baseline_pr_curve.x)
+
+        return self.class_metrics_per_test_case(label, thresholds, class_matches, samples_count, average_precision)
+
+    def test_case_metrics(
+        self,
+        per_class_metrics: List[ClassMetricsPerTestCase],
+        metrics: List[TestSampleMetrics],
+    ) -> TestCaseMetrics:
+        tp_count = sum(im.count_TP for im in metrics)
+        fp_count = sum(im.count_FP for im in metrics)
+        fn_count = sum(im.count_FN for im in metrics)
+        ignored_count = sum(1 if im.ignored else 0 for im in metrics)
+        return TestCaseMetrics(
+            PerClass=per_class_metrics,
+            Objects=tp_count + fn_count,
+            Inferences=tp_count + fp_count,
+            TP=tp_count,
+            FN=fn_count,
+            FP=fp_count,
+            nIgnored=ignored_count,
+            macro_Precision=np.mean([data.Precision for data in per_class_metrics]) if per_class_metrics else 0.0,
+            macro_Recall=np.mean([data.Recall for data in per_class_metrics]) if per_class_metrics else 0.0,
+            macro_F1=np.mean([data.F1 for data in per_class_metrics]) if per_class_metrics else 0.0,
+            mean_AP=np.mean([data.AP for data in per_class_metrics]) if per_class_metrics else 0.0,
+            micro_Precision=compute_precision(tp_count, fp_count),
+            micro_Recall=compute_recall(tp_count, fn_count),
+            micro_F1=compute_f1_score(tp_count, fp_count, fn_count),
+        )
+
+    def compute_test_case_metrics(
+        self,
+        test_case: TestCase,
+        inferences: List[Tuple[TestSample, GroundTruth, Inference]],
+        metrics: List[TestSampleMetrics],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> TestCaseMetrics:
+        assert configuration is not None, "must specify configuration"
+        thresholds = self.get_confidence_thresholds(configuration)
+        all_polygon_matches = self.matchings_by_test_case[configuration.display_name()][test_case.name]
+        self.locators_by_test_case[test_case.name] = [ts.locator for ts, _, _ in inferences]
+
+        # compute nested metrics per class
+        labels = {gt.label for _, gts, _ in inferences for gt in gts.polygons} | {
+            inf.label for _, _, infs in inferences for inf in infs.polygons
+        }
+        per_class_metrics: List[ClassMetricsPerTestCase] = []
+        for label in sorted(labels):
+            metrics_per_class = self.compute_aggregate_label_metrics(all_polygon_matches, label, thresholds)
+            per_class_metrics.append(metrics_per_class)
+
+        return self.test_case_metrics(per_class_metrics, metrics)
+
+    def compute_test_case_plots(
+        self,
+        test_case: TestCase,
+        inferences: List[Tuple[TestSample, GroundTruth, Inference]],
+        metrics: List[TestSampleMetrics],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> Optional[List[Plot]]:
+        assert configuration is not None, "must specify configuration"
+        thresholds = self.get_confidence_thresholds(configuration)
+        all_polygon_matches = self.matchings_by_test_case[configuration.display_name()][test_case.name]
+
+        # clean matching for confusion matrix
+        match_matched = [
+            (gt, inf)
+            for match in all_polygon_matches
+            for gt, inf in match.matched
+            if inf.score >= thresholds[inf.label]
+        ]
+        match_unmatched_gt = [
+            (gt, inf)
+            for match in all_polygon_matches
+            for gt, inf in match.unmatched_gt
+            if inf is not None and inf.score >= thresholds[inf.label]
+        ]
+        confusion_matrix_matchings = [
+            MulticlassInferenceMatches(
+                matched=match_matched,
+                unmatched_gt=match_unmatched_gt,
+                unmatched_inf=[],
+            ),
+        ]
+
+        plots: Optional[List[Plot]] = []
+        plots.extend(
+            filter(
+                None,
+                [
+                    compute_f1_plot_multiclass(all_polygon_matches),
+                    compute_pr_plot_multiclass(all_polygon_matches),
+                    compute_confusion_matrix_plot(confusion_matrix_matchings),
+                ],
+            ),
+        )
+
+        return plots
+
+    def test_suite_metrics(self, unique_locators: Set[str], average_precisions: List[float]) -> TestSuiteMetrics:
+        return TestSuiteMetrics(
+            n_images=len(unique_locators),
+            mean_AP=np.mean(average_precisions) if average_precisions else 0.0,
+        )
+
+    def compute_test_suite_metrics(
+        self,
+        test_suite: TestSuite,
+        metrics: List[Tuple[TestCase, TestCaseMetrics]],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> TestSuiteMetrics:
+        assert configuration is not None, "must specify configuration"
+        unique_locators = {locator for tc, _ in metrics for locator in self.locators_by_test_case[tc.name]}
+        average_precisions = [tcm.mean_AP for _, tcm in metrics]
+        return self.test_suite_metrics(unique_locators, average_precisions)
+
+    def get_confidence_thresholds(self, configuration: ThresholdConfiguration) -> float:
+        if configuration.threshold_strategy == "F1-Optimal":
+            return self.threshold_cache[configuration.display_name()]
+        else:
+            return defaultdict(lambda: configuration.threshold_strategy)

--- a/kolena/_experimental/instance_segmentation/evaluator_multiclass.py
+++ b/kolena/_experimental/instance_segmentation/evaluator_multiclass.py
@@ -49,8 +49,8 @@ from kolena.workflow.metrics import recall as compute_recall
 
 class MulticlassInstanceSegmentationEvaluator(Evaluator):
     """
-    The `MulticlassInstanceSegmentationEvaluator` transforms inferences into metrics for the instance segmentation workflow for
-    multiple classes.
+    The `MulticlassInstanceSegmentationEvaluator` transforms inferences into metrics for the instance segmentation
+    workflow for multiple classes.
 
     When a [`ThresholdConfiguration`][kolena._experimental.instance_segmentation.workflow.ThresholdConfiguration] is
     configured to use an F1-Optimal threshold strategy, the evaluator requires that the first test case retrieved for

--- a/kolena/_experimental/instance_segmentation/evaluator_multiclass.py
+++ b/kolena/_experimental/instance_segmentation/evaluator_multiclass.py
@@ -406,7 +406,7 @@ class MulticlassInstanceSegmentationEvaluator(Evaluator):
         average_precisions = [tcm.mean_AP for _, tcm in metrics]
         return self.test_suite_metrics(unique_locators, average_precisions)
 
-    def get_confidence_thresholds(self, configuration: ThresholdConfiguration) -> float:
+    def get_confidence_thresholds(self, configuration: ThresholdConfiguration) -> Dict[str, float]:
         if configuration.threshold_strategy == "F1-Optimal":
             return self.threshold_cache[configuration.display_name()]
         else:

--- a/kolena/_experimental/instance_segmentation/evaluator_single_class.py
+++ b/kolena/_experimental/instance_segmentation/evaluator_single_class.py
@@ -248,7 +248,12 @@ class SingleClassInstanceSegmentationEvaluator(Evaluator):
 
         return plots
 
-    def test_suite_metrics(self, unique_locators: Set[str], average_precisions: List[float], threshold: float) -> TestSuiteMetrics:
+    def test_suite_metrics(
+        self,
+        unique_locators: Set[str],
+        average_precisions: List[float],
+        threshold: float,
+    ) -> TestSuiteMetrics:
         return TestSuiteMetrics(
             n_images=len(unique_locators),
             mean_AP=np.mean(average_precisions) if average_precisions else 0.0,

--- a/kolena/_experimental/instance_segmentation/evaluator_single_class.py
+++ b/kolena/_experimental/instance_segmentation/evaluator_single_class.py
@@ -46,8 +46,8 @@ from kolena.workflow.metrics import recall as compute_recall
 
 class SingleClassInstanceSegmentationEvaluator(Evaluator):
     """
-    The `SingleClassInstanceSegmentationEvaluator` transforms inferences into metrics for the instance segmentation workflow for
-    a single class.
+    The `SingleClassInstanceSegmentationEvaluator` transforms inferences into metrics for the instance segmentation
+    workflow for a single class.
 
     When a [`ThresholdConfiguration`][kolena._experimental.instance_segmentation.workflow.ThresholdConfiguration] is
     configured to use an F1-Optimal threshold strategy, the evaluator requires that the first test case retrieved for

--- a/kolena/_experimental/instance_segmentation/evaluator_single_class.py
+++ b/kolena/_experimental/instance_segmentation/evaluator_single_class.py
@@ -1,0 +1,272 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import defaultdict
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+
+import numpy as np
+
+from kolena._experimental.instance_segmentation import GroundTruth
+from kolena._experimental.instance_segmentation import Inference
+from kolena._experimental.instance_segmentation import TestCase
+from kolena._experimental.instance_segmentation import TestCaseMetricsSingleClass
+from kolena._experimental.instance_segmentation import TestSample
+from kolena._experimental.instance_segmentation import TestSampleMetricsSingleClass
+from kolena._experimental.instance_segmentation import TestSuite
+from kolena._experimental.instance_segmentation import TestSuiteMetrics
+from kolena._experimental.instance_segmentation import ThresholdConfiguration
+from kolena._experimental.instance_segmentation.utils import filter_inferences
+from kolena._experimental.object_detection.utils import compute_average_precision
+from kolena._experimental.object_detection.utils import compute_f1_plot
+from kolena._experimental.object_detection.utils import compute_optimal_f1_threshold
+from kolena._experimental.object_detection.utils import compute_pr_curve
+from kolena._experimental.object_detection.utils import compute_pr_plot
+from kolena.workflow import Evaluator
+from kolena.workflow import Plot
+from kolena.workflow.metrics import f1_score as compute_f1_score
+from kolena.workflow.metrics import InferenceMatches
+from kolena.workflow.metrics import match_inferences
+from kolena.workflow.metrics import precision as compute_precision
+from kolena.workflow.metrics import recall as compute_recall
+
+
+class SingleClassInstanceSegmentationEvaluator(Evaluator):
+    """
+    The `SingleClassInstanceSegmentationEvaluator` transforms inferences into metrics for the instance segmentation workflow for
+    a single class.
+
+    When a [`ThresholdConfiguration`][kolena._experimental.instance_segmentation.workflow.ThresholdConfiguration] is
+    configured to use an F1-Optimal threshold strategy, the evaluator requires that the first test case retrieved for
+    a test suite contains the complete sample set.
+
+    For additional functionality, see the associated [base class documentation][kolena.workflow.evaluator.Evaluator].
+    """
+
+    threshold_cache: Dict[str, float] = {}  # configuration -> threshold
+    """
+    Assumes that the first test case retrieved for the test suite contains the complete sample set to be used for
+    F1-Optimal threshold computation. Subsequent requests for a given threshold strategy (for other test cases) will
+    hit this cache and use the previously computed population level confidence thresholds.
+    """
+
+    locators_by_test_case: Dict[str, List[str]] = {}
+    """
+    Keeps track of test sample locators for each test case (used for total # of image count in aggregated metrics).
+    """
+
+    matchings_by_test_case: Dict[str, Dict[str, List[InferenceMatches]]] = defaultdict(
+        lambda: defaultdict(list),
+    )
+    """
+    Caches matchings per configuration and test case for faster test case metric and plot computation.
+    """
+
+    def test_sample_metrics_ignored(
+        self,
+        thresholds: float,
+    ) -> TestSampleMetricsSingleClass:
+        return TestSampleMetricsSingleClass(
+            TP=[],
+            FP=[],
+            FN=[],
+            count_TP=0,
+            count_FP=0,
+            count_FN=0,
+            has_TP=False,
+            has_FP=False,
+            has_FN=False,
+            ignored=True,
+            max_confidence_above_t=None,
+            min_confidence_above_t=None,
+            thresholds=thresholds,
+        )
+
+    def test_sample_metrics_single_class(
+        self,
+        polygon_matches: InferenceMatches,
+        thresholds: float,
+    ) -> TestSampleMetricsSingleClass:
+        tp = [inf for _, inf in polygon_matches.matched if inf.score >= thresholds]
+        fp = [inf for inf in polygon_matches.unmatched_inf if inf.score >= thresholds]
+        fn = polygon_matches.unmatched_gt + [gt for gt, inf in polygon_matches.matched if inf.score < thresholds]
+        non_ignored_inferences = tp + fp
+        scores = [inf.score for inf in non_ignored_inferences]
+        return TestSampleMetricsSingleClass(
+            TP=tp,
+            FP=fp,
+            FN=fn,
+            count_TP=len(tp),
+            count_FP=len(fp),
+            count_FN=len(fn),
+            has_TP=len(tp) > 0,
+            has_FP=len(fp) > 0,
+            has_FN=len(fn) > 0,
+            ignored=False,
+            max_confidence_above_t=max(scores) if len(scores) > 0 else None,
+            min_confidence_above_t=min(scores) if len(scores) > 0 else None,
+            thresholds=thresholds,
+        )
+
+    def compute_image_metrics(
+        self,
+        ground_truth: GroundTruth,
+        inference: Inference,
+        configuration: ThresholdConfiguration,
+        test_case_name: str,
+    ) -> TestSampleMetricsSingleClass:
+        assert configuration is not None, "must specify configuration"
+        thresholds = self.get_confidence_thresholds(configuration)
+        if inference.ignored:
+            return self.test_sample_metrics_ignored(thresholds)
+
+        polygon_matches: InferenceMatches = match_inferences(
+            ground_truth.polygons,
+            filter_inferences(inferences=inference.polygons, confidence_score=configuration.min_confidence_score),
+            ignored_ground_truths=ground_truth.ignored_polygons,
+            mode="pascal",
+            iou_threshold=configuration.iou_threshold,
+        )
+        self.matchings_by_test_case[configuration.display_name()][test_case_name].append(polygon_matches)
+
+        return self.test_sample_metrics_single_class(polygon_matches, thresholds)
+
+    def compute_and_cache_f1_optimal_thresholds(
+        self,
+        configuration: ThresholdConfiguration,
+        inferences: List[Tuple[TestSample, GroundTruth, Inference]],
+    ) -> None:
+        if configuration.threshold_strategy != "F1-Optimal":
+            return
+
+        if configuration.display_name() in self.threshold_cache.keys():
+            return
+
+        all_polygon_matches = [
+            match_inferences(
+                ground_truth.polygons,
+                filter_inferences(inferences=inference.polygons, confidence_score=configuration.min_confidence_score),
+                ignored_ground_truths=ground_truth.ignored_polygons,
+                mode="pascal",
+                iou_threshold=configuration.iou_threshold,
+            )
+            for _, ground_truth, inference in inferences
+            if not inference.ignored
+        ]
+        optimal_thresholds = compute_optimal_f1_threshold(all_polygon_matches)
+        self.threshold_cache[configuration.display_name()] = max(configuration.min_confidence_score, optimal_thresholds)
+
+    def compute_test_sample_metrics(
+        self,
+        test_case: TestCase,
+        inferences: List[Tuple[TestSample, GroundTruth, Inference]],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> List[Tuple[TestSample, TestSampleMetricsSingleClass]]:
+        assert configuration is not None, "must specify configuration"
+        # compute thresholds to cache values for subsequent steps
+        self.compute_and_cache_f1_optimal_thresholds(configuration, inferences)
+        return [(ts, self.compute_image_metrics(gt, inf, configuration, test_case.name)) for ts, gt, inf in inferences]
+
+    def test_case_metrics_single_class(
+        self,
+        metrics: List[TestSampleMetricsSingleClass],
+        average_precision: float,
+    ) -> TestCaseMetricsSingleClass:
+        tp_count = sum(im.count_TP for im in metrics)
+        fp_count = sum(im.count_FP for im in metrics)
+        fn_count = sum(im.count_FN for im in metrics)
+        ignored_count = sum(1 if im.ignored else 0 for im in metrics)
+
+        precision = compute_precision(tp_count, fp_count)
+        recall = compute_recall(tp_count, fn_count)
+        f1_score = compute_f1_score(tp_count, fp_count, fn_count)
+
+        return TestCaseMetricsSingleClass(
+            Objects=tp_count + fn_count,
+            Inferences=tp_count + fp_count,
+            TP=tp_count,
+            FN=fn_count,
+            FP=fp_count,
+            nIgnored=ignored_count,
+            Precision=precision,
+            Recall=recall,
+            F1=f1_score,
+            AP=average_precision,
+        )
+
+    def compute_test_case_metrics(
+        self,
+        test_case: TestCase,
+        inferences: List[Tuple[TestSample, GroundTruth, Inference]],
+        metrics: List[TestSampleMetricsSingleClass],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> TestCaseMetricsSingleClass:
+        assert configuration is not None, "must specify configuration"
+        all_polygon_matches = self.matchings_by_test_case[configuration.display_name()][test_case.name]
+        self.locators_by_test_case[test_case.name] = [ts.locator for ts, _, _ in inferences]
+
+        average_precision = 0.0
+        baseline_pr_curve = compute_pr_curve(all_polygon_matches)
+        if baseline_pr_curve is not None:
+            average_precision = compute_average_precision(baseline_pr_curve.y, baseline_pr_curve.x)
+
+        return self.test_case_metrics_single_class(metrics, average_precision)
+
+    def compute_test_case_plots(
+        self,
+        test_case: TestCase,
+        inferences: List[Tuple[TestSample, GroundTruth, Inference]],
+        metrics: List[TestSampleMetricsSingleClass],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> Optional[List[Plot]]:
+        assert configuration is not None, "must specify configuration"
+        all_polygon_matches = self.matchings_by_test_case[configuration.display_name()][test_case.name]
+
+        plots: Optional[List[Plot]] = []
+        plots.extend(
+            filter(
+                None,
+                [
+                    compute_pr_plot(all_polygon_matches),
+                    compute_f1_plot(all_polygon_matches),
+                ],
+            ),
+        )
+
+        return plots
+
+    def test_suite_metrics(self, unique_locators: Set[str], average_precisions: List[float]) -> TestSuiteMetrics:
+        return TestSuiteMetrics(
+            n_images=len(unique_locators),
+            mean_AP=np.mean(average_precisions) if average_precisions else 0.0,
+        )
+
+    def compute_test_suite_metrics(
+        self,
+        test_suite: TestSuite,
+        metrics: List[Tuple[TestCase, TestCaseMetricsSingleClass]],
+        configuration: Optional[ThresholdConfiguration] = None,
+    ) -> TestSuiteMetrics:
+        assert configuration is not None, "must specify configuration"
+        unique_locators = {locator for tc, _ in metrics for locator in self.locators_by_test_case[tc.name]}
+        average_precisions = [tcm.AP for _, tcm in metrics]
+        return self.test_suite_metrics(unique_locators, average_precisions)
+
+    def get_confidence_thresholds(self, configuration: ThresholdConfiguration) -> float:
+        if configuration.threshold_strategy == "F1-Optimal":
+            return self.threshold_cache[configuration.display_name()]
+        else:
+            return configuration.threshold_strategy

--- a/kolena/_experimental/instance_segmentation/utils.py
+++ b/kolena/_experimental/instance_segmentation/utils.py
@@ -1,0 +1,31 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+from typing import Optional
+from typing import Set
+
+from kolena.workflow.annotation import ScoredLabeledPolygon
+
+
+def filter_inferences(
+    inferences: List[ScoredLabeledPolygon],
+    confidence_score: Optional[float] = None,
+    labels: Optional[Set[str]] = None,
+) -> List[ScoredLabeledPolygon]:
+    filtered_by_confidence = (
+        [inf for inf in inferences if inf.score >= confidence_score] if confidence_score else inferences
+    )
+    if labels is None:
+        return filtered_by_confidence
+    return [inf for inf in filtered_by_confidence if inf.label in labels]

--- a/kolena/_experimental/instance_segmentation/workflow.py
+++ b/kolena/_experimental/instance_segmentation/workflow.py
@@ -1,0 +1,215 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import dataclasses
+from typing import List
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+from typing import Optional
+from typing import Union
+
+from pydantic.dataclasses import dataclass
+
+from kolena.workflow import define_workflow
+from kolena.workflow import EvaluatorConfiguration
+from kolena.workflow import GroundTruth as BaseGroundTruth
+from kolena.workflow import Image
+from kolena.workflow import Inference as BaseInference
+from kolena.workflow import Metadata
+from kolena.workflow import MetricsTestCase
+from kolena.workflow import MetricsTestSample
+from kolena.workflow import MetricsTestSuite
+from kolena.workflow.annotation import LabeledPolygon
+from kolena.workflow.annotation import ScoredLabel
+from kolena.workflow.annotation import ScoredLabeledPolygon
+
+
+@dataclass(frozen=True)
+class TestSample(Image):
+    """The [`Image`][kolena.workflow.Image] sample type for the pre-built 2D Instance Segmentation workflow."""
+
+    metadata: Metadata = dataclasses.field(default_factory=dict)
+    """The optional [`Metadata`][kolena.workflow.Metadata] dictionary."""
+
+
+@dataclass(frozen=True)
+class GroundTruth(BaseGroundTruth):
+    """Ground truth type for the pre-built 2D Instance Segmentation workflow."""
+
+    polygons: List[LabeledPolygon]
+    """
+    The ground truth [`LabeledPolygons`][kolena.workflow.annotation.LabeledPolygon] associated with an image.
+    """
+
+    ignored_polygons: List[LabeledPolygon] = dataclasses.field(default_factory=list)
+    """
+    The ground truth [`LabeledPolygons`][kolena.workflow.annotation.LabeledPolygon] to be ignored in evaluation
+    associated with an image.
+    """
+
+    n_polygons: int = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        object.__setattr__(self, "n_polygons", len(self.polygons))
+
+
+@dataclass(frozen=True)
+class Inference(BaseInference):
+    """Inference type for the pre-built 2D Instance Segmentation workflow."""
+
+    polygons: List[ScoredLabeledPolygon]
+    """
+    The inference [`ScoredLabeledPolygons`][kolena.workflow.annotation.ScoredLabeledPolygons] associated with
+    an image.
+    """
+    ignored: bool = False
+    """
+    Whether the image (and its associated inference `polygons`) should be ignored in evaluating the results of the model.
+    """
+
+
+_, TestCase, TestSuite, Model = define_workflow(
+    "Instance Segmentation",
+    TestSample,
+    GroundTruth,
+    Inference,
+)
+
+
+@dataclass(frozen=True)
+class TestSampleMetricsSingleClass(MetricsTestSample):
+    TP: List[ScoredLabeledPolygon]
+    FP: List[ScoredLabeledPolygon]
+    FN: List[LabeledPolygon]
+
+    count_TP: int
+    count_FP: int
+    count_FN: int
+
+    has_TP: bool
+    has_FP: bool
+    has_FN: bool
+    ignored: bool
+
+    max_confidence_above_t: Optional[float]
+    min_confidence_above_t: Optional[float]
+    thresholds: float
+
+
+@dataclass(frozen=True)
+class TestCaseMetricsSingleClass(MetricsTestCase):
+    Objects: int
+    Inferences: int
+    TP: int
+    FN: int
+    FP: int
+    nIgnored: int
+    Precision: float
+    Recall: float
+    F1: float
+    AP: float
+
+
+@dataclass(frozen=True)
+class TestSampleMetrics(MetricsTestSample):
+    TP: List[ScoredLabeledPolygon]
+    FP: List[ScoredLabeledPolygon]
+    FN: List[LabeledPolygon]
+    Confused: List[ScoredLabeledPolygon]
+
+    count_TP: int
+    count_FP: int
+    count_FN: int
+    count_Confused: int
+
+    has_TP: bool
+    has_FP: bool
+    has_FN: bool
+    has_Confused: bool
+    ignored: bool
+
+    max_confidence_above_t: Optional[float]
+    min_confidence_above_t: Optional[float]
+    thresholds: List[ScoredLabel]
+
+
+@dataclass(frozen=True)
+class ClassMetricsPerTestCase(MetricsTestCase):
+    Class: str
+    nImages: int
+    Threshold: float
+    Objects: int
+    Inferences: int
+    TP: int
+    FN: int
+    FP: int
+    Precision: float
+    Recall: float
+    F1: float
+    AP: float
+
+
+@dataclass(frozen=True)
+class TestCaseMetrics(MetricsTestCase):
+    PerClass: List[ClassMetricsPerTestCase]
+    Objects: int
+    Inferences: int
+    TP: int
+    FN: int
+    FP: int
+    nIgnored: int
+    macro_Precision: float
+    macro_Recall: float
+    macro_F1: float
+    mean_AP: float
+    micro_Precision: float
+    micro_Recall: float
+    micro_F1: float
+
+
+@dataclass(frozen=True)
+class TestSuiteMetrics(MetricsTestSuite):
+    n_images: int
+    mean_AP: float
+
+
+@dataclass(frozen=True)
+class ThresholdConfiguration(EvaluatorConfiguration):
+    """
+    Confidence and [IoU ↗](../../metrics/iou.md) threshold configuration for the pre-built 2D Instance Segmentation workflow.
+    Specify a confidence and IoU threshold to apply to all classes.
+    """
+
+    threshold_strategy: Union[Literal["F1-Optimal"], float] = "F1-Optimal"
+    """The confidence threshold strategy. It can either be a fixed confidence threshold such as `0.3` or `0.75`, or
+    the F1-optimal threshold by default."""
+
+    iou_threshold: float = 0.5
+    """The [IoU ↗](../../metrics/iou.md) threshold, defaulting to `0.5`."""
+
+    min_confidence_score: float = 0.0
+    """
+    The minimum confidence score to consider for the evaluation. This is usually set to reduce noise by excluding
+    inferences with low confidence score.
+    """
+
+    def display_name(self) -> str:
+        return (
+            f"Confidence Threshold: {self.threshold_strategy}, "
+            f"IoU: {self.iou_threshold}, "
+            f"min confidence ≥ {self.min_confidence_score}"
+        )

--- a/kolena/_experimental/instance_segmentation/workflow.py
+++ b/kolena/_experimental/instance_segmentation/workflow.py
@@ -107,7 +107,7 @@ class TestSampleMetricsSingleClass(MetricsTestSample):
 
     max_confidence_above_t: Optional[float]
     min_confidence_above_t: Optional[float]
-    thresholds: float
+    threshold: float
 
 
 @dataclass(frozen=True)
@@ -185,6 +185,7 @@ class TestCaseMetrics(MetricsTestCase):
 class TestSuiteMetrics(MetricsTestSuite):
     n_images: int
     mean_AP: float
+    threshold: Union[float, None] = None
 
 
 @dataclass(frozen=True)

--- a/kolena/_experimental/instance_segmentation/workflow.py
+++ b/kolena/_experimental/instance_segmentation/workflow.py
@@ -78,7 +78,7 @@ class Inference(BaseInference):
     """
     ignored: bool = False
     """
-    Whether the image (and its associated inference `polygons`) should be ignored in evaluating the results of the model.
+    Whether the image (and associated inference `polygons`) should be ignored in evaluating the results of the model.
     """
 
 
@@ -190,7 +190,8 @@ class TestSuiteMetrics(MetricsTestSuite):
 @dataclass(frozen=True)
 class ThresholdConfiguration(EvaluatorConfiguration):
     """
-    Confidence and [IoU ↗](../../metrics/iou.md) threshold configuration for the pre-built 2D Instance Segmentation workflow.
+    Confidence and [IoU ↗](../../metrics/iou.md) threshold configuration for the pre-built
+    2D Instance Segmentation workflow.
     Specify a confidence and IoU threshold to apply to all classes.
     """
 

--- a/tests/integration/_experimental/instance_segmentation/__init__.py
+++ b/tests/integration/_experimental/instance_segmentation/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integration/_experimental/instance_segmentation/test_evaluator_multiclass_f1_optimal.py
+++ b/tests/integration/_experimental/instance_segmentation/test_evaluator_multiclass_f1_optimal.py
@@ -1,0 +1,513 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+from typing import Tuple
+
+import pytest
+
+from kolena.workflow.annotation import LabeledPolygon
+from kolena.workflow.annotation import ScoredLabel
+from kolena.workflow.annotation import ScoredLabeledPolygon
+from kolena.workflow.plot import ConfusionMatrix
+from kolena.workflow.plot import Curve
+from kolena.workflow.plot import CurvePlot
+from tests.integration._experimental.instance_segmentation.test_evaluator_multiclass_fixed import (
+    assert_curve_plot_equal,
+)
+from tests.integration._experimental.instance_segmentation.test_evaluator_multiclass_fixed import (
+    assert_test_case_metrics_equals_expected,
+)
+from tests.integration._experimental.instance_segmentation.test_evaluator_multiclass_fixed import TEST_DATA
+from tests.integration.helper import fake_locator
+from tests.integration.helper import with_test_prefix
+
+
+instance_segmentation = pytest.importorskip("kolena._experimental.instance_segmentation", reason="requires kolena[metrics] extra")
+InstanceSegmentationEvaluator = instance_segmentation.InstanceSegmentationEvaluator
+TestCase = instance_segmentation.TestCase
+ClassMetricsPerTestCase = instance_segmentation.ClassMetricsPerTestCase
+TestCaseMetrics = instance_segmentation.TestCaseMetrics
+TestSample = instance_segmentation.TestSample
+TestSampleMetrics = instance_segmentation.TestSampleMetrics
+ThresholdConfiguration = instance_segmentation.ThresholdConfiguration
+
+
+EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetrics]] = [
+    (
+        TestSample(locator=fake_locator(112, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "c", 0.8),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "d", 0.7),
+            ],
+            FP=[],
+            FN=[],
+            Confused=[],
+            count_TP=4,
+            count_FP=0,
+            count_FN=0,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=False,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.7,
+            thresholds=[
+                ScoredLabel("a", 0.1),
+                ScoredLabel("b", 0.4),
+                ScoredLabel("c", 0.8),
+                ScoredLabel("d", 0.7),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(113, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1.1, 1), (1.1, 2), (2, 1.1), (2, 2)], "a", 0.9),
+            ],
+            FP=[
+                ScoredLabeledPolygon([(3.2, 3), (3.2, 4), (4, 3.2), (4, 4)], "a", 0.8),
+                ScoredLabeledPolygon([(5.3, 5), (5.3, 6), (6, 5.3), (6, 6)], "a", 0.7),
+                ScoredLabeledPolygon([(7.4, 7), (7.4, 8), (8, 7.4), (8, 8)], "b", 1),
+            ],
+            FN=[
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "b"),
+            ],
+            Confused=[],
+            count_TP=1,
+            count_FP=3,
+            count_FN=3,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=True,
+            has_FN=True,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.7,
+            thresholds=[
+                ScoredLabel("a", 0.1),
+                ScoredLabel("b", 0.4),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(114, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.6),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b", 0.5),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b", 0.4),
+            ],
+            FP=[],
+            FN=[],
+            Confused=[],
+            count_TP=4,
+            count_FP=0,
+            count_FN=0,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=False,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=0.6,
+            min_confidence_above_t=0.1,
+            thresholds=[
+                ScoredLabel("a", 0.1),
+                ScoredLabel("b", 0.4),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(115, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.8),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b", 0.9),
+            ],
+            FP=[
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.9),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.8),
+            ],
+            FN=[],
+            Confused=[],
+            count_TP=4,
+            count_FP=4,
+            count_FN=0,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=True,
+            has_FN=False,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.8,
+            thresholds=[
+                ScoredLabel("a", 0.1),
+                ScoredLabel("b", 0.4),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(116, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.4),
+            ],
+            FP=[],
+            FN=[
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b"),
+            ],
+            Confused=[],
+            count_TP=2,
+            count_FP=0,
+            count_FN=2,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=True,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.4,
+            thresholds=[
+                ScoredLabel("a", 0.1),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(117, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.9)],
+            FP=[ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "b", 0.9)],
+            FN=[
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "c"),
+            ],
+            Confused=[ScoredLabeledPolygon([(7.0, 7.0), (7.0, 8.0), (8.0, 7.0), (8.0, 8.0)], "b", 0.9)],
+            count_TP=1,
+            count_FP=1,
+            count_FN=3,
+            count_Confused=1,
+            has_TP=True,
+            has_FP=True,
+            has_FN=True,
+            has_Confused=True,
+            ignored=False,
+            max_confidence_above_t=0.9,
+            min_confidence_above_t=0.9,
+            thresholds=[
+                ScoredLabel("a", 0.1),
+                ScoredLabel("b", 0.4),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(118, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "c", 0.8),
+            ],
+            FP=[],
+            FN=[],
+            Confused=[],
+            count_TP=2,
+            count_FP=0,
+            count_FN=0,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=False,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=0.9,
+            min_confidence_above_t=0.8,
+            thresholds=[
+                ScoredLabel("a", 0.1),
+                ScoredLabel("c", 0.8),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(119, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "e", 0.8),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "e", 0.7),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "e", 0.6),
+                ScoredLabeledPolygon([(9, 9), (9, 10), (10, 9), (10, 10)], "e", 0.1),
+            ],
+            FP=[
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 1),
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.8),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.1),
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "b", 0.9),
+                ScoredLabeledPolygon([(10, 10), (10, 11), (11, 10), (11, 11)], "b", 0.7),
+                ScoredLabeledPolygon([(12, 12), (12, 13), (13, 12), (13, 13)], "b", 0.6),
+            ],
+            FN=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "e"),
+                LabeledPolygon([(11, 11), (11, 12), (12, 11), (12, 12)], "e"),
+                LabeledPolygon([(13, 13), (13, 14), (14, 13), (14, 14)], "e"),
+                LabeledPolygon([(15, 15), (15, 16), (16, 15), (16, 16)], "e"),
+                LabeledPolygon([(17, 17), (17, 18), (18, 17), (18, 18)], "e"),
+                LabeledPolygon([(19, 19), (19, 20), (20, 19), (20, 20)], "e"),
+            ],
+            Confused=[ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9)],
+            count_TP=4,
+            count_FP=7,
+            count_FN=6,
+            count_Confused=1,
+            has_TP=True,
+            has_FP=True,
+            has_FN=True,
+            has_Confused=True,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.1,
+            thresholds=[
+                ScoredLabel("a", 0.1),
+                ScoredLabel("b", 0.4),
+                ScoredLabel("e", 0.1),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(120, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[],
+            FP=[],
+            FN=[],
+            Confused=[],
+            count_TP=0,
+            count_FP=0,
+            count_FN=0,
+            count_Confused=0,
+            has_TP=False,
+            has_FP=False,
+            has_FN=False,
+            has_Confused=False,
+            ignored=True,
+            max_confidence_above_t=None,
+            min_confidence_above_t=None,
+            thresholds=[],
+        ),
+    ),
+]
+
+
+EXPECTED_COMPUTE_TEST_CASE_METRICS = TestCaseMetrics(
+    PerClass=[
+        ClassMetricsPerTestCase(
+            Class="a",
+            nImages=7,
+            Threshold=0.1,
+            Objects=14,
+            Inferences=20,
+            TP=10,
+            FN=4,
+            FP=10,
+            Precision=0.5,
+            Recall=10 / 14,
+            F1=10 / 17,
+            AP=29 / 77,
+        ),
+        ClassMetricsPerTestCase(
+            Class="b",
+            nImages=5,
+            Threshold=0.4,
+            Objects=8,
+            Inferences=10,
+            TP=5,
+            FN=3,
+            FP=5,
+            Precision=0.5,
+            Recall=5 / 8,
+            F1=5 / 9,
+            AP=5 / 16,
+        ),
+        ClassMetricsPerTestCase(
+            Class="c",
+            nImages=3,
+            Threshold=0.8,
+            Objects=3,
+            Inferences=2,
+            TP=2,
+            FN=1,
+            FP=0,
+            Precision=1,
+            Recall=2 / 3,
+            F1=0.8,
+            AP=2 / 3,
+        ),
+        ClassMetricsPerTestCase(
+            Class="d",
+            nImages=1,
+            Threshold=0.7,
+            Objects=1,
+            Inferences=1,
+            TP=1,
+            FN=0,
+            FP=0,
+            Precision=1,
+            Recall=1,
+            F1=1,
+            AP=1,
+        ),
+        ClassMetricsPerTestCase(
+            Class="e",
+            nImages=1,
+            Threshold=0.1,
+            Objects=10,
+            Inferences=4,
+            TP=4,
+            FN=6,
+            FP=0,
+            Precision=1,
+            Recall=0.4,
+            F1=4 / 7,
+            AP=0.4,
+        ),
+    ],
+    Objects=36,
+    Inferences=37,
+    TP=22,
+    FN=14,
+    FP=15,
+    nIgnored=1,
+    macro_Precision=0.8,
+    macro_Recall=641 / 941,
+    macro_F1=670 / 953,
+    mean_AP=404 / 733,
+    micro_Precision=22 / 37,
+    micro_Recall=11 / 18,
+    micro_F1=44 / 73,
+)
+
+
+EXPECTED_CONFUSION_MATRIX = ConfusionMatrix(
+    title="Confusion Matrix",
+    labels=["a", "b", "c", "d", "e"],
+    matrix=[[10, 1, 0, 0, 0], [0, 5, 0, 0, 0], [0, 0, 2, 0, 0], [0, 0, 0, 1, 0], [1, 0, 0, 0, 4]],
+    x_label="Predicted",
+    y_label="Actual",
+)
+
+
+EXPECTED_F1_CURVE_PLOT = CurvePlot(
+    title="F1-Score vs. Confidence Threshold Per Class",
+    x_label="Confidence Threshold",
+    y_label="F1-Score",
+    curves=[
+        Curve(
+            x=[0.1, 0.4, 0.6, 0.8, 0.9, 1],
+            y=[10 / 17, 9 / 16, 16 / 31, 14 / 29, 12 / 25, 0.3],
+            label="a",
+            extra={
+                "Precision": [0.5, 0.5, 8 / 17, 7 / 15, 6 / 11, 0.5],
+                "Recall": [5 / 7, 9 / 14, 4 / 7, 0.5, 3 / 7, 3 / 14],
+            },
+        ),
+        Curve(
+            x=[0.4, 0.5, 0.9, 1],
+            y=[5 / 9, 8 / 17, 3 / 7, 0],
+            label="b",
+            extra={
+                "Precision": [0.5, 4 / 9, 0.5, 0],
+                "Recall": [5 / 8, 0.5, 3 / 8, 0],
+            },
+        ),
+        Curve(
+            x=[0.1, 0.6, 0.7, 0.8],
+            y=[4 / 7, 6 / 13, 1 / 3, 2 / 11],
+            label="e",
+            extra={
+                "Precision": [1.0, 1.0, 1.0, 1.0],
+                "Recall": [0.4, 0.3, 0.2, 0.1],
+            },
+        ),
+    ],
+    x_config=None,
+    y_config=None,
+)
+
+
+@pytest.mark.metrics
+def test__instance_segmentation__multiclass_evaluator__f1_optimal() -> None:
+    TEST_CASE_NAME = "multiclass IS test"
+    TEST_CASE = TestCase(with_test_prefix(TEST_CASE_NAME + " case"))
+    config = ThresholdConfiguration(
+        min_confidence_score=0.1,
+    )
+
+    eval = InstanceSegmentationEvaluator(configurations=[config])
+
+    test_sample_metrics = eval.compute_test_sample_metrics(
+        test_case=TEST_CASE,
+        inferences=TEST_DATA,
+        configuration=config,
+    )
+
+    assert config.display_name() in eval.evaluator.threshold_cache
+    assert "b" in eval.evaluator.threshold_cache[config.display_name()]
+    assert eval.evaluator.threshold_cache[config.display_name()]["b"] == 0.4
+    assert len(eval.evaluator.matchings_by_test_case) != 0
+    assert len(eval.evaluator.matchings_by_test_case[config.display_name()]) != 0
+    num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
+    assert (
+        len(eval.evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
+        == len(TEST_DATA) - num_of_ignored
+    )
+    assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
+
+    test_case_metrics = eval.compute_test_case_metrics(
+        test_case=TEST_CASE,
+        inferences=TEST_DATA,
+        metrics=[pair[1] for pair in EXPECTED_COMPUTE_TEST_SAMPLE_METRICS],
+        configuration=config,
+    )
+
+    assert TEST_CASE.name in eval.evaluator.locators_by_test_case
+    assert len(eval.evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
+    assert_test_case_metrics_equals_expected(test_case_metrics, EXPECTED_COMPUTE_TEST_CASE_METRICS)
+
+    # test case plots only use the cached values
+    plots = eval.compute_test_case_plots(
+        test_case=TEST_CASE,
+        inferences=[],
+        metrics=[],
+        configuration=config,
+    )
+    assert_curve_plot_equal(plots[0], EXPECTED_F1_CURVE_PLOT)
+    assert plots[2] == EXPECTED_CONFUSION_MATRIX
+
+    # test suite behaviour is consistent with fixed evaluator

--- a/tests/integration/_experimental/instance_segmentation/test_evaluator_multiclass_f1_optimal.py
+++ b/tests/integration/_experimental/instance_segmentation/test_evaluator_multiclass_f1_optimal.py
@@ -34,7 +34,8 @@ from tests.integration.helper import with_test_prefix
 
 
 instance_segmentation = pytest.importorskip(
-    "kolena._experimental.instance_segmentation", reason="requires kolena[metrics] extra"
+    "kolena._experimental.instance_segmentation",
+    reason="requires kolena[metrics] extra",
 )
 InstanceSegmentationEvaluator = instance_segmentation.InstanceSegmentationEvaluator
 TestCase = instance_segmentation.TestCase

--- a/tests/integration/_experimental/instance_segmentation/test_evaluator_multiclass_f1_optimal.py
+++ b/tests/integration/_experimental/instance_segmentation/test_evaluator_multiclass_f1_optimal.py
@@ -33,7 +33,9 @@ from tests.integration.helper import fake_locator
 from tests.integration.helper import with_test_prefix
 
 
-instance_segmentation = pytest.importorskip("kolena._experimental.instance_segmentation", reason="requires kolena[metrics] extra")
+instance_segmentation = pytest.importorskip(
+    "kolena._experimental.instance_segmentation", reason="requires kolena[metrics] extra"
+)
 InstanceSegmentationEvaluator = instance_segmentation.InstanceSegmentationEvaluator
 TestCase = instance_segmentation.TestCase
 ClassMetricsPerTestCase = instance_segmentation.ClassMetricsPerTestCase

--- a/tests/integration/_experimental/instance_segmentation/test_evaluator_multiclass_fixed.py
+++ b/tests/integration/_experimental/instance_segmentation/test_evaluator_multiclass_fixed.py
@@ -1,0 +1,796 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+from typing import Tuple
+
+import pytest
+
+from kolena.workflow.annotation import LabeledPolygon, ScoredLabel
+from kolena.workflow.annotation import ScoredLabeledPolygon
+from kolena.workflow.plot import ConfusionMatrix
+from kolena.workflow.plot import Curve
+from kolena.workflow.plot import CurvePlot
+from tests.integration.helper import fake_locator
+from tests.integration.helper import with_test_prefix
+
+
+instance_segmentation = pytest.importorskip(
+    "kolena._experimental.instance_segmentation",
+    reason="requires kolena[metrics] extra",
+)
+GroundTruth = instance_segmentation.GroundTruth
+Inference = instance_segmentation.Inference
+TestCase = instance_segmentation.TestCase
+TestSample = instance_segmentation.TestSample
+TestSuite = instance_segmentation.TestSuite
+InstanceSegmentationEvaluator = instance_segmentation.InstanceSegmentationEvaluator
+ThresholdConfiguration = instance_segmentation.ThresholdConfiguration
+ClassMetricsPerTestCase = instance_segmentation.ClassMetricsPerTestCase
+TestCaseMetrics = instance_segmentation.TestCaseMetrics
+TestSampleMetrics = instance_segmentation.TestSampleMetrics
+TestSuiteMetrics = instance_segmentation.TestSuiteMetrics
+
+
+TEST_DATA: List[Tuple[TestSample, GroundTruth, Inference]] = [
+    (
+        TestSample(locator=fake_locator(112, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "c"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "d"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "c", 0.8),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "d", 0.7),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(113, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "b"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1.1, 1), (1.1, 2), (2, 1.1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3.2, 3), (3.2, 4), (4, 3.2), (4, 4)], "a", 0.8),
+                ScoredLabeledPolygon([(5.3, 5), (5.3, 6), (6, 5.3), (6, 6)], "a", 0.7),
+                ScoredLabeledPolygon([(7.4, 7), (7.4, 8), (8, 7.4), (8, 8)], "b", 1),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(114, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.6),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b", 0.5),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b", 0.4),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.1),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(115, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.9),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.8),
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b", 0.9),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.8),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(116, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.4),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(117, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "c"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.9),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "b", 0.9),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(118, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "c"),
+            ],
+            ignored_polygons=[
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "c", 0.8),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b", 0.1),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 1),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(119, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "e"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "e"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "e"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "e"),
+                LabeledPolygon([(9, 9), (9, 10), (10, 9), (10, 10)], "e"),
+                LabeledPolygon([(11, 11), (11, 12), (12, 11), (12, 12)], "e"),
+                LabeledPolygon([(13, 13), (13, 14), (14, 13), (14, 14)], "e"),
+                LabeledPolygon([(15, 15), (15, 16), (16, 15), (16, 16)], "e"),
+                LabeledPolygon([(17, 17), (17, 18), (18, 17), (18, 18)], "e"),
+                LabeledPolygon([(19, 19), (19, 20), (20, 19), (20, 20)], "e"),
+            ],
+            ignored_polygons=[
+                LabeledPolygon([(2, 2), (2, 3), (3, 2), (3, 3)], "b"),
+                LabeledPolygon([(4, 4), (4, 5), (5, 4), (5, 5)], "b"),
+                LabeledPolygon([(6, 6), (6, 7), (7, 6), (7, 7)], "b"),
+                LabeledPolygon([(8, 8), (8, 9), (9, 8), (9, 9)], "b"),
+                LabeledPolygon([(10, 10), (10, 11), (11, 10), (11, 11)], "a"),
+                LabeledPolygon([(12, 12), (12, 13), (13, 12), (13, 13)], "a"),
+                LabeledPolygon([(14, 14), (14, 15), (15, 14), (15, 15)], "a"),
+                LabeledPolygon([(16, 16), (16, 17), (17, 16), (17, 17)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "b", 0.9),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "e", 0.8),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "e", 0.7),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "e", 0.6),
+                ScoredLabeledPolygon([(9, 9), (9, 10), (10, 9), (10, 10)], "e", 0.1),
+                ScoredLabeledPolygon([(11, 11), (11, 12), (12, 11), (12, 12)], "e", 0),
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.8),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.1),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 1),
+                ScoredLabeledPolygon([(6, 6), (6, 7), (7, 6), (7, 7)], "b", 0.9),
+                ScoredLabeledPolygon([(8, 8), (8, 9), (9, 8), (9, 9)], "b", 0.8),
+                ScoredLabeledPolygon([(10, 10), (10, 11), (11, 10), (11, 11)], "b", 0.7),
+                ScoredLabeledPolygon([(12, 12), (12, 13), (13, 12), (13, 13)], "b", 0.6),
+                ScoredLabeledPolygon([(14, 14), (14, 15), (15, 14), (15, 15)], "b", 0.1),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(120, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "c"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "d"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "c", 0.8),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "d", 0.7),
+            ],
+            ignored=True,
+        ),
+    ),
+]
+
+
+EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetrics]] = [
+    (
+        TestSample(locator=fake_locator(112, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "c", 0.8),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "d", 0.7),
+            ],
+            FP=[],
+            FN=[],
+            Confused=[],
+            count_TP=4,
+            count_FP=0,
+            count_FN=0,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=False,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.7,
+            thresholds=[
+                ScoredLabel("a", 0.5),
+                ScoredLabel("b", 0.5),
+                ScoredLabel("c", 0.5),
+                ScoredLabel("d", 0.5),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(113, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1.1, 1), (1.1, 2), (2, 1.1), (2, 2)], "a", 0.9),
+            ],
+            FP=[
+                ScoredLabeledPolygon([(3.2, 3), (3.2, 4), (4, 3.2), (4, 4)], "a", 0.8),
+                ScoredLabeledPolygon([(5.3, 5), (5.3, 6), (6, 5.3), (6, 6)], "a", 0.7),
+                ScoredLabeledPolygon([(7.4, 7), (7.4, 8), (8, 7.4), (8, 8)], "b", 1),
+            ],
+            FN=[
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "b"),
+            ],
+            Confused=[],
+            count_TP=1,
+            count_FP=3,
+            count_FN=3,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=True,
+            has_FN=True,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.7,
+            thresholds=[
+                ScoredLabel("a", 0.5),
+                ScoredLabel("b", 0.5),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(114, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.6),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b", 0.5),
+            ],
+            FP=[],
+            FN=[
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b"),
+            ],
+            Confused=[],
+            count_TP=2,
+            count_FP=0,
+            count_FN=2,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=True,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=0.6,
+            min_confidence_above_t=0.5,
+            thresholds=[
+                ScoredLabel("a", 0.5),
+                ScoredLabel("b", 0.5),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(115, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.8),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b", 0.9),
+            ],
+            FP=[
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.9),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.8),
+            ],
+            FN=[],
+            Confused=[],
+            count_TP=4,
+            count_FP=4,
+            count_FN=0,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=True,
+            has_FN=False,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.8,
+            thresholds=[
+                ScoredLabel("a", 0.5),
+                ScoredLabel("b", 0.5),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(116, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+            ],
+            FP=[],
+            FN=[
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "b"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "b"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+            Confused=[],
+            count_TP=1,
+            count_FP=0,
+            count_FN=3,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=True,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=1,
+            thresholds=[
+                ScoredLabel("a", 0.5),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(117, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.9)],
+            FP=[ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "b", 0.9)],
+            FN=[
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "c"),
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+            ],
+            Confused=[ScoredLabeledPolygon([(7.0, 7.0), (7.0, 8.0), (8.0, 7.0), (8.0, 8.0)], 'b', 0.9)],
+            count_TP=1,
+            count_FP=1,
+            count_FN=3,
+            count_Confused=1,
+            has_TP=True,
+            has_FP=True,
+            has_FN=True,
+            has_Confused=True,
+            ignored=False,
+            max_confidence_above_t=0.9,
+            min_confidence_above_t=0.9,
+            thresholds=[
+                ScoredLabel("a", 0.5),
+                ScoredLabel("b", 0.5),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(118, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "c", 0.8),
+            ],
+            FP=[],
+            FN=[],
+            Confused=[],
+            count_TP=2,
+            count_FP=0,
+            count_FN=0,
+            count_Confused=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=False,
+            has_Confused=False,
+            ignored=False,
+            max_confidence_above_t=0.9,
+            min_confidence_above_t=0.8,
+            thresholds=[
+                ScoredLabel("a", 0.5),
+                ScoredLabel("c", 0.5),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(119, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "e", 0.8),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "e", 0.7),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "e", 0.6),
+            ],
+            FP=[
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 1),
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.8),
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "b", 0.9),
+                ScoredLabeledPolygon([(10, 10), (10, 11), (11, 10), (11, 11)], "b", 0.7),
+                ScoredLabeledPolygon([(12, 12), (12, 13), (13, 12), (13, 13)], "b", 0.6),
+            ],
+            FN=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "e"),
+                LabeledPolygon([(13, 13), (13, 14), (14, 13), (14, 14)], "e"),
+                LabeledPolygon([(15, 15), (15, 16), (16, 15), (16, 16)], "e"),
+                LabeledPolygon([(17, 17), (17, 18), (18, 17), (18, 18)], "e"),
+                LabeledPolygon([(19, 19), (19, 20), (20, 19), (20, 20)], "e"),
+                LabeledPolygon([(9, 9), (9, 10), (10, 9), (10, 10)], "e"),
+                LabeledPolygon([(11, 11), (11, 12), (12, 11), (12, 12)], "e"),
+            ],
+            Confused=[ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9)],
+            count_TP=3,
+            count_FP=6,
+            count_FN=7,
+            count_Confused=1,
+            has_TP=True,
+            has_FP=True,
+            has_FN=True,
+            has_Confused=True,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.6,
+            thresholds=[
+                ScoredLabel("a", 0.5),
+                ScoredLabel("b", 0.5),
+                ScoredLabel("e", 0.5),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(120, "IS"), metadata={}),
+        TestSampleMetrics(
+            TP=[],
+            FP=[],
+            FN=[],
+            Confused=[],
+            count_TP=0,
+            count_FP=0,
+            count_FN=0,
+            count_Confused=0,
+            has_TP=False,
+            has_FP=False,
+            has_FN=False,
+            has_Confused=False,
+            ignored=True,
+            max_confidence_above_t=None,
+            min_confidence_above_t=None,
+            thresholds=[],
+        ),
+    ),
+
+]
+
+
+EXPECTED_COMPUTE_TEST_CASE_METRICS = TestCaseMetrics(
+    PerClass=[
+        ClassMetricsPerTestCase(
+            Class="a",
+            nImages=7,
+            Threshold=0.5,
+            Objects=14,
+            Inferences=17,
+            TP=8,
+            FN=6,
+            FP=9,
+            Precision=8 / 17,
+            Recall=4 / 7,
+            F1=16 / 31,
+            AP=210 / 499,
+        ),
+        ClassMetricsPerTestCase(
+            Class="b",
+            nImages=5,
+            Threshold=0.5,
+            Objects=8,
+            Inferences=9,
+            TP=4,
+            FN=4,
+            FP=5,
+            Precision=4 / 9,
+            Recall=0.5,
+            F1=8 / 17,
+            AP=5 / 16,
+        ),
+        ClassMetricsPerTestCase(
+            Class="c",
+            nImages=3,
+            Threshold=0.5,
+            Objects=3,
+            Inferences=2,
+            TP=2,
+            FN=1,
+            FP=0,
+            Precision=1,
+            Recall=2 / 3,
+            F1=0.8,
+            AP=2 / 3,
+        ),
+        ClassMetricsPerTestCase(
+            Class="d",
+            nImages=1,
+            Threshold=0.5,
+            Objects=1,
+            Inferences=1,
+            TP=1,
+            FN=0,
+            FP=0,
+            Precision=1,
+            Recall=1,
+            F1=1,
+            AP=1,
+        ),
+        ClassMetricsPerTestCase(
+            Class="e",
+            nImages=1,
+            Threshold=0.5,
+            Objects=10,
+            Inferences=3,
+            TP=3,
+            FN=7,
+            FP=0,
+            Precision=1,
+            Recall=0.3,
+            F1=6 / 13,
+            AP=0.5,
+        ),
+    ],
+    Objects=36,
+    Inferences=32,
+    TP=18,
+    FN=18,
+    FP=14,
+    nIgnored=1,
+    macro_Precision=599 / 765,
+    macro_Recall=319 / 525,
+    macro_F1=280 / 431,
+    mean_AP=29 / 50,
+    micro_Precision=9 / 16,
+    micro_Recall=0.5,
+    micro_F1=9 / 17,
+)
+
+
+EXPECTED_CONFUSION_MATRIX = ConfusionMatrix(
+    title="Confusion Matrix",
+    labels=["a", "b", "c", "d", "e"],
+    matrix=[[8, 1, 0, 0, 0], [0, 4, 0, 0, 0], [0, 0, 2, 0, 0], [0, 0, 0, 1, 0], [1, 0, 0, 0, 3]],
+    x_label="Predicted",
+    y_label="Actual",
+)
+
+
+EXPECTED_F1_CURVE_PLOT = CurvePlot(
+    title="F1-Score vs. Confidence Threshold Per Class",
+    x_label="Confidence Threshold",
+    y_label="F1-Score",
+    curves=[
+        Curve(
+            x=[0, 0.1, 0.4, 0.6, 0.8, 0.9, 1],
+            y=[22 / 35, 10 / 17, 9 / 16, 16 / 31, 14 / 29, 12 / 25, 0.3],
+            label="a",
+            extra={
+                "Precision": [11 / 21, 0.5, 0.5, 8 / 17, 7 / 15, 6 / 11, 0.5],
+                "Recall": [11 / 14, 5 / 7, 9 / 14, 4 / 7, 0.5, 3 / 7, 3 / 14],
+            },
+        ),
+        Curve(
+            x=[0.4, 0.5, 0.9, 1],
+            y=[5 / 9, 8 / 17, 3 / 7, 0],
+            label="b",
+            extra={
+                "Precision": [0.5, 4 / 9, 0.5, 0],
+                "Recall": [5 / 8, 0.5, 3 / 8, 0],
+            },
+        ),
+        Curve(
+            x=[0, 0.1, 0.6, 0.7, 0.8],
+            y=[2 / 3, 4 / 7, 6 / 13, 1 / 3, 2 / 11],
+            label="e",
+            extra={
+                "Precision": [1.0, 1.0, 1.0, 1.0, 1.0],
+                "Recall": [0.5, 0.4, 0.3, 0.2, 0.1],
+            },
+        ),
+    ],
+    x_config=None,
+    y_config=None,
+)
+
+
+def assert_test_case_metrics_equals_expected(
+    metrics: TestCaseMetrics,
+    other_metrics: TestCaseMetrics,
+) -> None:
+    assert len(metrics.PerClass) == len(other_metrics.PerClass)
+    pytest_precision = 1e-5
+    for pc_metric, expected_pc_metric in zip(metrics.PerClass, other_metrics.PerClass):
+        assert pc_metric.Class == expected_pc_metric.Class
+        assert pc_metric.nImages == expected_pc_metric.nImages
+        assert pc_metric.Threshold == expected_pc_metric.Threshold
+        assert pc_metric.Objects == expected_pc_metric.Objects
+        assert pc_metric.Inferences == expected_pc_metric.Inferences
+        assert pc_metric.TP == expected_pc_metric.TP
+        assert pc_metric.FN == expected_pc_metric.FN
+        assert pc_metric.FP == expected_pc_metric.FP
+        assert pytest.approx(pc_metric.Precision, abs=pytest_precision) == expected_pc_metric.Precision
+        assert pytest.approx(pc_metric.Recall, abs=pytest_precision) == expected_pc_metric.Recall
+        assert pytest.approx(pc_metric.F1, abs=pytest_precision) == expected_pc_metric.F1
+        assert pytest.approx(pc_metric.AP, abs=pytest_precision) == expected_pc_metric.AP
+
+    assert metrics.Objects == other_metrics.Objects
+    assert metrics.Inferences == other_metrics.Inferences
+    assert metrics.TP == other_metrics.TP
+    assert metrics.FN == other_metrics.FN
+    assert metrics.FP == other_metrics.FP
+    assert pytest.approx(metrics.macro_Precision, abs=pytest_precision) == other_metrics.macro_Precision
+    assert pytest.approx(metrics.macro_Recall, abs=pytest_precision) == other_metrics.macro_Recall
+    assert pytest.approx(metrics.macro_F1, abs=pytest_precision) == other_metrics.macro_F1
+    assert pytest.approx(metrics.mean_AP, abs=pytest_precision) == other_metrics.mean_AP
+
+
+def assert_curves(
+    curves: List[Curve],
+    expected: List[Curve],
+) -> None:
+    assert len(curves) == len(expected)
+    for curve, expectation in zip(curves, expected):
+        print(curve, expectation)
+        assert curve.label == expectation.label
+        assert len(curve.x) == len(expectation.x)
+        assert sum(abs(a - b) for a, b in zip(curve.x, expectation.x)) < 1e-12
+        assert len(curve.y) == len(expectation.y)
+        assert sum(abs(a - b) for a, b in zip(curve.y, expectation.y)) < 1e-12
+        for extra_key in curve.extra.keys():
+            assert sum(abs(a - b) for a, b in zip(curve.extra[extra_key], expectation.extra[extra_key])) < 1e-12
+
+
+def assert_curve_plot_equal(
+    plot: CurvePlot,
+    expected: CurvePlot,
+) -> None:
+    assert plot.title == expected.title
+    assert plot.x_label == expected.x_label
+    assert plot.y_label == expected.y_label
+    assert_curves(plot.curves, expected.curves)
+    assert plot.x_config == expected.x_config
+    assert plot.y_config == expected.y_config
+
+
+@pytest.mark.metrics
+def test__instance_segmentation__multiclass_evaluator__fixed() -> None:
+    TEST_CASE_NAME = "multiclass IS test fixed"
+    TEST_CASE = TestCase(with_test_prefix(TEST_CASE_NAME + " case"))
+    TEST_SUITE = TestSuite(with_test_prefix(TEST_CASE_NAME + " suite"))
+    config = ThresholdConfiguration(
+        threshold_strategy=0.5,
+        min_confidence_score=0,
+    )
+
+    eval = InstanceSegmentationEvaluator(configurations=[config])
+
+    test_sample_metrics = eval.compute_test_sample_metrics(
+        test_case=TEST_CASE,
+        inferences=TEST_DATA,
+        configuration=config,
+    )
+
+    assert config.display_name() not in eval.evaluator.threshold_cache
+    assert len(eval.evaluator.matchings_by_test_case) != 0
+    assert len(eval.evaluator.matchings_by_test_case[config.display_name()]) != 0
+    num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
+    assert (
+        len(eval.evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
+        == len(TEST_DATA) - num_of_ignored
+    )
+    assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
+
+    test_case_metrics = eval.compute_test_case_metrics(
+        test_case=TEST_CASE,
+        inferences=TEST_DATA,
+        metrics=[pair[1] for pair in EXPECTED_COMPUTE_TEST_SAMPLE_METRICS],
+        configuration=config,
+    )
+    assert TEST_CASE.name in eval.evaluator.locators_by_test_case
+    assert len(eval.evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
+    assert_test_case_metrics_equals_expected(test_case_metrics, EXPECTED_COMPUTE_TEST_CASE_METRICS)
+
+    # test case plots only use the cached values
+    plots = eval.compute_test_case_plots(
+        test_case=TEST_CASE,
+        inferences=[],
+        metrics=[],
+        configuration=config,
+    )
+    assert_curve_plot_equal(plots[0], EXPECTED_F1_CURVE_PLOT)
+    assert plots[2] == EXPECTED_CONFUSION_MATRIX
+
+    # test suite metrics - one
+    test_suite_metrics = eval.compute_test_suite_metrics(
+        test_suite=TEST_SUITE,
+        metrics=[
+            (TEST_CASE, EXPECTED_COMPUTE_TEST_CASE_METRICS),
+        ],
+        configuration=config,
+    )
+    assert test_suite_metrics == TestSuiteMetrics(n_images=len(TEST_DATA), mean_AP=29 / 50)
+
+    # test suite metrics - two
+    test_suite_metrics_dup = eval.compute_test_suite_metrics(
+        test_suite=TEST_SUITE,
+        metrics=[
+            (TEST_CASE, EXPECTED_COMPUTE_TEST_CASE_METRICS),
+            (TEST_CASE, EXPECTED_COMPUTE_TEST_CASE_METRICS),
+        ],
+        configuration=config,
+    )
+    assert test_suite_metrics_dup == TestSuiteMetrics(n_images=len(TEST_DATA), mean_AP=29 / 50)

--- a/tests/integration/_experimental/instance_segmentation/test_evaluator_multiclass_fixed.py
+++ b/tests/integration/_experimental/instance_segmentation/test_evaluator_multiclass_fixed.py
@@ -16,7 +16,8 @@ from typing import Tuple
 
 import pytest
 
-from kolena.workflow.annotation import LabeledPolygon, ScoredLabel
+from kolena.workflow.annotation import LabeledPolygon
+from kolena.workflow.annotation import ScoredLabel
 from kolena.workflow.annotation import ScoredLabeledPolygon
 from kolena.workflow.plot import ConfusionMatrix
 from kolena.workflow.plot import Curve
@@ -417,7 +418,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetrics]]
                 LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "c"),
                 LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
             ],
-            Confused=[ScoredLabeledPolygon([(7.0, 7.0), (7.0, 8.0), (8.0, 7.0), (8.0, 8.0)], 'b', 0.9)],
+            Confused=[ScoredLabeledPolygon([(7.0, 7.0), (7.0, 8.0), (8.0, 7.0), (8.0, 8.0)], "b", 0.9)],
             count_TP=1,
             count_FP=1,
             count_FN=3,
@@ -527,7 +528,6 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetrics]]
             thresholds=[],
         ),
     ),
-
 ]
 
 

--- a/tests/integration/_experimental/instance_segmentation/test_evaluator_single_class_f1_optimal.py
+++ b/tests/integration/_experimental/instance_segmentation/test_evaluator_single_class_f1_optimal.py
@@ -1,0 +1,340 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+from typing import Tuple
+
+import pytest
+
+from kolena.workflow.annotation import LabeledPolygon
+from kolena.workflow.annotation import ScoredLabeledPolygon
+from kolena.workflow.plot import Curve
+from kolena.workflow.plot import CurvePlot
+from tests.integration._experimental.instance_segmentation.test_evaluator_single_class_fixed import (
+    assert_curve_plot_equal,
+)
+from tests.integration._experimental.instance_segmentation.test_evaluator_single_class_fixed import (
+    assert_test_case_metrics_equals_expected,
+)
+from tests.integration._experimental.instance_segmentation.test_evaluator_single_class_fixed import TEST_DATA
+from tests.integration.helper import fake_locator
+from tests.integration.helper import with_test_prefix
+
+
+instance_segmentation = pytest.importorskip(
+    "kolena._experimental.instance_segmentation",
+    reason="requires kolena[metrics] extra",
+)
+InstanceSegmentationEvaluator = instance_segmentation.InstanceSegmentationEvaluator
+TestSample = instance_segmentation.TestSample
+TestCase = instance_segmentation.TestCase
+ThresholdConfiguration = instance_segmentation.ThresholdConfiguration
+TestCaseMetricsSingleClass = instance_segmentation.TestCaseMetricsSingleClass
+TestSampleMetricsSingleClass = instance_segmentation.TestSampleMetricsSingleClass
+
+
+EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSingleClass]] = [
+    (
+        TestSample(locator=fake_locator(112, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.8),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.7),
+            ],
+            FP=[],
+            FN=[],
+            count_TP=4,
+            count_FP=0,
+            count_FN=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=False,
+            ignored=False,
+            max_confidence_above_t=1.0,
+            min_confidence_above_t=0.7,
+            thresholds=0.1,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(113, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1.1, 1), (1.1, 2), (2, 1.1), (2, 2)], "a", 0.9),
+            ],
+            FP=[
+                ScoredLabeledPolygon([(3.2, 3), (3.2, 4), (4, 3.2), (4, 4)], "a", 0.8),
+                ScoredLabeledPolygon([(5.3, 5), (5.3, 6), (6, 5.3), (6, 6)], "a", 0.7),
+                ScoredLabeledPolygon([(7.4, 7), (7.4, 8), (8, 7.4), (8, 8)], "a", 0.1),
+            ],
+            FN=[
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+            count_TP=1,
+            count_FP=3,
+            count_FN=3,
+            has_TP=True,
+            has_FP=True,
+            has_FN=True,
+            ignored=False,
+            max_confidence_above_t=0.9,
+            min_confidence_above_t=0.1,
+            thresholds=0.1,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(114, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.6),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.5),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.4),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.1),
+            ],
+            FP=[],
+            FN=[],
+            count_TP=4,
+            count_FP=0,
+            count_FN=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=False,
+            ignored=False,
+            max_confidence_above_t=0.6,
+            min_confidence_above_t=0.1,
+            thresholds=0.1,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(115, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.9),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.8),
+            ],
+            FP=[
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.9),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.8),
+            ],
+            FN=[],
+            count_TP=4,
+            count_FP=4,
+            count_FN=0,
+            has_TP=True,
+            has_FP=True,
+            has_FN=False,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.8,
+            thresholds=0.1,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(116, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.4),
+            ],
+            FP=[],
+            FN=[
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+            count_TP=2,
+            count_FP=0,
+            count_FN=2,
+            has_TP=True,
+            has_FP=False,
+            has_FN=True,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.4,
+            thresholds=0.1,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(117, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.9),
+            ],
+            FP=[],
+            FN=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+            count_TP=2,
+            count_FP=0,
+            count_FN=2,
+            has_TP=True,
+            has_FP=False,
+            has_FN=True,
+            ignored=False,
+            max_confidence_above_t=0.9,
+            min_confidence_above_t=0.9,
+            thresholds=0.1,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(118, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.8),
+            ],
+            FP=[],
+            FN=[],
+            count_TP=2,
+            count_FP=0,
+            count_FN=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=False,
+            ignored=False,
+            max_confidence_above_t=0.9,
+            min_confidence_above_t=0.8,
+            thresholds=0.1,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(119, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[],
+            FP=[],
+            FN=[],
+            count_TP=0,
+            count_FP=0,
+            count_FN=0,
+            has_TP=False,
+            has_FP=False,
+            has_FN=False,
+            ignored=True,
+            max_confidence_above_t=None,
+            min_confidence_above_t=None,
+            thresholds=0.1,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(120, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[],
+            FP=[],
+            FN=[],
+            count_TP=0,
+            count_FP=0,
+            count_FN=0,
+            has_TP=False,
+            has_FP=False,
+            has_FN=False,
+            ignored=True,
+            max_confidence_above_t=None,
+            min_confidence_above_t=None,
+            thresholds=0.1,
+        ),
+    ),
+]
+
+
+EXPECTED_COMPUTE_TEST_CASE_METRICS = TestCaseMetricsSingleClass(
+    Objects=26,
+    Inferences=26,
+    TP=19,
+    FN=7,
+    FP=7,
+    nIgnored=2,
+    Precision=19 / 26,
+    Recall=19 / 26,
+    F1=19 / 26,
+    AP=375 / 676,
+)
+
+
+EXPECTED_F1_CURVE_PLOT = CurvePlot(
+    title="F1-Score vs. Confidence Threshold",
+    x_label="Confidence Threshold",
+    y_label="F1-Score",
+    curves=[
+        Curve(
+            label=None,
+            x=[0.1, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1],
+            y=[19 / 26, 18 / 25, 2 / 3, 30 / 47, 14 / 23, 13 / 22, 20 / 39, 6 / 31],
+            extra={
+                "Precision": [19 / 26, 18 / 24, 16 / 22, 15 / 21, 0.7, 13 / 18, 10 / 13, 0.6],
+                "Recall": [19 / 26, 9 / 13, 8 / 13, 15 / 26, 7 / 13, 1 / 2, 10 / 26, 3 / 26],
+            },
+        ),
+    ],
+    x_config=None,
+    y_config=None,
+)
+
+
+@pytest.mark.metrics
+def test__instance_segmentation__multiclass_evaluator__f1_optimal() -> None:
+    TEST_CASE_NAME = "single class IS test fixed"
+    TEST_CASE = TestCase(with_test_prefix(TEST_CASE_NAME + " case"))
+
+    config = ThresholdConfiguration(
+        iou_threshold=0.5,
+        min_confidence_score=0.1,
+    )
+
+    eval = InstanceSegmentationEvaluator(configurations=[config])
+
+    test_sample_metrics = eval.compute_test_sample_metrics(
+        test_case=TEST_CASE,
+        inferences=TEST_DATA,
+        configuration=config,
+    )
+
+    assert config.display_name() in eval.evaluator.threshold_cache
+    assert eval.evaluator.threshold_cache[config.display_name()] == 0.1
+    assert len(eval.evaluator.matchings_by_test_case) != 0
+    assert len(eval.evaluator.matchings_by_test_case[config.display_name()]) != 0
+    num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
+    assert (
+        len(eval.evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
+        == len(TEST_DATA) - num_of_ignored
+    )
+    assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
+
+    test_case_metrics = eval.compute_test_case_metrics(
+        test_case=TEST_CASE,
+        inferences=TEST_DATA,
+        metrics=[pair[1] for pair in EXPECTED_COMPUTE_TEST_SAMPLE_METRICS],
+        configuration=config,
+    )
+
+    assert TEST_CASE.name in eval.evaluator.locators_by_test_case
+    assert len(eval.evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
+    assert_test_case_metrics_equals_expected(test_case_metrics, EXPECTED_COMPUTE_TEST_CASE_METRICS)
+
+    # test case plots only use the cached values
+    plots = eval.compute_test_case_plots(
+        test_case=TEST_CASE,
+        inferences=[],
+        metrics=[],
+        configuration=config,
+    )
+    assert_curve_plot_equal(plots[1], EXPECTED_F1_CURVE_PLOT)
+
+    # test suite behaviour is consistent with fixed evaluator

--- a/tests/integration/_experimental/instance_segmentation/test_evaluator_single_class_f1_optimal.py
+++ b/tests/integration/_experimental/instance_segmentation/test_evaluator_single_class_f1_optimal.py
@@ -64,7 +64,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=1.0,
             min_confidence_above_t=0.7,
-            thresholds=0.1,
+            threshold=0.1,
         ),
     ),
     (
@@ -92,7 +92,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=0.9,
             min_confidence_above_t=0.1,
-            thresholds=0.1,
+            threshold=0.1,
         ),
     ),
     (
@@ -115,7 +115,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=0.6,
             min_confidence_above_t=0.1,
-            thresholds=0.1,
+            threshold=0.1,
         ),
     ),
     (
@@ -143,7 +143,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=1,
             min_confidence_above_t=0.8,
-            thresholds=0.1,
+            threshold=0.1,
         ),
     ),
     (
@@ -167,7 +167,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=1,
             min_confidence_above_t=0.4,
-            thresholds=0.1,
+            threshold=0.1,
         ),
     ),
     (
@@ -191,7 +191,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=0.9,
             min_confidence_above_t=0.9,
-            thresholds=0.1,
+            threshold=0.1,
         ),
     ),
     (
@@ -212,7 +212,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=0.9,
             min_confidence_above_t=0.8,
-            thresholds=0.1,
+            threshold=0.1,
         ),
     ),
     (
@@ -230,7 +230,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=True,
             max_confidence_above_t=None,
             min_confidence_above_t=None,
-            thresholds=0.1,
+            threshold=0.1,
         ),
     ),
     (
@@ -248,7 +248,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=True,
             max_confidence_above_t=None,
             min_confidence_above_t=None,
-            thresholds=0.1,
+            threshold=0.1,
         ),
     ),
 ]

--- a/tests/integration/_experimental/instance_segmentation/test_evaluator_single_class_fixed.py
+++ b/tests/integration/_experimental/instance_segmentation/test_evaluator_single_class_fixed.py
@@ -234,7 +234,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=1,
             min_confidence_above_t=0.7,
-            thresholds=0.5,
+            threshold=0.5,
         ),
     ),
     (
@@ -261,7 +261,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=0.9,
             min_confidence_above_t=0.7,
-            thresholds=0.5,
+            threshold=0.5,
         ),
     ),
     (
@@ -285,7 +285,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=0.6,
             min_confidence_above_t=0.5,
-            thresholds=0.5,
+            threshold=0.5,
         ),
     ),
     (
@@ -313,7 +313,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=1,
             min_confidence_above_t=0.8,
-            thresholds=0.5,
+            threshold=0.5,
         ),
     ),
     (
@@ -337,7 +337,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=1,
             min_confidence_above_t=1,
-            thresholds=0.5,
+            threshold=0.5,
         ),
     ),
     (
@@ -361,7 +361,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=0.9,
             min_confidence_above_t=0.9,
-            thresholds=0.5,
+            threshold=0.5,
         ),
     ),
     (
@@ -382,7 +382,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=False,
             max_confidence_above_t=0.9,
             min_confidence_above_t=0.8,
-            thresholds=0.5,
+            threshold=0.5,
         ),
     ),
     (
@@ -400,7 +400,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=True,
             max_confidence_above_t=None,
             min_confidence_above_t=None,
-            thresholds=0.5,
+            threshold=0.5,
         ),
     ),
     (
@@ -418,7 +418,7 @@ EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSi
             ignored=True,
             max_confidence_above_t=None,
             min_confidence_above_t=None,
-            thresholds=0.5,
+            threshold=0.5,
         ),
     ),
 ]
@@ -555,7 +555,7 @@ def test__instance_segmentation__multiclass_evaluator__fixed() -> None:
         ],
         configuration=config,
     )
-    assert test_suite_metrics == TestSuiteMetrics(n_images=len(TEST_DATA), mean_AP=200 / 343)
+    assert test_suite_metrics == TestSuiteMetrics(n_images=len(TEST_DATA), mean_AP=200 / 343, threshold=config.threshold_strategy)
 
     # test suite metrics - two
     test_suite_metrics_dup = eval.compute_test_suite_metrics(
@@ -566,4 +566,4 @@ def test__instance_segmentation__multiclass_evaluator__fixed() -> None:
         ],
         configuration=config,
     )
-    assert test_suite_metrics_dup == TestSuiteMetrics(n_images=len(TEST_DATA), mean_AP=200 / 343)
+    assert test_suite_metrics_dup == TestSuiteMetrics(n_images=len(TEST_DATA), mean_AP=200 / 343, threshold=config.threshold_strategy)

--- a/tests/integration/_experimental/instance_segmentation/test_evaluator_single_class_fixed.py
+++ b/tests/integration/_experimental/instance_segmentation/test_evaluator_single_class_fixed.py
@@ -555,7 +555,11 @@ def test__instance_segmentation__multiclass_evaluator__fixed() -> None:
         ],
         configuration=config,
     )
-    assert test_suite_metrics == TestSuiteMetrics(n_images=len(TEST_DATA), mean_AP=200 / 343, threshold=config.threshold_strategy)
+    assert test_suite_metrics == TestSuiteMetrics(
+        n_images=len(TEST_DATA),
+        mean_AP=200 / 343,
+        threshold=config.threshold_strategy,
+    )
 
     # test suite metrics - two
     test_suite_metrics_dup = eval.compute_test_suite_metrics(
@@ -566,4 +570,8 @@ def test__instance_segmentation__multiclass_evaluator__fixed() -> None:
         ],
         configuration=config,
     )
-    assert test_suite_metrics_dup == TestSuiteMetrics(n_images=len(TEST_DATA), mean_AP=200 / 343, threshold=config.threshold_strategy)
+    assert test_suite_metrics_dup == TestSuiteMetrics(
+        n_images=len(TEST_DATA),
+        mean_AP=200 / 343,
+        threshold=config.threshold_strategy,
+    )

--- a/tests/integration/_experimental/instance_segmentation/test_evaluator_single_class_fixed.py
+++ b/tests/integration/_experimental/instance_segmentation/test_evaluator_single_class_fixed.py
@@ -1,0 +1,569 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+from typing import Tuple
+
+import pytest
+
+from kolena.workflow.annotation import LabeledPolygon
+from kolena.workflow.annotation import ScoredLabeledPolygon
+from kolena.workflow.plot import Curve
+from kolena.workflow.plot import CurvePlot
+from tests.integration.helper import fake_locator
+from tests.integration.helper import with_test_prefix
+
+
+instance_segmentation = pytest.importorskip(
+    "kolena._experimental.instance_segmentation",
+    reason="requires kolena[metrics] extra",
+)
+GroundTruth = instance_segmentation.GroundTruth
+Inference = instance_segmentation.Inference
+TestCase = instance_segmentation.TestCase
+TestSample = instance_segmentation.TestSample
+TestSuite = instance_segmentation.TestSuite
+InstanceSegmentationEvaluator = instance_segmentation.InstanceSegmentationEvaluator
+ThresholdConfiguration = instance_segmentation.ThresholdConfiguration
+TestCaseMetricsSingleClass = instance_segmentation.TestCaseMetricsSingleClass
+TestSampleMetricsSingleClass = instance_segmentation.TestSampleMetricsSingleClass
+TestSuiteMetrics = instance_segmentation.TestSuiteMetrics
+
+
+TEST_DATA: List[Tuple[TestSample, GroundTruth, Inference]] = [
+    (
+        TestSample(locator=fake_locator(112, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.8),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.7),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(113, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1.1, 1), (1.1, 2), (2, 1.1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3.2, 3), (3.2, 4), (4, 3.2), (4, 4)], "a", 0.8),
+                ScoredLabeledPolygon([(5.3, 5), (5.3, 6), (6, 5.3), (6, 6)], "a", 0.7),
+                ScoredLabeledPolygon([(7.4, 7), (7.4, 8), (8, 7.4), (8, 8)], "a", 0.1),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(114, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.6),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.5),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.4),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.1),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(115, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.9),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.8),
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.9),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.8),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(116, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.4),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(117, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.9),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(118, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+            ],
+            ignored_polygons=[
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.8),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.1),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 1),
+            ],
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(119, "IS")),
+        GroundTruth(
+            polygons=[],
+            ignored_polygons=[],
+        ),
+        Inference(
+            polygons=[],
+            ignored=True,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(120, "IS")),
+        GroundTruth(
+            polygons=[
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+            ],
+            ignored_polygons=[
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+        ),
+        Inference(
+            polygons=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.8),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.1),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 1),
+            ],
+            ignored=True,
+        ),
+    ),
+]
+
+
+EXPECTED_COMPUTE_TEST_SAMPLE_METRICS: List[Tuple[TestSample, TestSampleMetricsSingleClass]] = [
+    (
+        TestSample(locator=fake_locator(112, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.8),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.7),
+            ],
+            FP=[],
+            FN=[],
+            count_TP=4,
+            count_FP=0,
+            count_FN=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=False,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.7,
+            thresholds=0.5,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(113, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1.1, 1), (1.1, 2), (2, 1.1), (2, 2)], "a", 0.9),
+            ],
+            FP=[
+                ScoredLabeledPolygon([(3.2, 3), (3.2, 4), (4, 3.2), (4, 4)], "a", 0.8),
+                ScoredLabeledPolygon([(5.3, 5), (5.3, 6), (6, 5.3), (6, 6)], "a", 0.7),
+            ],
+            FN=[
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+            count_TP=1,
+            count_FP=2,
+            count_FN=3,
+            has_TP=True,
+            has_FP=True,
+            has_FN=True,
+            ignored=False,
+            max_confidence_above_t=0.9,
+            min_confidence_above_t=0.7,
+            thresholds=0.5,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(114, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.6),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.5),
+            ],
+            FP=[],
+            FN=[
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+            ],
+            count_TP=2,
+            count_FP=0,
+            count_FN=2,
+            has_TP=True,
+            has_FP=False,
+            has_FN=True,
+            ignored=False,
+            max_confidence_above_t=0.6,
+            min_confidence_above_t=0.5,
+            thresholds=0.5,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(115, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.9),
+                ScoredLabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a", 0.8),
+            ],
+            FP=[
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 1),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.9),
+                ScoredLabeledPolygon([(0, 0), (0, 1), (1, 0), (1, 1)], "a", 0.8),
+            ],
+            FN=[],
+            count_TP=4,
+            count_FP=4,
+            count_FN=0,
+            has_TP=True,
+            has_FP=True,
+            has_FN=False,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=0.8,
+            thresholds=0.5,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(116, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 1),
+            ],
+            FP=[],
+            FN=[
+                LabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a"),
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+                LabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a"),
+            ],
+            count_TP=1,
+            count_FP=0,
+            count_FN=3,
+            has_TP=True,
+            has_FP=False,
+            has_FN=True,
+            ignored=False,
+            max_confidence_above_t=1,
+            min_confidence_above_t=1,
+            thresholds=0.5,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(117, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.9),
+                ScoredLabeledPolygon([(5, 5), (5, 6), (6, 5), (6, 6)], "a", 0.9),
+            ],
+            FP=[],
+            FN=[
+                LabeledPolygon([(7, 7), (7, 8), (8, 7), (8, 8)], "a"),
+                LabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a"),
+            ],
+            count_TP=2,
+            count_FP=0,
+            count_FN=2,
+            has_TP=True,
+            has_FP=False,
+            has_FN=True,
+            ignored=False,
+            max_confidence_above_t=0.9,
+            min_confidence_above_t=0.9,
+            thresholds=0.5,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(118, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[
+                ScoredLabeledPolygon([(1, 1), (1, 2), (2, 1), (2, 2)], "a", 0.9),
+                ScoredLabeledPolygon([(3, 3), (3, 4), (4, 3), (4, 4)], "a", 0.8),
+            ],
+            FP=[],
+            FN=[],
+            count_TP=2,
+            count_FP=0,
+            count_FN=0,
+            has_TP=True,
+            has_FP=False,
+            has_FN=False,
+            ignored=False,
+            max_confidence_above_t=0.9,
+            min_confidence_above_t=0.8,
+            thresholds=0.5,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(119, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[],
+            FP=[],
+            FN=[],
+            count_TP=0,
+            count_FP=0,
+            count_FN=0,
+            has_TP=False,
+            has_FP=False,
+            has_FN=False,
+            ignored=True,
+            max_confidence_above_t=None,
+            min_confidence_above_t=None,
+            thresholds=0.5,
+        ),
+    ),
+    (
+        TestSample(locator=fake_locator(120, "IS"), metadata={}),
+        TestSampleMetricsSingleClass(
+            TP=[],
+            FP=[],
+            FN=[],
+            count_TP=0,
+            count_FP=0,
+            count_FN=0,
+            has_TP=False,
+            has_FP=False,
+            has_FN=False,
+            ignored=True,
+            max_confidence_above_t=None,
+            min_confidence_above_t=None,
+            thresholds=0.5,
+        ),
+    ),
+]
+
+
+EXPECTED_COMPUTE_TEST_CASE_METRICS = TestCaseMetricsSingleClass(
+    Objects=26,
+    Inferences=22,
+    TP=16,
+    FN=10,
+    FP=6,
+    nIgnored=2,
+    Precision=16 / 22,
+    Recall=16 / 26,
+    F1=32 / 48,
+    AP=200 / 343,
+)
+
+
+EXPECTED_F1_CURVE_PLOT = CurvePlot(
+    title="F1-Score vs. Confidence Threshold",
+    x_label="Confidence Threshold",
+    y_label="F1-Score",
+    curves=[
+        Curve(
+            label=None,
+            x=[0, 0.1, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1],
+            y=[40 / 53, 19 / 26, 18 / 25, 2 / 3, 30 / 47, 14 / 23, 13 / 22, 20 / 39, 6 / 31],
+            extra={
+                "Precision": [20 / 27, 19 / 26, 18 / 24, 16 / 22, 15 / 21, 0.7, 13 / 18, 10 / 13, 0.6],
+                "Recall": [10 / 13, 19 / 26, 9 / 13, 8 / 13, 15 / 26, 7 / 13, 1 / 2, 10 / 26, 3 / 26],
+            },
+        ),
+    ],
+    x_config=None,
+    y_config=None,
+)
+
+
+def assert_test_case_metrics_equals_expected(
+    metrics: TestCaseMetricsSingleClass,
+    other_metrics: TestCaseMetricsSingleClass,
+) -> None:
+    assert metrics.Objects == other_metrics.Objects
+    assert metrics.Inferences == other_metrics.Inferences
+    assert metrics.TP == other_metrics.TP
+    assert metrics.FN == other_metrics.FN
+    assert metrics.FP == other_metrics.FP
+    assert pytest.approx(other_metrics.Precision, abs=1e-12) == metrics.Precision
+    assert pytest.approx(other_metrics.Recall, abs=1e-12) == metrics.Recall
+    assert pytest.approx(other_metrics.F1, abs=1e-12) == metrics.F1
+    assert pytest.approx(other_metrics.AP, abs=1e-3) == metrics.AP
+
+
+def assert_curves(
+    curves: List[Curve],
+    expected: List[Curve],
+) -> None:
+    assert len(curves) == len(expected)
+    for curve, expectation in zip(curves, expected):
+        print(curve, expectation)
+        assert curve.label == expectation.label
+        assert len(curve.x) == len(expectation.x)
+        assert sum(abs(a - b) for a, b in zip(curve.x, expectation.x)) < 1e-12
+        assert len(curve.y) == len(expectation.y)
+        assert sum(abs(a - b) for a, b in zip(curve.y, expectation.y)) < 1e-12
+        for extra_key in curve.extra.keys():
+            assert sum(abs(a - b) for a, b in zip(curve.extra[extra_key], expectation.extra[extra_key])) < 1e-12
+
+
+def assert_curve_plot_equal(
+    plot: CurvePlot,
+    expected: CurvePlot,
+) -> None:
+    assert plot.title == expected.title
+    assert plot.x_label == expected.x_label
+    assert plot.y_label == expected.y_label
+    assert_curves(plot.curves, expected.curves)
+    assert plot.x_config == expected.x_config
+    assert plot.y_config == expected.y_config
+
+
+@pytest.mark.metrics
+def test__instance_segmentation__multiclass_evaluator__fixed() -> None:
+    TEST_CASE_NAME = "single class IS test fixed"
+    TEST_CASE = TestCase(with_test_prefix(TEST_CASE_NAME + " case"))
+    TEST_SUITE = TestSuite(with_test_prefix(TEST_CASE_NAME + " suite"))
+    config = ThresholdConfiguration(
+        threshold_strategy=0.5,
+    )
+
+    eval = InstanceSegmentationEvaluator(configurations=[config])
+
+    test_sample_metrics = eval.compute_test_sample_metrics(
+        test_case=TEST_CASE,
+        inferences=TEST_DATA,
+        configuration=config,
+    )
+
+    assert config.display_name() not in eval.evaluator.threshold_cache
+    assert len(eval.evaluator.matchings_by_test_case) != 0
+    assert len(eval.evaluator.matchings_by_test_case[config.display_name()]) != 0
+    num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
+    assert (
+        len(eval.evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
+        == len(TEST_DATA) - num_of_ignored
+    )
+    assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
+
+    test_case_metrics = eval.compute_test_case_metrics(
+        test_case=TEST_CASE,
+        inferences=TEST_DATA,
+        metrics=[pair[1] for pair in EXPECTED_COMPUTE_TEST_SAMPLE_METRICS],
+        configuration=config,
+    )
+    assert TEST_CASE.name in eval.evaluator.locators_by_test_case
+    assert len(eval.evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
+    assert_test_case_metrics_equals_expected(test_case_metrics, EXPECTED_COMPUTE_TEST_CASE_METRICS)
+
+    # test case plots only use the cached values
+    plots = eval.compute_test_case_plots(
+        test_case=TEST_CASE,
+        inferences=[],
+        metrics=[],
+        configuration=config,
+    )
+    assert_curve_plot_equal(plots[1], EXPECTED_F1_CURVE_PLOT)
+
+    # test suite metrics - one
+    test_suite_metrics = eval.compute_test_suite_metrics(
+        test_suite=TEST_SUITE,
+        metrics=[
+            (TEST_CASE, EXPECTED_COMPUTE_TEST_CASE_METRICS),
+        ],
+        configuration=config,
+    )
+    assert test_suite_metrics == TestSuiteMetrics(n_images=len(TEST_DATA), mean_AP=200 / 343)
+
+    # test suite metrics - two
+    test_suite_metrics_dup = eval.compute_test_suite_metrics(
+        test_suite=TEST_SUITE,
+        metrics=[
+            (TEST_CASE, EXPECTED_COMPUTE_TEST_CASE_METRICS),
+            (TEST_CASE, EXPECTED_COMPUTE_TEST_CASE_METRICS),
+        ],
+        configuration=config,
+    )
+    assert test_suite_metrics_dup == TestSuiteMetrics(n_images=len(TEST_DATA), mean_AP=200 / 343)

--- a/tests/integration/_experimental/instance_segmentation/test_workflow.py
+++ b/tests/integration/_experimental/instance_segmentation/test_workflow.py
@@ -1,0 +1,61 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import random
+
+import pytest
+
+from kolena.workflow import test
+from kolena.workflow.annotation import LabeledPolygon
+from kolena.workflow.annotation import ScoredLabeledPolygon
+from tests.integration.helper import fake_locator
+from tests.integration.helper import with_test_prefix
+
+
+instance_segmentation = pytest.importorskip(
+    "kolena._experimental.instance_segmentation",
+    reason="requires kolena[metrics] extra",
+)
+GroundTruth = instance_segmentation.GroundTruth
+Inference = instance_segmentation.Inference
+Model = instance_segmentation.Model
+TestCase = instance_segmentation.TestCase
+TestSample = instance_segmentation.TestSample
+TestSuite = instance_segmentation.TestSuite
+ThresholdConfiguration = instance_segmentation.ThresholdConfiguration
+InstanceSegmentationEvaluator = instance_segmentation.InstanceSegmentationEvaluator
+
+
+@pytest.mark.metrics
+def test__instance_segmentation__smoke() -> None:
+    name = with_test_prefix(f"{__file__} test__multiclass__instance_segmentation__smoke")
+    test_sample = TestSample(locator=fake_locator(0), metadata=dict(example="metadata", values=[1, 2, 3]))
+    ground_truth = GroundTruth(polygons=[LabeledPolygon(points=[(0, 0), (0, 1), (1, 0), (1, 1)], label="a")])
+    test_case = TestCase(f"{name} test case", test_samples=[(test_sample, ground_truth)])
+    test_suite = TestSuite(f"{name} test suite", test_cases=[test_case])
+
+    def infer(_: TestSample) -> Inference:
+        return Inference(
+            polygons=[
+                ScoredLabeledPolygon(points=[(0, 0), (0, 1), (1, 0), (1, 1)], label="b", score=random.random()),
+                ScoredLabeledPolygon(points=[(0, 0), (0, 1.1), (1.1, 0), (1.1, 1.1)], label="a", score=random.random()),
+                ScoredLabeledPolygon(points=[(0, 0), (0, 1.01), (1.01, 0), (1.01, 1.01)], label="a", score=0.99),
+            ],
+        )
+
+    eval = InstanceSegmentationEvaluator(
+        configurations=[ThresholdConfiguration()],
+    )
+
+    model = Model(f"{name} model", infer=infer)
+    test(model, test_suite, eval, reset=True)


### PR DESCRIPTION
### Linked issue(s):
Closes KOL-3869

### What change does this PR introduce and why?
Adds an experimental Instance Segmentation workflow based off of the
experimental Object Detection workflow. The primary difference is that
Instance Segmentation deals with Polygons while Object Detection deals
with Bounding Boxes.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated