### PR TITLE
Docs: disable instant nav

### DIFF
--- a/docs/metrics/fpr.md
+++ b/docs/metrics/fpr.md
@@ -27,7 +27,7 @@ FPR is often used in conjuction with [TPR (recall)](./recall.md). By measuring b
 of a model's performance can be drawn.
 
 <div class="grid cards" markdown>
-- :kolena-manual-16: API Reference: [`FPR` ↗][kolena.workflow.metrics.fpr]
+- :kolena-manual-16: API Reference: [`fpr` ↗][kolena.workflow.metrics.fpr]
 </div>
 
 

--- a/docs/reference/workflow/thresholded-metrics.md
+++ b/docs/reference/workflow/thresholded-metrics.md
@@ -1,3 +1,7 @@
+---
+status: new
+---
+
 # `kolena._experimental.workflow.ThresholdedMetrics`
 
 !!! example "Experimental Feature"

--- a/kolena/_experimental/workflow/thresholded.py
+++ b/kolena/_experimental/workflow/thresholded.py
@@ -92,10 +92,6 @@ class ThresholdedMetrics(TypedDataObject[_MetricsType], metaclass=PreventThresho
     threshold: float
 
     def __init_subclass__(cls, **kwargs):
-        """
-        Registers the subclass in the system, allowing it to be recognized and utilized
-        within the broader workflow infrastructure.
-        """
         _register_data_type(cls)
 
     @classmethod
@@ -109,12 +105,6 @@ class ThresholdedMetrics(TypedDataObject[_MetricsType], metaclass=PreventThresho
         return _MetricsType.THRESHOLDED
 
     def __post_init__(self) -> None:
-        """
-        Post-initialization processing to ensure data integrity.
-
-        Checks each field to ensure no dictionary types are used, raising TypeError if violated.
-        This maintains the integrity and expected structure of the data.
-        """
         for field in fields(self):
             field_value = getattr(self, field.name)
             if isinstance(field_value, dict):

--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -30,7 +30,6 @@ theme:
     - content.code.copy
     - content.tabs.link
     - navigation.indexes
-    - navigation.instant
     - navigation.footer
     - navigation.sections
     - navigation.tabs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,7 +121,6 @@ theme:
     - content.code.copy
     - content.tabs.link
     - navigation.indexes
-    - navigation.instant
     - navigation.footer
     - navigation.sections
     - navigation.tabs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,13 +45,13 @@ nav:
           - <code>TestSuite</code>: reference/workflow/test-suite.md
           - <code>Model</code>: reference/workflow/model.md
           - <code>test</code>: reference/workflow/test-run.md
-          - <code>ThresholdedMetrics</code>: reference/workflow/thresholded-metrics.md
           - Utilities:
               - Annotations: reference/workflow/annotation.md
               - Assets: reference/workflow/asset.md
               - Plots: reference/workflow/plot.md
               - <code>define_workflow</code>: reference/workflow/define-workflow.md
               - <code>metrics</code>: reference/workflow/metrics.md
+              - <code>ThresholdedMetrics</code>: reference/workflow/thresholded-metrics.md
               - <code>visualization</code>: reference/workflow/visualization.md
               - IO: reference/workflow/io.md
       - Pre-built Workflows:


### PR DESCRIPTION
Disable `navigation.instant` mode, which appears to have bugs when rendering math formulas (see [related discussion](https://github.com/squidfunk/mkdocs-material/discussions/6138)).

Fixes KOL-3848 