### PR TITLE
Remove Model class attributes that are shadowed

### DIFF
--- a/kolena/workflow/model.py
+++ b/kolena/workflow/model.py
@@ -217,7 +217,6 @@ class Model(Frozen, WithTelemetry, metaclass=ABCMeta):
                 yield test_sample, ground_truth, inference
         log.info(f"loaded inferences from model '{self.name}' on test case '{test_case.name}'")
 
-
     @classmethod
     def _from_data(
         cls,

--- a/tests/integration/workflow/test_model.py
+++ b/tests/integration/workflow/test_model.py
@@ -34,6 +34,7 @@ from tests.integration.workflow.dummy import TestSuite
 META_DATA = {"a": "b"}
 TAGS = {"c", "d"}
 
+
 def no_op_infer():
     pass
 


### PR DESCRIPTION
### What change does this PR introduce and why?
Model has class attributes defined for name, metadata, tags, infer,
and _id which are shadowed as instance attributes
during initialization. This change removes these class attributes since
they belong as instance attributes.

### Please check if the PR fulfills these requirements

- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
