### PR TITLE
[EXPERIMENTAL] (DO NOT MERGE) RAG QA for dataset + test-suite

### DIFF
--- a/examples/question_answering/question_answering/seed_dataset.py
+++ b/examples/question_answering/question_answering/seed_dataset.py
@@ -1,0 +1,82 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+from argparse import Namespace
+
+import pandas as pd
+
+import kolena
+from examples.question_answering.question_answering.utils import normalize_string
+from kolena._experimental.dataset import register_dataset
+from kolena.workflow.annotation import Utterance
+
+BUCKET = "kolena-public-datasets"
+DATASET = "CoQA"
+
+
+def main(args: Namespace) -> None:
+    kolena.initialize(verbose=True)
+
+    df = pd.read_csv(args.dataset_csv)
+    context_dict = {
+        x[0]: x[1]
+        for x in df[["data_id", "question", "metadata_answer"]]
+        .groupby("data_id")
+        .agg(list)
+        .reset_index()
+        .apply(
+            lambda x: [
+                x["data_id"],
+                [
+                    (Utterance(text=q, group="question"), Utterance(text=a, group="answer"))
+                    for q, a in zip(x["question"], x["metadata_answer"])
+                ],
+            ],
+            axis=1,
+            result_type="expand",
+        )
+        .to_dict("records")
+    }
+    df["context"] = df.apply(lambda x: [e for y in context_dict[x["data_id"]][: x["turn"]] for e in y], axis=1)
+    df["text"] = df.apply(
+        lambda x: x["story"]
+        + "\n\n"
+        + "\n".join(
+            [f"{t.group[0].upper()}: {t.text}" for e in context_dict[x["data_id"]][: x["turn"]] for t in e],
+        ),
+        axis=1,
+    )
+    df["clean_answer"] = df["metadata_answer"].apply(normalize_string)
+
+    register_dataset(
+        DATASET,
+        df.rename(
+            columns={
+                "metadata_answer": "answer",
+                "metadata_wc_answer": "wc_answer",
+                "metadata_wc_number": "wc_number",
+            },
+        ),
+    )
+
+
+if __name__ == "__main__":
+    ap = ArgumentParser()
+    ap.add_argument(
+        "--dataset_csv",
+        type=str,
+        default=f"s3://{BUCKET}/{DATASET}/metadata/metadata.csv",
+        help="CSV file with a stories, questions, and answers.",
+    )
+    main(ap.parse_args())

--- a/examples/question_answering/question_answering/seed_results.py
+++ b/examples/question_answering/question_answering/seed_results.py
@@ -1,0 +1,58 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+from argparse import Namespace
+
+import pandas as pd
+from question_answering.evaluator import compute_metrics
+from question_answering.seed_dataset import BUCKET
+from question_answering.seed_dataset import DATASET
+from question_answering.utils import normalize_string
+
+import kolena
+from kolena._experimental.dataset import test
+from kolena.workflow.annotation import ClassificationLabel
+
+MODELS = ["gpt-3.5-turbo-0301", "gpt-3.5-turbo", "gpt-4-0314", "gpt-4"]
+
+
+def main(args: Namespace) -> None:
+    kolena.initialize(verbose=True)
+
+    model_file_path = f"s3://{BUCKET}/{DATASET}/results/{args.model}.csv"
+    data_file_path = f"s3://{BUCKET}/{DATASET}/metadata/metadata.csv"
+    df_data = pd.read_csv(data_file_path)
+    df = pd.read_csv(model_file_path)
+
+    threshold = 0.5
+    df["clean_answer"] = df["answer"].apply(normalize_string)
+    df["answer"] = df["answer"].apply(lambda x: ClassificationLabel(label=x))
+    results = df_data[["data_id", "turn", "metadata_answer"]].merge(df, on=["data_id", "turn"])
+    df_metrics = results.apply(
+        lambda x: compute_metrics(normalize_string(x["metadata_answer"]), x["clean_answer"]),
+        result_type="expand",
+        axis=1,
+    )
+    results = pd.concat([results, df_metrics], axis=1)
+    results["MEAN_METRIC"] = round((results["BERT_f1"] + results["ROUGE_1"]) / 2, 3)
+    results["is_correct"] = results["MEAN_METRIC"] >= threshold
+    test(args.dataset, args.model, [(dict(threshold=threshold), results)], on=["data_id", "turn"])
+
+
+if __name__ == "__main__":
+    ap = ArgumentParser()
+    ap.add_argument("--dataset", default=DATASET, help="Name of the dataset to test.")
+    ap.add_argument("--model", default="gpt-4", choices=MODELS, help="Name of the model to test.")
+
+    main(ap.parse_args())

--- a/examples/rag_qa/pyproject.toml
+++ b/examples/rag_qa/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.poetry]
+name = "rag_qa"
+version = "0.1.0"
+description = "Example Kolena integration for retrieval-augmented-generation-based question answering"
+authors = ["Kolena Engineering <eng@kolena.io>"]
+license = "Apache-2.0"
+
+[tool.poetry.dependencies]
+python = ">=3.8,<3.11"
+kolena = ">=0.82.0,<1"
+s3fs = "^2022.7.1"
+torch = [
+    { markers = "sys_platform == 'darwin' and platform_machine == 'arm64'", url = "https://download.pytorch.org/whl/cpu/torch-2.0.1-cp39-none-macosx_11_0_arm64.whl" },
+    { markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", url = "https://download.pytorch.org/whl/cpu/torch-2.0.1-cp39-none-macosx_10_9_x86_64.whl" },
+    { markers = "sys_platform != 'darwin'", version = "2.0.1", source = "torch+cpu" }
+]
+evaluate = "^0.4.0"
+bert-score = "^0.3.13"
+rouge-score = "^0.1.2"
+
+[tool.poetry.group.dev.dependencies]
+pre-commit = "^2.17"
+pytest = "^7"
+pytest-depends = "^1.0.1"
+
+[[tool.poetry.source]]
+name = "torch+cpu"
+url = "https://download.pytorch.org/whl/cpu/"
+priority = "explicit"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/examples/rag_qa/rag_qa/__init__.py
+++ b/examples/rag_qa/rag_qa/__init__.py
@@ -11,19 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pydantic.dataclasses import dataclass
-
-from kolena.workflow import define_workflow
-from kolena.workflow import EvaluatorConfiguration
-from kolena.workflow import GroundTruth
-from kolena.workflow import Inference
-from kolena.workflow import Text
-
-workflow, TestCase, TestSuite, Model = define_workflow("Retrieval Augmented Generation", Text, GroundTruth, Inference)
-
-
-@dataclass(frozen=True)
-class Configuration(EvaluatorConfiguration):
-    # leverage DataObject __str__
-    def display_name(self) -> str:
-        return self.__str__()

--- a/examples/rag_qa/rag_qa/constants.py
+++ b/examples/rag_qa/rag_qa/constants.py
@@ -1,0 +1,20 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BUCKET = "kolena-public-datasets"
+SQUAD2_DEV = "squad2-dev"
+SQUAD2_TRAIN = "squad2-train"
+HALU_QA = "halu-qa"
+HALU_DIALOG = "halu-dialog"
+HALU_SUMMARIZATION = "halu-summarization"

--- a/examples/rag_qa/rag_qa/data_loader.py
+++ b/examples/rag_qa/rag_qa/data_loader.py
@@ -1,0 +1,167 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any
+from typing import Dict
+from typing import Tuple
+
+import pandas as pd
+from rag_qa.constants import BUCKET
+from rag_qa.evaluation_prompts import dialogue_instruction
+from rag_qa.evaluation_prompts import qa_instruction
+from rag_qa.evaluation_prompts import summarization_instruction
+
+SQUAD_MODELS = ["IE-Net (ensemble)", "FPNet (ensemble)"]
+HALU_MODELS = ["gpt-3.5-turbo"]
+
+
+def load_squad2_dev() -> pd.DataFrame:
+    dev_json = pd.read_json(f"s3://{BUCKET}/SQuAD2/dev-v2.0.json")
+
+    dev = pd.DataFrame(
+        [
+            {
+                "title": r["title"],
+                "context": p["context"],
+                "question": qas["question"],
+                "id": qas["id"],
+                "answers": qas["answers"],
+                "is_impossible": qas["is_impossible"],
+                "plausible_answers": qas.get("plausible_answers", None),
+            }
+            for r in dev_json["data"]
+            for p in r["paragraphs"]
+            for qas in p["qas"]
+        ],
+    )
+
+    dev["text"] = dev[["context", "question"]].apply(
+        lambda x: "Context:\n{}\n\nQuestion\n{}".format(x["context"], x["question"]),
+        axis=1,
+    )
+    return dev
+
+
+def load_squad_dev_results(model: str) -> pd.DataFrame:
+    assert model in SQUAD_MODELS
+    result = (
+        pd.read_json(f"s3://{BUCKET}/SQuAD2/results/{model}.json", orient="index")
+        .reset_index(
+            names="id",
+        )
+        .rename(columns={0: "answer"})
+    )
+    return result
+
+
+def load_squad2_train() -> pd.DataFrame:
+    train_json = pd.read_json(f"s3://{BUCKET}/SQuAD2/train-v2.0.json")
+
+    train = pd.DataFrame(
+        [
+            {
+                "title": r["title"],
+                "context": p["context"],
+                "question": qas["question"],
+                "id": qas["id"],
+                "answers": qas["answers"],
+                "is_impossible": qas["is_impossible"],
+                "plausible_answers": qas.get(
+                    "plausible_answers",
+                    None,
+                ),
+            }
+            for r in train_json["data"]
+            for p in r["paragraphs"]
+            for qas in p["qas"]
+        ],
+    )
+
+    train["text"] = train[["context", "question"]].apply(
+        lambda x: "Context:\n{}\n\nQuestion\n{}".format(
+            x["context"],
+            x["question"],
+        ),
+        axis=1,
+    )
+    return train
+
+
+def load_halu_qa() -> pd.DataFrame:
+    qa = pd.read_json(f"s3://{BUCKET}/HaLuEval/data/qa_data.json", lines=True)
+    return qa.rename(columns={"knowledge": "text"})
+
+
+def load_halu_qa_results(model: str) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+    assert model in HALU_MODELS
+    qa_results = pd.read_json(f"s3://{BUCKET}/HaLuEval/evaluation/qa_{model}_result.json", lines=True).rename(
+        columns={"knowledge": "text"},
+    )
+
+    system_prompt = (
+        "You are a hallucination detector. You MUST determine if the provided answer contains "
+        "hallucination or not for the question based on the world knowledge. The answer you provided "
+        'MUST be "Yes" or "No"'
+    )
+    user_prompt = qa_instruction + "\n\n#Question#: <question>" + "\n#Answer#: <answer>" + "\n#Your Judgement#: "
+
+    return (
+        qa_results,
+        dict(system_promt=system_prompt, user_prompt=user_prompt),
+    )
+
+
+def load_halu_dialog() -> pd.DataFrame:
+    dialogue = pd.read_json(f"s3://{BUCKET}/HaLuEval/data/dialogue_data.json", lines=True)
+    return dialogue.rename(columns={"knowledge": "text"})
+
+
+def load_halu_dialog_results(model: str) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+    assert model in HALU_MODELS
+    dialogue_results = pd.read_json(
+        f"s3://{BUCKET}/HaLuEval/evaluation/dialogue_{model}_results.json",
+        lines=True,
+    ).rename(columns={"knowledge": "text"})
+
+    system_prompt = (
+        "You are a response judge. You MUST determine if the provided response contains non-factual or "
+        'hallucinated information. The answer you give MUST be "Yes" or "No"'
+    )
+    user_prompt = (
+        dialogue_instruction + "\n\n#Dialogue History#: <dialog>" + "\n#Response#: <response>\n#Your Judgement#: "
+    )
+
+    return dialogue_results, dict(system_prompt=system_prompt, user_prompt=user_prompt)
+
+
+def load_halu_summarization() -> pd.DataFrame:
+    summarization = pd.read_json(f"s3://{BUCKET}/HaLuEval/data/summarization_data.json", lines=True)
+    return summarization.rename(columns={"document": "text"})
+
+
+def load_halu_summarization_results(model: str) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+    assert model in HALU_MODELS
+    summarization_results = pd.read_json(
+        f"s3://{BUCKET}/HaLuEval/evaluation/summarization_{model}_results.json",
+        lines=True,
+    ).rename(columns={"document": "text"})
+
+    system_prompt = (
+        "You are a summary judge. You MUST determine if the provided summary contains non-factual "
+        'or hallucinated information. The answer you give MUST be "Yes" or "No"'
+    )
+    user_prompt = (
+        summarization_instruction + "\n\n#Document#: <document>" + "\n#Summary#: <summary>" + "\n#Your Judgement#: "
+    )
+
+    return summarization_results, dict(system_promt=system_prompt, user_prompt=user_prompt)

--- a/examples/rag_qa/rag_qa/data_loader.py
+++ b/examples/rag_qa/rag_qa/data_loader.py
@@ -52,7 +52,7 @@ def load_squad2_dev() -> pd.DataFrame:
     return dev
 
 
-def load_squad_dev_results(model: str) -> pd.DataFrame:
+def load_squad2_dev_results(model: str) -> Tuple[pd.DataFrame, Dict[str, Any]]:
     assert model in SQUAD_MODELS
     result = (
         pd.read_json(f"s3://{BUCKET}/SQuAD2/results/{model}.json", orient="index")
@@ -61,7 +61,7 @@ def load_squad_dev_results(model: str) -> pd.DataFrame:
         )
         .rename(columns={0: "answer"})
     )
-    return result
+    return result, {}
 
 
 def load_squad2_train() -> pd.DataFrame:

--- a/examples/rag_qa/rag_qa/evaluation_prompts.py
+++ b/examples/rag_qa/rag_qa/evaluation_prompts.py
@@ -1,0 +1,155 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+qa_instruction = """
+I want you act as an answer judge. Given a question and an answer, your objective is to determine if the provided
+answer contains non-factual or hallucinated information. You SHOULD give your judgement based on the following
+hallucination types and the world knowledge.
+
+You are trying to determine if the answer misunderstands the question context and intention.
+#Question#: What is a rare breed of dog that was derived as a variant of Rat Terrier, Shiloh Shepherd dog or American
+Hairless Terrier?
+#Answer#: American Hairless Terrier
+#Your Judgement#: No
+
+You are trying to determine if there is a factual contradiction between the answer and the world knowledge. Some
+information in the answer might be fabricated.
+#Question#: Are the New Orleans Outfall Canals the same length as the Augusta Canal?
+#Answer#: No, the New Orleans Outfall Canals and the Augusta Canal are not the same length. The Orleans Canal is
+approximately 3.6 miles (5.8 kilometers) long while the Augusta Canal is approximately 7 miles (11.3 kilometers) long.
+#Your Judgement#: Yes
+#Question#: What U.S Highway gives access to Zilpo Road, and is also known as Midland Trail?
+#Answer#: U.S Highway 70
+#Your Judgement#: Yes
+
+You are trying to determine if the answer is too general or too specific to answer the question at an appropriate
+level of specificity.
+#Question#: What genre do Superheaven and Oceansize belong to?
+#Answer#: Superheaven and Oceansize belong to the rock genre.
+#Your Judgement#: No
+#Question#: What profession do Kōbō Abe and Agatha Christie share?
+#Answer#: Playwright.
+#Your Judgement#: No
+
+You are trying to determine if the answer can be correctly inferred from the knowledge.
+#Question#: Which band has more members, Muse or The Raconteurs?
+#Answer#: Muse has more members than The Raconteurs.
+#Your Judgement#: Yes
+#Question#: Which is currently more valuable, Temagami-Lorrain Mine or Meadowbank Gold Mine?
+#Answer#: Meadowbank Gold Mine, since Meadowbank Gold Mine is still producing gold and the TemagamiLorrain Mine has
+been inactive for years.
+#Your Judgement#: No
+
+You should try your best to determine if the answer contains non-factual or hallucinated information according to the
+above hallucination types. The answer you give MUST be \"Yes\" or \"No\"".
+"""
+
+dialogue_instruction = """
+I want you act as a response judge. Given a dialogue history and a response, your objective is to determine if the
+provided response contains non-factual or hallucinated information. You SHOULD give your judgement based on the
+following hallucination types and the world knowledge.
+
+You are trying to determine if the true entity in the response is replaced with a highly similar entity.
+#Dialogue History#: [Human]: Could you recommand movies similar to The Dark Knight? [Assistant]: The sequel to Batman
+Begins is The Dark Knight. [Human]: Okay. Who is the director of The Dark Knight and any other movies from him not
+related to Batman?
+#Response#: Christopher Nolan was the director. He also directed insomnia and inception.
+#Your Judgement#: No
+#Dialogue History#: [Human]: Could you recommand movies similar to The Dark Knight? [Assistant]: The sequel to Batman
+Begins is The Dark Knight. [Human]: Okay. Who is the director of The Dark Knight and any other movies from him not
+related to Batman?
+#Response#: Steven Spielberg was the director. He also directed insomnia and inception.
+#Your Judgement#: Yes
+
+You are trying to determine if the true entity in the response is replaced with a dissimilar entity.
+#Dialogue History#: [Human]: Could you recommand movies similar to The Dark Knight? [Assistant]: The sequel to Batman
+Begins is The Dark Knight. [Human]: Okay. Who is the director of The Dark Knight and any other movies from him not
+related to Batman?
+#Response#: Christopher Nolan was the director. He also directed insomnia and inception.
+#Your Judgement#: No
+#Dialogue History#: [Human]: Could you recommand movies similar to The Dark Knight? [Assistant]: The sequel to Batman
+Begins is The Dark Knight. [Human]: Okay. Who is the director of The Dark Knight and any other movies from him not
+related to Batman?
+#Response#: Batman Begins was the director. He also directed insomnia and inception.
+#Your Judgement#: Yes
+
+You are trying to determine if the true entity in the response is replaced with a dissimilar entity in a different
+entity type.
+#Dialogue History#: [Human]: Could you recommand movies similar to The Dark Knight? [Assistant]: The sequel to Batman
+Begins is The Dark Knight. [Human]: Okay. Who is the director of The Dark Knight and any other movies from him not
+related to Batman?
+#Response#: Christopher Nolan was the director. He also directed insomnia and inception.
+#Your Judgement#: No
+#Dialogue History#: [Human]: Could you recommand movies similar to The Dark Knight? [Assistant]: The sequel to Batman
+Begins is The Dark Knight. [Human]: Okay. Who is the director of The Dark Knight and any other movies from him not
+related to Batman?
+#Response#: United States of America was the director. He also directed insomnia and inception.
+#Your Judgement#: Yes
+
+You should try your best to determine if the response contains non-factual or hallucinated information according to
+the above hallucination types. The answer you give MUST be \"Yes\" or \"No\"".
+"""
+
+summarization_instruction = """
+I want you act as a summary judge. Given a document and a summary, your objective is to determine if the provided
+summary contains non-factual or hallucinated information. You SHOULD give your judgement based on the following
+hallucination types and the world knowledge.
+
+You are trying to determine if the summary is factual but some information cannot be directly inferred or entailed
+from the document.
+#Document#: The panther chameleon was found on Monday by a dog walker in the wooded area at Marl Park. It had to be
+put down after X-rays showed all of its legs were broken and it had a deformed spine. RSPCA Cymru said it was an
+"extremely sad example of an abandoned and neglected exotic pet". Inspector Selina Chan said: "It is a possibility
+that the owners took on this animal but were unable to provide the care he needs and decided to release him to the
+wild. "We are urging potential owners of exotic animals to thoroughly research what is required in the care of the
+particular species before taking one on. "Potential owners need to make sure they can give their animal the
+environment it needs and they have the facilities, time, financial means and long-term commitment to maintain a good
+standard of care, as required under the Animal Welfare Act 2006." She added it was illegal to release non-native
+species into the wild.
+#Summary#: A chameleon that was found in a Cardiff park has been put down after being abandoned and neglected by its
+owners.
+#Your Judgement#: Yes
+
+You are trying to determine if there exists some non-factual and incorrect information in the summary.
+#Document#: The city was brought to a standstill on 15 December last year when a gunman held 18 hostages for 17
+hours. Family members of victims Tori Johnson and Katrina Dawson were in attendance. Images of the floral tributes
+that filled the city centre in the wake of the siege were projected on to the cafe and surrounding buildings in an
+emotional twilight ceremony. Prime Minister Malcolm Turnbull gave an address saying a "whole nation resolved to
+answer hatred with love". "Testament to the spirit of Australians is that with such unnecessary, thoughtless tragedy,
+an amazing birth of mateship, unity and love occurs. Proud to be Australian," he said. How the Sydney siege unfolded
+New South Wales Premier Mike Baird has also announced plans for a permanent memorial to be built into the pavement in
+Martin Place. Clear cubes containing flowers will be embedded into the concrete and will shine with specialised
+lighting. It is a project inspired by the massive floral tributes that were left in the days after the siege.
+"Something remarkable happened here. As a city we were drawn to Martin Place. We came in shock and in sorrow but
+every step we took was with purpose," he said on Tuesday.
+#Summary#: Crowds have gathered in Sydney's Martin Place to honour the victims of the Lindt cafe siege, one year on.
+#Your Judgement#: No
+
+You are trying to determine if there is a factual contradiction between the summary and the document.
+#Document#: Christopher Huxtable, 34, from Swansea, had been missing since the collapse in February. His body was
+found on Wednesday and workers who carried out the search formed a guard of honour as it was driven from the site in
+the early hours of the morning. Ken Cresswell, 57, and John Shaw, 61, both from Rotherham, remain missing. The body
+of a fourth man, Michael Collings, 53, from Brotton, Teesside, was previously recovered from the site. Swansea East
+MP Carolyn Harris, who has been involved with the family since the incident, said they still did not know all the
+facts about the collapse. She said: "I feel very sad. My heart and my prayers go out to the family who have waited
+desperately for Christopher's body to be found. They can finally have closure, and say goodbye to him and grieve his
+loss. "But let's not forget that there's two other families who are still waiting for their loved ones to be
+returned." The building was due for demolition when it partially collapsed in February.
+#Summary#: The body of a man whose body was found at the site of the Swansea Bay Power Station collapse has been
+removed from the site.
+#Your Judgement#: Yes
+
+You should try your best to determine if the summary contains non-factual or hallucinated information according to
+the above hallucination types. The answer you give MUST be \"Yes\" or \"No\"".
+"""

--- a/examples/rag_qa/rag_qa/evaluator.py
+++ b/examples/rag_qa/rag_qa/evaluator.py
@@ -1,0 +1,112 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+import evaluate
+from rag_qa.utils import compute_metric_bar_plot
+from rag_qa.utils import compute_score_distribution_plot
+from rag_qa.utils import mean_metric
+from rag_qa.workflow import Configuration
+from rag_qa.workflow import TestCase
+
+from kolena.workflow import Inference
+from kolena.workflow import MetricsTestCase
+from kolena.workflow import MetricsTestSample
+from kolena.workflow import MetricsTestSuite
+from kolena.workflow import Plot
+from kolena.workflow import Text
+
+bertscore = evaluate.load("bertscore")
+rouge = evaluate.load("rouge")
+
+
+def compute_metrics(norm_gt_answer: str, norm_inf_answer: str) -> Dict[str, float]:
+    bertscore_results = bertscore.compute(
+        predictions=[norm_inf_answer],
+        references=[norm_gt_answer],
+        lang="en",
+        model_type="distilbert-base-uncased",
+    )
+
+    rouge_results = rouge.compute(
+        predictions=[norm_inf_answer],
+        references=[norm_gt_answer],
+        rouge_types=["rouge1", "rouge2", "rougeL"],
+    )
+
+    return {
+        "BERT_prec": bertscore_results["precision"][0],
+        "BERT_rec": bertscore_results["recall"][0],
+        "BERT_f1": bertscore_results["f1"][0],
+        "ROUGE_1": rouge_results["rouge1"],
+        "ROUGE_2": rouge_results["rouge2"],
+        "ROUGE_L": rouge_results["rougeL"],
+    }
+
+
+def compute_test_sample_metrics(gt: str, inf: str, configuration: Configuration):
+    results = compute_metrics(gt, inf)
+    custom_metric = round((results["BERT_f1"] + results["ROUGE_1"]) / 2, 3)
+    return MetricsTestSample(
+        BERT_prec=results["BERT_prec"],
+        BERT_rec=results["BERT_rec"],
+        BERT_f1=results["BERT_f1"],
+        MEAN_METRIC=custom_metric,
+        ROUGE_1=results["ROUGE_1"],
+        ROUGE_2=results["ROUGE_2"],
+        ROUGE_L=results["ROUGE_L"],
+    )
+
+
+def compute_test_case_metrics(
+    metrics: List[MetricsTestSample],
+) -> MetricsTestCase:
+    return MetricsTestSample(
+        BERT_prec=mean_metric("BERT_prec", metrics),
+        BERT_rec=mean_metric("BERT_rec", metrics),
+        BERT_f1=mean_metric("BERT_f1", metrics),
+        MEAN_METRIC=mean_metric("MEAN_METRIC", metrics),
+        ROUGE_1=mean_metric("ROUGE_1", metrics),
+        ROUGE_2=mean_metric("ROUGE_2", metrics),
+        ROUGE_L=mean_metric("ROUGE_L", metrics),
+    )
+
+
+def compute_test_case_plots(
+    test_samples: List[Text],
+    inferences: List[Inference],
+    metrics: List[MetricsTestSample],
+) -> Optional[List[Plot]]:
+    metrics_of_interest = ["BERT_f1", "ROUGE_1", "MEAN_METRIC"]
+    metric_values = [mean_metric(metric, metrics) for metric in metrics_of_interest]
+
+    plots: List[Plot] = [
+        compute_metric_bar_plot(metrics_of_interest, metric_values),
+        compute_score_distribution_plot("BERT_f1", metrics, (0, 1, 101)),
+        compute_score_distribution_plot("ROUGE_1", metrics, (0, 1, 101)),
+        compute_score_distribution_plot("ROUGE_L", metrics, (0, 1, 101)),
+        compute_score_distribution_plot("MEAN_METRIC", metrics, (0, 1, 101)),
+    ]
+
+    return [plot for plot in plots if plot is not None]
+
+
+def compute_test_suite_metrics(
+    test_samples: List[Text],
+    test_case_metrics: List[Tuple[TestCase, MetricsTestCase]],
+) -> MetricsTestSuite:
+    return MetricsTestSuite()

--- a/examples/rag_qa/rag_qa/evaluator.py
+++ b/examples/rag_qa/rag_qa/evaluator.py
@@ -75,7 +75,7 @@ def compute_test_sample_metrics(gt: str, inf: str, configuration: Configuration)
 def compute_test_case_metrics(
     metrics: List[MetricsTestSample],
 ) -> MetricsTestCase:
-    return MetricsTestSample(
+    return MetricsTestCase(
         BERT_prec=mean_metric("BERT_prec", metrics),
         BERT_rec=mean_metric("BERT_rec", metrics),
         BERT_f1=mean_metric("BERT_f1", metrics),

--- a/examples/rag_qa/rag_qa/seed_dataset.py
+++ b/examples/rag_qa/rag_qa/seed_dataset.py
@@ -1,0 +1,129 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+from argparse import Namespace
+
+import pandas as pd
+
+import kolena
+from kolena._experimental.dataset import register_dataset
+
+BUCKET = "kolena-public-datasets"
+
+
+def seed_squad2_dev():
+    dev_json = pd.read_json(f"s3://{BUCKET}/SQuAD2/dev-v2.0.json")
+
+    dev = pd.DataFrame(
+        [
+            {
+                "title": r["title"],
+                "context": p["context"],
+                "question": qas["question"],
+                "id": qas["id"],
+                "answers": qas["answers"],
+                "is_impossible": qas["is_impossible"],
+                "plausible_answers": qas.get("plausible_answers", None),
+            }
+            for r in dev_json["data"]
+            for p in r["paragraphs"]
+            for qas in p["qas"]
+        ],
+    )
+
+    register_dataset("SQuAD 2.0 Dev", dev)
+
+
+def seed_squad2_train():
+    train_json = pd.read_json(f"s3://{BUCKET}/SQuAD2/train-v2.0.json")
+
+    train = pd.DataFrame(
+        [
+            {
+                "title": r["title"],
+                "context": p["context"],
+                "question": qas["question"],
+                "id": qas["id"],
+                "answers": qas["answers"],
+                "is_impossible": qas["is_impossible"],
+                "plausible_answers": qas.get(
+                    "plausible_answers",
+                    None,
+                ),
+            }
+            for r in train_json["data"]
+            for p in r["paragraphs"]
+            for qas in p["qas"]
+        ],
+    )
+
+    train["text"] = train[["context", "question"]].apply(
+        lambda x: "Context:\n{}\n\nQuestion\n{}".format(
+            x["context"],
+            x["question"],
+        ),
+        axis=1,
+    )
+
+    register_dataset("SQuAD 2.0 Train", train)
+
+
+def seed_halu_qa():
+    qa = pd.read_json(f"{BUCKET}/HaluEval/data/qa_data.json", lines=True)
+    register_dataset("HaLuEval qa", qa.rename(columns={"knowledge": "text"}))
+
+
+def seed_halu_dialog():
+    dialogue = pd.read_json(f"{BUCKET}/HaluEval/data/dialogue_data.json", lines=True)
+    register_dataset("HaLuEval dialogue", dialogue.rename(columns={"knowledge": "text"}))
+
+
+def seed_halu_summarization():
+    summarization = pd.read_json(f"s3://{BUCKET}/HaluEval/data/summarization_data.json", lines=True)
+    register_dataset("HaLuEval summarization", summarization.rename(columns={"document": "text"}))
+
+
+def main(args: Namespace) -> int:
+    benchmark = args.benchmark
+    kolena.initialize()
+    if benchmark == "squad2-dev":
+        seed_squad2_dev()
+    elif benchmark == "sqaud2-train":
+        seed_squad2_train()
+    elif benchmark == "halu-qa":
+        seed_halu_qa()
+    elif benchmark == "halu-dialog":
+        seed_halu_dialog()
+    elif benchmark == "halu-summarization":
+        seed_halu_summarization()
+    else:
+        # seed all
+        seed_squad2_train()
+        seed_squad2_dev()
+        seed_halu_qa()
+        seed_halu_dialog()
+        seed_halu_summarization()
+
+    return 0
+
+
+if __name__ == "__main__":
+    ap = ArgumentParser()
+    ap.add_argument(
+        "--benchmark",
+        choices=["squad2-dev", "squad2-train", "halu-qa", "halu-dialog", "halu-summarization"],
+        help="Name of the benchmark to seed.",
+    )
+
+    main(ap.parse_args())

--- a/examples/rag_qa/rag_qa/seed_dataset.py
+++ b/examples/rag_qa/rag_qa/seed_dataset.py
@@ -30,24 +30,39 @@ import kolena
 from kolena._experimental.dataset import register_dataset
 
 
-def seed_squad2_dev():
-    register_dataset("SQuAD 2.0 Dev", load_squad2_dev())
+def seed_squad2_dev(sample_count: int = 0):
+    dataset = "SQuAD 2.0 Dev"
+    if sample_count:
+        dataset = f"{dataset} ({sample_count})"
+    register_dataset(dataset, load_squad2_dev(sample_count))
 
 
-def seed_squad2_train():
-    register_dataset("SQuAD 2.0 Train", load_squad2_train())
+def seed_squad2_train(sample_count: int = 0):
+    dataset = "SQuAD 2.0 Train"
+    if sample_count:
+        dataset = f"{dataset} ({sample_count})"
+    register_dataset(dataset, load_squad2_train(sample_count))
 
 
-def seed_halu_qa():
-    register_dataset("HaLuEval qa", load_halu_qa())
+def seed_halu_qa(sample_count: int = 0):
+    dataset = "HaLuEval qa"
+    if sample_count:
+        dataset = f"{dataset} ({sample_count})"
+    register_dataset(dataset, load_halu_qa())
 
 
-def seed_halu_dialog():
-    register_dataset("HaLuEval dialogue", load_halu_dialog())
+def seed_halu_dialog(sample_count: int = 0):
+    dataset = "HaLuEval dialogue"
+    if sample_count:
+        dataset = f"{dataset} ({sample_count})"
+    register_dataset(dataset, load_halu_dialog())
 
 
-def seed_halu_summarization():
-    register_dataset("HaLuEval summarization", load_halu_summarization())
+def seed_halu_summarization(sample_count: int = 0):
+    dataset = "HaLuEval summarization"
+    if sample_count:
+        dataset = f"{dataset} ({sample_count})"
+    register_dataset(dataset, load_halu_summarization())
 
 
 proc = OrderedDict(
@@ -65,12 +80,12 @@ def main(args: Namespace) -> None:
     benchmark = args.benchmark
     kolena.initialize(verbose=True)
     if benchmark:
-        proc[benchmark]()
+        proc[benchmark](args.sample_count)
     else:
         # seed all
         for dataset, func in proc.items():
             print(f"seeding {dataset}")
-            func()
+            func(args.sample_count)
 
 
 if __name__ == "__main__":
@@ -80,5 +95,6 @@ if __name__ == "__main__":
         choices=[SQUAD2_DEV, SQUAD2_TRAIN, HALU_QA, HALU_DIALOG, HALU_SUMMARIZATION],
         help="Name of the benchmark to seed.",
     )
+    ap.add_argument("--sample-count", default=0, type=int, help="Number of samples")
 
     main(ap.parse_args())

--- a/examples/rag_qa/rag_qa/seed_results.py
+++ b/examples/rag_qa/rag_qa/seed_results.py
@@ -1,0 +1,140 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+from argparse import Namespace
+
+import pandas as pd
+from rag_qa.seed_dataset import BUCKET
+
+import kolena
+from kolena._experimental.dataset import test
+
+
+def submit_squad_dev() -> None:
+    model = "IE-Net (ensemble)"
+    # model = "FPNet (ensemble)"
+    result_json = pd.read_json(f"s3://{BUCKET}/SQuAD2/results/{model}.json")
+    result = pd.DataFrame([dict(id=id, answer=ans) for id, ans in result_json.items()])
+    test("SQuAD 2.0 Dev", model, result, on="id")
+
+
+def submit_qa() -> None:
+    qa_results = pd.read_json(f"s3://{BUCKET}/HaLuEval/evaluation/qa/qa_gpt-3.5-turbo_result.json", lines=True)
+    kolena.initialize()
+
+    with open("evaluation/qa/qa_evaluation_instruction.txt") as f:
+        instruction = f.read()
+
+    system_prompt = (
+        "You are a hallucination detector. You MUST determine if the provided answer contains "
+        "hallucination or not for the question based on the world knowledge. The answer you provided "
+        'MUST be "Yes" or "No"'
+    )
+    user_prompt = instruction + "\n\n#Question#: <question>" + "\n#Answer#: <answer>" + "\n#Your Judgement#: "
+
+    test(
+        "HaLuEval qa",
+        "gpt-3.5-turbo",
+        [
+            (
+                dict(system_promt=system_prompt, user_prompt=user_prompt),
+                qa_results.rename(columns={"knowledge": "text"}),
+            ),
+        ],
+        on=["text", "question"],
+    )
+    print(qa_results.shape)
+
+
+def submit_dialogue() -> None:
+    # dialogue = pd.read_json("data/dialogue_data.json", lines=True)
+    dialogue_results = pd.read_json(
+        f"s3://{BUCKET}/HaLuEval/evaluation/dialogue/dialogue_gpt-3.5-turbo_results.json",
+        lines=True,
+    )
+
+    with open("evaluation/dialogue/dialogue_evaluation_instruction.txt") as f:
+        instruction = f.read()
+
+    system_prompt = (
+        "You are a response judge. You MUST determine if the provided response contains non-factual or "
+        'hallucinated information. The answer you give MUST be "Yes" or "No"'
+    )
+    user_prompt = instruction + "\n\n#Dialogue History#: <dialog>" + "\n#Response#: <response>" + "\n#Your Judgement#: "
+
+    kolena.initialize()
+    test(
+        "HaLuEval dialogue",
+        "gpt-3.5-turbo",
+        [
+            (
+                dict(system_prompt=system_prompt, user_prompt=user_prompt),
+                dialogue_results.rename(columns={"knowledge": "text"}),
+            ),
+        ],
+        on=["text", "dialogue_history"],
+    )
+    print(dialogue_results.shape)
+
+
+def submit_summarization() -> None:
+    summarization_results = pd.read_json(
+        "evaluation/summarization/summarization_gpt-3.5-turbo_results.json",
+        lines=True,
+    )
+
+    with open("evaluation/summarization/summarization_evaluation_instruction.txt") as f:
+        instruction = f.read()
+
+    system_prompt = (
+        "You are a summary judge. You MUST determine if the provided summary contains non-factual "
+        'or hallucinated information. The answer you give MUST be "Yes" or "No"'
+    )
+    user_prompt = instruction + "\n\n#Document#: <document>" + "\n#Summary#: <summary>" + "\n#Your Judgement#: "
+
+    test(
+        "HaLuEval summarization",
+        "gpt-3.5-turbo",
+        [
+            (
+                dict(system_promt=system_prompt, user_prompt=user_prompt),
+                summarization_results.rename(columns={"document": "text"}),
+            ),
+        ],
+        on=["text"],
+    )
+    print(summarization_results.shape)
+
+
+def main(args: Namespace) -> None:
+    kolena.initialize()
+
+
+if __name__ == "__main__":
+    ap = ArgumentParser()
+    ap.add_argument(
+        "--benchmark",
+        choices=["squad2-dev", "squad2-train", "halu-qa", "halu-dialog", "halu-summarization"],
+        required=True,
+        help="Name of the benchmark to seed.",
+    )
+    ap.add_argument(
+        "--model",
+        choices=["squad2-dev", "squad2-train", "halu-qa", "halu-dialog", "halu-summarization"],
+        required=True,
+        help="Name of the benchmark to seed.",
+    )
+    ap.add_argument("--dataset-name", help="")
+
+    main(ap.parse_args())

--- a/examples/rag_qa/rag_qa/seed_results.py
+++ b/examples/rag_qa/rag_qa/seed_results.py
@@ -30,30 +30,38 @@ import kolena
 from kolena._experimental.dataset import test
 
 
-def submit_squad_dev(model: str, dataset: Optional[str] = None) -> None:
+def submit_squad_dev(model: str, sample_count: int = 0, dataset: Optional[str] = None) -> None:
     dataset = dataset or "SQuAD 2.0 Dev"
+    if sample_count:
+        dataset = f"{dataset} ({sample_count})"
     result, _ = load_squad2_dev_results(model)
     test(dataset, model, result, on="id")
 
 
-def submit_qa(model: str, dataset: Optional[str] = None) -> None:
+def submit_qa(model: str, sample_count: int = 0, dataset: Optional[str] = None) -> None:
     dataset = dataset or "HaLuEval qa"
+    if sample_count:
+        dataset = f"{dataset} ({sample_count})"
     qa_results, config = load_halu_qa_results(model)
 
     test(dataset, model, [(config, qa_results)], on=["text", "question"])
     print(qa_results.shape)
 
 
-def submit_dialogue(model: str, dataset: Optional[str] = None) -> None:
+def submit_dialogue(model: str, sample_count: int = 0, dataset: Optional[str] = None) -> None:
     dataset = dataset or "HaLuEval dialogue"
+    if sample_count:
+        dataset = f"{dataset} ({sample_count})"
     dialogue_results, config = load_halu_dialog_results(model)
 
     test(dataset, model, [(config, dialogue_results)], on=["text", "dialogue_history"])
     print(dialogue_results.shape)
 
 
-def submit_summarization(model: str, dataset: Optional[str] = None) -> None:
+def submit_summarization(model: str, sample_count: int = 0, dataset: Optional[str] = None) -> None:
     dataset = dataset or "HaLuEval summarization"
+    if sample_count:
+        dataset = f"{dataset} ({sample_count})"
     summarization_results, config = load_halu_summarization_results(model)
 
     # TODO: this does not work yet because of non-trivial join between data and result json
@@ -72,7 +80,7 @@ proc = {
 def main(args: Namespace) -> None:
     kolena.initialize(verbose=True)
 
-    proc[args.benchmark](args.model, args.dataset_name)
+    proc[args.benchmark](args.model, sample_count=args.sample_count, dataset=args.dataset_name)
 
 
 if __name__ == "__main__":
@@ -90,5 +98,6 @@ if __name__ == "__main__":
         help="Name of the model to seed.",
     )
     ap.add_argument("--dataset-name", help="dataset name")
+    ap.add_argument("--sample-count", default=0, type=int, help="Number of samples")
 
     main(ap.parse_args())

--- a/examples/rag_qa/rag_qa/seed_results.py
+++ b/examples/rag_qa/rag_qa/seed_results.py
@@ -23,7 +23,7 @@ from rag_qa.data_loader import HALU_MODELS
 from rag_qa.data_loader import load_halu_dialog_results
 from rag_qa.data_loader import load_halu_qa_results
 from rag_qa.data_loader import load_halu_summarization_results
-from rag_qa.data_loader import load_squad_dev_results
+from rag_qa.data_loader import load_squad2_dev_results
 from rag_qa.data_loader import SQUAD_MODELS
 
 import kolena
@@ -32,7 +32,7 @@ from kolena._experimental.dataset import test
 
 def submit_squad_dev(model: str, dataset: Optional[str] = None) -> None:
     dataset = dataset or "SQuAD 2.0 Dev"
-    result = load_squad_dev_results(model)
+    result, _ = load_squad2_dev_results(model)
     test(dataset, model, result, on="id")
 
 
@@ -40,7 +40,7 @@ def submit_qa(model: str, dataset: Optional[str] = None) -> None:
     dataset = dataset or "HaLuEval qa"
     qa_results, config = load_halu_qa_results(model)
 
-    test(dataset, model, [(config, qa_results.rename(columns={"knowledge": "text"}))], on=["text", "question"])
+    test(dataset, model, [(config, qa_results)], on=["text", "question"])
     print(qa_results.shape)
 
 

--- a/examples/rag_qa/rag_qa/seed_test_run.py
+++ b/examples/rag_qa/rag_qa/seed_test_run.py
@@ -121,6 +121,8 @@ def main(args: Namespace) -> None:
 
     benchmark = args.benchmark
     test_suite_name = args.test_suite or benchmark
+    if args.sample_count:
+        test_suite_name = f"{test_suite_name} ({args.sample_count})"
     df, config = results_loader[args.benchmark](args.model)
     keys = key_columns[benchmark]
     df = df.set_index(keys)
@@ -146,6 +148,7 @@ if __name__ == "__main__":
         help="Name of the benchmark to test.",
     )
     ap.add_argument("--model", choices=SQUAD_MODELS + HALU_MODELS, help="Name of the model to test.")
+    ap.add_argument("--sample-count", default=0, type=int, help="Number of samples in the test-suite.")
     ap.add_argument("--test_suite", help="Name of the test suite to test.")
 
     main(ap.parse_args())

--- a/examples/rag_qa/rag_qa/seed_test_run.py
+++ b/examples/rag_qa/rag_qa/seed_test_run.py
@@ -1,0 +1,151 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+from argparse import Namespace
+from collections import OrderedDict
+from typing import Callable
+from typing import List
+from typing import Tuple
+
+from rag_qa.constants import HALU_DIALOG
+from rag_qa.constants import HALU_QA
+from rag_qa.constants import HALU_SUMMARIZATION
+from rag_qa.constants import SQUAD2_DEV
+from rag_qa.data_loader import HALU_MODELS
+from rag_qa.data_loader import load_halu_dialog_results
+from rag_qa.data_loader import load_halu_qa_results
+from rag_qa.data_loader import load_halu_summarization_results
+from rag_qa.data_loader import load_squad2_dev_results
+from rag_qa.data_loader import SQUAD_MODELS
+from rag_qa.evaluator import compute_test_case_metrics
+from rag_qa.evaluator import compute_test_case_plots
+from rag_qa.evaluator import compute_test_sample_metrics
+from rag_qa.evaluator import compute_test_suite_metrics
+from rag_qa.utils import normalize_string
+from rag_qa.workflow import Configuration
+from rag_qa.workflow import Inference
+from rag_qa.workflow import Model
+from rag_qa.workflow import TestCase
+from rag_qa.workflow import TestSuite
+from tqdm import tqdm
+
+import kolena
+from kolena.workflow import BasicEvaluatorFunction
+from kolena.workflow import EvaluationResults
+from kolena.workflow import GroundTruth
+from kolena.workflow import MetricsTestCase
+from kolena.workflow import Plot
+from kolena.workflow import test
+from kolena.workflow import TestCases
+from kolena.workflow import Text
+
+results_loader = OrderedDict(
+    [
+        (SQUAD2_DEV, load_squad2_dev_results),
+        (HALU_QA, load_halu_qa_results),
+        (HALU_DIALOG, load_halu_dialog_results),
+        (HALU_SUMMARIZATION, load_halu_summarization_results),
+    ],
+)
+
+key_columns = {
+    SQUAD2_DEV: ["id"],
+    HALU_QA: ["text", "question"],
+    HALU_DIALOG: ["text", "dialogue_history"],
+    # TODO: does not work yet due to non-trivial matching between test-sample and inference
+    HALU_SUMMARIZATION: ["text"],
+}
+
+answer_getters = {
+    SQUAD2_DEV: lambda gt, inf: (gt.answers[0] if gt.answers else "", inf.answer),
+    HALU_QA: lambda gt, inf: (gt.right_answer, inf.answer),
+    HALU_DIALOG: lambda gt, inf: (gt.right_response, inf.answer),
+    HALU_SUMMARIZATION: lambda gt, inf: (gt.right_summary, inf.answer),
+}
+
+
+def get_evaluator(getter: Callable[[GroundTruth, Inference], Tuple[str, str]]) -> BasicEvaluatorFunction:
+    def evaluator(
+        test_samples: List[Text],
+        ground_truths: List[GroundTruth],
+        inferences: List[Inference],
+        test_cases: TestCases,
+        configuration: Configuration,
+    ) -> EvaluationResults:
+        # compute sample-level metrics for each sample
+        test_sample_metrics = []
+        for gt, inf in tqdm(zip(ground_truths, inferences), total=len(ground_truths)):
+            gt_val, inf_val = getter(gt, inf)
+            test_sample_metrics.append(
+                compute_test_sample_metrics(normalize_string(gt_val), normalize_string(inf_val), configuration),
+            )
+
+        # compute aggregate metrics across all test cases using `test_cases.iter(...)`
+        all_test_case_metrics: List[Tuple[TestCase, MetricsTestCase]] = []
+        all_test_case_plots: List[Tuple[TestCase, List[Plot]]] = []
+        for test_case, ts, gt, inf, tsm in test_cases.iter(
+            test_samples,
+            ground_truths,
+            inferences,
+            test_sample_metrics,
+        ):
+            all_test_case_metrics.append((test_case, compute_test_case_metrics(tsm)))
+            all_test_case_plots.append((test_case, compute_test_case_plots(ts, inf, tsm)))
+
+        test_suite_metrics = compute_test_suite_metrics(test_samples, all_test_case_metrics)
+
+        # if desired, compute and add `plots_test_case` and `metrics_test_suite` to this `EvaluationResults`
+        return EvaluationResults(
+            metrics_test_sample=list(zip(test_samples, test_sample_metrics)),
+            metrics_test_case=all_test_case_metrics,
+            plots_test_case=all_test_case_plots,
+            metrics_test_suite=test_suite_metrics,
+        )
+
+    return evaluator
+
+
+def main(args: Namespace) -> None:
+    kolena.initialize(verbose=True)
+
+    benchmark = args.benchmark
+    test_suite_name = args.test_suite or benchmark
+    df, config = results_loader[args.benchmark](args.model)
+    keys = key_columns[benchmark]
+    df = df.set_index(keys)
+
+    # define a function that generates an inference from a test sample
+    def infer(test_sample: Text) -> Inference:
+        target = [getattr(test_sample, k) for k in keys]
+        result = df.loc[target].to_dict(orient="records")[0]
+        return Inference(**result)
+
+    model = Model(args.model, infer=infer)
+    test_suite = TestSuite.load(test_suite_name)
+    evaluator = get_evaluator(answer_getters[benchmark])
+    test(model, test_suite, evaluator, [Configuration(**config)], reset=True)
+
+
+if __name__ == "__main__":
+    ap = ArgumentParser()
+    ap.add_argument(
+        "--benchmark",
+        choices=[SQUAD2_DEV, HALU_QA, HALU_DIALOG, HALU_SUMMARIZATION],
+        required=True,
+        help="Name of the benchmark to test.",
+    )
+    ap.add_argument("--model", choices=SQUAD_MODELS + HALU_MODELS, help="Name of the model to test.")
+    ap.add_argument("--test_suite", help="Name of the test suite to test.")
+
+    main(ap.parse_args())

--- a/examples/rag_qa/rag_qa/seed_test_suite.py
+++ b/examples/rag_qa/rag_qa/seed_test_suite.py
@@ -1,0 +1,100 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+from argparse import Namespace
+from collections import OrderedDict
+from typing import Optional
+
+from rag_qa.constants import HALU_DIALOG
+from rag_qa.constants import HALU_QA
+from rag_qa.constants import HALU_SUMMARIZATION
+from rag_qa.constants import SQUAD2_DEV
+from rag_qa.constants import SQUAD2_TRAIN
+from rag_qa.data_loader import load_halu_dialog
+from rag_qa.data_loader import load_halu_qa
+from rag_qa.data_loader import load_halu_summarization
+from rag_qa.data_loader import load_squad2_dev
+from rag_qa.data_loader import load_squad2_train
+from rag_qa.workflow import GroundTruth
+from rag_qa.workflow import TestCase
+from rag_qa.workflow import TestSuite
+
+import kolena
+from kolena.workflow import Text
+
+
+def clean_name(name: str) -> str:
+    return name[9:] if name.startswith("metadata_") else name
+
+
+data_loader = OrderedDict(
+    [
+        (SQUAD2_DEV, load_squad2_dev),
+        (SQUAD2_TRAIN, load_squad2_train),
+        (HALU_QA, load_halu_qa),
+        (HALU_DIALOG, load_halu_dialog),
+        (HALU_SUMMARIZATION, load_halu_summarization),
+    ],
+)
+
+df_gt_columns = {
+    SQUAD2_DEV: ["answers", "is_impossible", "plausible_answers"],
+    SQUAD2_TRAIN: ["answers", "is_impossible", "plausible_answers"],
+    HALU_QA: ["right_answer", "hallucinated_answer"],
+    HALU_DIALOG: ["right_response", "hallucinated_response"],
+    HALU_SUMMARIZATION: ["right_summary", "hallucinated_summary"],
+}
+
+
+def seed_benchmark(benchmark: str, test_suite: Optional[str] = None) -> None:
+    df = data_loader[benchmark]()
+    gt_columns = df_gt_columns[benchmark]
+    ts_columns = [col for col in df.columns if col not in gt_columns]
+    test_samples = df[ts_columns].to_dict(orient="records")
+    ground_truths = df[gt_columns].to_dict(orient="records")
+    test_suite_name = test_suite or benchmark
+
+    # Create a list of every test sample with its ground truth
+    test_samples_and_ground_truths = [(Text(**ts), GroundTruth(**gt)) for ts, gt in zip(test_samples, ground_truths)]
+    complete_test_case = TestCase(
+        f"complete {test_suite_name}",
+        description=f"complete {test_suite_name}",
+        test_samples=test_samples_and_ground_truths,
+        reset=True,
+    )
+    test_suite = TestSuite(test_suite_name, test_cases=[complete_test_case], reset=True)
+    print(f"created test suite: {test_suite.name} v{test_suite.version}")
+
+
+def main(args: Namespace) -> None:
+    kolena.initialize(verbose=True)
+
+    benchmark = args.benchmark
+    if benchmark:
+        seed_benchmark(benchmark, args.test_suite)
+    else:
+        # seed all datasets
+        for dataset in data_loader.keys():
+            seed_benchmark(dataset)
+
+
+if __name__ == "__main__":
+    ap = ArgumentParser()
+    ap.add_argument(
+        "--benchmark",
+        choices=[SQUAD2_DEV, SQUAD2_TRAIN, HALU_QA, HALU_DIALOG, HALU_SUMMARIZATION],
+        help="Name of the benchmark to seed.",
+    )
+    ap.add_argument("--test-suite", help="test suite name to create")
+    main(ap.parse_args())

--- a/examples/rag_qa/rag_qa/seed_test_suite.py
+++ b/examples/rag_qa/rag_qa/seed_test_suite.py
@@ -33,11 +33,6 @@ from rag_qa.workflow import TestSuite
 import kolena
 from kolena.workflow import Text
 
-
-def clean_name(name: str) -> str:
-    return name[9:] if name.startswith("metadata_") else name
-
-
 data_loader = OrderedDict(
     [
         (SQUAD2_DEV, load_squad2_dev),

--- a/examples/rag_qa/rag_qa/utils.py
+++ b/examples/rag_qa/rag_qa/utils.py
@@ -1,0 +1,82 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+import numpy as np
+
+from kolena.workflow import AxisConfig
+from kolena.workflow import BarPlot
+from kolena.workflow import Histogram
+from kolena.workflow import Inference
+from kolena.workflow import MetricsTestSample
+
+
+def normalize_string(text: str) -> str:
+    text = str(text)
+    lower_text = text.lower()
+
+    # remove punctuation except apostrophes and hyphens within words
+    clean_text = re.sub(r"[^\w\s'-]", "", lower_text)
+
+    # remove "the", "a", and "an"
+    clean_text = re.sub(r"\b(the|a|an)\b", "", clean_text)
+
+    # remove extra spaces
+    normalized_text = re.sub(r"\s+", " ", clean_text).strip()
+
+    return normalized_text
+
+
+def mean_metric(metric: str, metrics: List[MetricsTestSample]) -> float:
+    return np.mean([getattr(m, metric) for m in metrics])
+
+
+def compute_score_distribution_plot(
+    score: str,
+    metrics: List[Union[MetricsTestSample, Inference]],
+    binning_info: Optional[Tuple[float, float, float]] = None,  # start, end, num
+    logarithmic: bool = False,
+) -> Histogram:
+    scores = [getattr(m, score) for m in metrics]
+    if logarithmic:
+        bins = np.logspace(*binning_info, base=2)
+    else:
+        bins = np.linspace(*binning_info)
+
+    hist, _ = np.histogram(scores, bins=bins)
+    return Histogram(
+        title=f"Distribution of {score}",
+        x_label=f"{score}",
+        y_label="Count",
+        buckets=list(bins),
+        frequency=list(hist),
+        x_config=AxisConfig(type="log") if logarithmic else None,
+    )
+
+
+def compute_metric_bar_plot(
+    labels: List[str],
+    values: List[float],
+) -> BarPlot:
+    return BarPlot(
+        title="Performance Metrics Across Test Cases",
+        x_label="Metrics",
+        y_label="Performance",
+        labels=labels,
+        values=values,
+    )

--- a/examples/rag_qa/rag_qa/workflow.py
+++ b/examples/rag_qa/rag_qa/workflow.py
@@ -1,0 +1,119 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pydantic.dataclasses import dataclass
+
+from kolena.workflow import define_workflow
+from kolena.workflow import EvaluatorConfiguration
+from kolena.workflow import GroundTruth
+from kolena.workflow import Inference
+from kolena.workflow import MetricsTestCase
+from kolena.workflow import MetricsTestSample
+from kolena.workflow import MetricsTestSuite
+from kolena.workflow import Text
+
+workflow, TestCase, TestSuite, Model = define_workflow("Retrieval Augmented Generation", Text, GroundTruth, Inference)
+
+
+@dataclass(frozen=True)
+class TestSampleMetrics(MetricsTestSample):
+    """Sample-level metrics for the Question Answering workflow."""
+
+    is_correct: bool
+    """An indication of the answer being correct or wrong based on the score of MEAN_METRIC."""
+
+    BERT_prec: float
+    """The BERT precision score for this test sample."""
+
+    BERT_rec: float
+    """The BERT recall score for this test sample."""
+
+    BERT_f1: float
+    """The BERT F1 score for this test sample."""
+
+    MEAN_METRIC: float
+    """The average value of BERT F1 and ROUGE1."""
+
+    ROUGE_1: float
+    """The ROUGE_1 score for this test sample."""
+
+    ROUGE_2: float
+    """The ROUGE_2 score for this test sample."""
+
+    ROUGE_L: float
+    """The ROUGE_L score for this test sample."""
+
+
+@dataclass(frozen=True)
+class TestCaseMetrics(MetricsTestCase):
+    """Test-case-level aggregate metrics for the Question Answering workflow."""
+
+    n_correct: int
+    """Total number of correct predictions within this test case."""
+
+    n_incorrect: int
+    """Total number of incorrect predictions within this test case."""
+
+    BERT_prec: float
+    """Overall BERT precision score for predictions within this test case."""
+
+    BERT_rec: float
+    """Overall BERT recall score for predictions within this test case."""
+
+    BERT_f1: float
+    """Overall BERT F1 score for predictions within this test case."""
+
+    MEAN_METRIC: float
+    """Overall average for BERT F1 and ROUGE_1 scores within this test case."""
+
+    ROUGE_1: float
+    """Overall ROUGE_1 score for predictions within this test case."""
+
+    ROUGE_2: float
+    """Overall ROUGE_2 score for predictions within this test case."""
+
+    ROUGE_L: float
+    """Overall ROUGE_L score for predictions within this test case."""
+
+
+@dataclass(frozen=True)
+class TestSuiteMetrics(MetricsTestSuite):
+    """Test-suite-level metrics for the Question Answering workflow."""
+
+    n_stories: int
+    """Number of stories tested within this test suite."""
+
+    n_questions: int
+    """Number of question and answer pairs tested within this test suite."""
+
+    n_correct: int
+    """Number of questions answered correctly within this test suite."""
+
+    overall_accuracy: float
+    """The percentage of questions answered correctly within this test suite."""
+
+
+@dataclass(frozen=True)
+class ThresholdConfiguration(EvaluatorConfiguration):
+    """
+    Similarity score threshold configuration for the Question Answering workflow.
+    Specify a minimum similarity `threshold` for answers to be considered valid, defaulting to 0.5.
+    """
+
+    threshold: float = 0.5
+    """
+    Answers are considered correct when a metric similarity score is above this threshold.
+    """
+
+    def display_name(self) -> str:
+        return f"Similarity Above Threshold (threshold={self.threshold})"

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -16,15 +16,23 @@ Annotations are visualized in Kolena as overlays on top of [`TestSample`][kolena
 
 | Annotation | Valid [`TestSample`][kolena.workflow.TestSample] Types |
 | --- | --- |
-| [`BoundingBox`][kolena.workflow.annotation.BoundingBox] | [`Image`][kolena.workflow.Image], [`Video`][kolena.workflow.Video] |
+| [`BoundingBox`][kolena.workflow.annotation.BoundingBox] | [`Image`][kolena.workflow.Image], [`Video`][
+kolena.workflow.Video] |
 | [`BoundingBox3D`][kolena.workflow.annotation.BoundingBox3D] | [`PointCloud`][kolena.workflow.PointCloud] |
 | [`Polygon`][kolena.workflow.annotation.Polygon] | [`Image`][kolena.workflow.Image], [`Video`][kolena.workflow.Video] |
-| [`Polyline`][kolena.workflow.annotation.Polyline] | [`Image`][kolena.workflow.Image], [`Video`][kolena.workflow.Video] |
-| [`Keypoints`][kolena.workflow.annotation.Keypoints] | [`Image`][kolena.workflow.Image], [`Video`][kolena.workflow.Video] |
-| [`SegmentationMask`][kolena.workflow.annotation.SegmentationMask] | [`Image`][kolena.workflow.Image], [`Video`][kolena.workflow.Video] |
-| [`BitmapMask`][kolena.workflow.annotation.BitmapMask] | [`Image`][kolena.workflow.Image], [`Video`][kolena.workflow.Video] |
-| [`Label`][kolena.workflow.annotation.Label] | [`Text`][kolena.workflow.Text], [`Document`][kolena.workflow.Document], [`Image`][kolena.workflow.Image], [`PointCloud`][kolena.workflow.PointCloud], [`Audio`][kolena.workflow.Audio], [`Video`][kolena.workflow.Video] |
-| [`TimeSegment`][kolena.workflow.annotation.TimeSegment] | [`Audio`][kolena.workflow.Audio], [`Video`][kolena.workflow.Video] |
+| [`Polyline`][kolena.workflow.annotation.Polyline] | [`Image`][kolena.workflow.Image], [`Video`][
+kolena.workflow.Video] |
+| [`Keypoints`][kolena.workflow.annotation.Keypoints] | [`Image`][kolena.workflow.Image], [`Video`][
+kolena.workflow.Video] |
+| [`SegmentationMask`][kolena.workflow.annotation.SegmentationMask] | [`Image`][kolena.workflow.Image],
+[`Video`][kolena.workflow.Video] |
+| [`BitmapMask`][kolena.workflow.annotation.BitmapMask] | [`Image`][kolena.workflow.Image], [`Video`][
+kolena.workflow.Video] |
+| [`Label`][kolena.workflow.annotation.Label] | [`Text`][kolena.workflow.Text], [`Document`][
+kolena.workflow.Document], [`Image`][kolena.workflow.Image], [`PointCloud`][kolena.workflow.PointCloud],
+[`Audio`][kolena.workflow.Audio], [`Video`][kolena.workflow.Video] |
+| [`TimeSegment`][kolena.workflow.annotation.TimeSegment] | [`Audio`][kolena.workflow.Audio], [`Video`][
+kolena.workflow.Video] |
 
 For example, when viewing images in the Studio, any annotations (such as lists of
 [`BoundingBox`][kolena.workflow.annotation.BoundingBox] objects) present in the
@@ -57,6 +65,7 @@ class _AnnotationType(DataType):
     BITMAP_MASK = "BITMAP_MASK"
     LABEL = "LABEL"
     TIME_SEGMENT = "TIME_SEGMENT"
+    UTTERANCE = "UTTERANCE"
 
     @staticmethod
     def _data_category() -> str:
@@ -387,6 +396,33 @@ class ScoredLabeledTimeSegment(TimeSegment):
     """The score associated with this time segment."""
 
 
+@dataclass(frozen=True, config=ValidatorConfig)
+class Utterance(Annotation):
+    """
+    Segment of time in the associated audio or video file.
+
+    When a `group` is specified, segments are displayed on Kolena with different colors for each group present in a
+    `List[TimeSegment]`. Example usage:
+
+    ```py
+    conversation: List[Utterance] = [
+        Utterance(group="system", text="You are a polite assistant"),
+        Utterance(group="user", text="In what country is Normandy located?"),
+        Utterance(group="system", text="France"),
+        Utterance(group="user", text="When were the Normans in Normandy?"),
+        Utterance(group="system", text="10th and 11th centuries"),
+    ]
+    ```
+    """
+
+    text: str
+    """content"""
+
+    @staticmethod
+    def _data_type() -> _AnnotationType:
+        return _AnnotationType.UTTERANCE
+
+
 _ANNOTATION_TYPES = [
     BoundingBox,
     LabeledBoundingBox,
@@ -412,4 +448,5 @@ _ANNOTATION_TYPES = [
     LabeledTimeSegment,
     ScoredTimeSegment,
     ScoredLabeledTimeSegment,
+    Utterance,
 ]


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?

Provide example project to explore RAG evaluations. Supported datasets are SQuAD2.0 and HaLuEval

#### Seeding using datasets
register datasets
```
# seed all datasets
$ python rag_qa/seed_dataset.py

# seed specific dataset
$ python rag_qa/seed_dataset.py --benchmark halu-qa

# help
$ python rag_qa/seed_dataset.py --help
usage: seed_dataset.py [-h]
                       [--benchmark {squad2-dev,squad2-train,halu-qa,halu-dialog,halu-summarization}]

optional arguments:
  -h, --help            show this help message and exit
  --benchmark {squad2-dev,squad2-train,halu-qa,halu-dialog,halu-summarization}
                        Name of the benchmark to seed.
```

upload results
```
# for squad2 dataset
$ python rag_qa/seed_results --benchmark squad2-dev --model "IE-Net (ensemble)"

# for halu dataset
$ python rag_qa/seed_results --benchmark halu-qa --model gpt-3.5-turbo

$ python rag_qa/seed_results.py --help
usage: seed_results.py [-h] --benchmark
                       {squad2-dev,halu-qa,halu-dialog,halu-summarization}
                       --model {IE-Net ensemble),FPNet
                       (ensemble,gpt-3.5-turbo} [--dataset-name DATASET_NAME]

optional arguments:
  -h, --help            show this help message and exit
  --benchmark {squad2-dev,halu-qa,halu-dialog,halu-summarization}
                        Name of the benchmark to seed.
  --model {IE-Net (ensemble),FPNet (ensemble),gpt-3.5-turbo}
                        Name of the model to seed.
  --dataset-name DATASET_NAME
                        dataset name
```

#### Seeding using test-suites
seed test-suite
```
# seed all datasets
$ python rag_qa/seed_test_suite.py

# seed specific dataset
$ python rag_qa/seed_test_suite.py --benchmark halu-dialog

# help
$ python rag_qa/seed_test_suite.py --help
usage: seed_test_suite.py [-h]
                          [--benchmark {squad2-dev,squad2-train,halu-qa,halu-dialog,halu-summarization}]
                          [--test-suite TEST_SUITE]

optional arguments:
  -h, --help            show this help message and exit
  --benchmark {squad2-dev,squad2-train,halu-qa,halu-dialog,halu-summarization}
                        Name of the benchmark to seed.
  --test-suite TEST_SUITE
                        test suite name to create
```

seed test run (programmatically runnable, but evaluation may not be ideal)
```
# squad2 dataset
$ python rag_qa/seed_test_run.py --benchmark squad2-dev --model "FPNet (ensemble)"

# halu dataset
$ python rag_qa/seed_test_run.py --benchmark halu-qa --model "gpt-3.5-turbo"

# help
$ python rag_qa/seed_test_run.py --help
usage: seed_test_run.py [-h] --benchmark
                        {squad2-dev,halu-qa,halu-dialog,halu-summarization}
                        [--model {IE-Net ensemble),FPNet (ensemble,gpt-3.5-turbo}]
                        [--test_suite TEST_SUITE]

optional arguments:
  -h, --help            show this help message and exit
  --benchmark {squad2-dev,halu-qa,halu-dialog,halu-summarization}
                        Name of the benchmark to test.
  --model {IE-Net (ensemble),FPNet (ensemble),gpt-3.5-turbo}
                        Name of the model to test.
  --test_suite TEST_SUITE
                        Name of the test suite to test.
```

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
