### PR TITLE
Don't require credentials to access public S3 bucket

### DIFF
--- a/examples/object_detection_2d/object_detection_2d/extended/seed_test_suite.py
+++ b/examples/object_detection_2d/object_detection_2d/extended/seed_test_suite.py
@@ -38,7 +38,7 @@ import kolena
 
 
 def load_transportation_data() -> Dict[str, List[ExtendedBoundingBox]]:
-    s3 = s3fs.S3FileSystem()
+    s3 = s3fs.S3FileSystem(anon=True)
 
     try:
         with s3.open(S3_ANNOTATION_FILE_PATH, "r") as file:

--- a/examples/object_detection_2d/object_detection_2d/seed_test_suite.py
+++ b/examples/object_detection_2d/object_detection_2d/seed_test_suite.py
@@ -38,7 +38,7 @@ from kolena.workflow.annotation import LabeledBoundingBox
 
 
 def load_transportation_data() -> Dict[str, List[LabeledBoundingBox]]:
-    s3 = s3fs.S3FileSystem()
+    s3 = s3fs.S3FileSystem(anon=True)
 
     try:
         with s3.open(S3_ANNOTATION_FILE_PATH, "r") as file:


### PR DESCRIPTION
### Linked issue(s):

Fixes #3987

https://linear.app/kolena/issue/KOL-3987/quickstart-guides-shouldnt-need-aws-credentials

### What change does this PR introduce and why?

Object Detection 2D quickstart flow accesses the public S3 bucket anonymously. With anon=False, the script fails when AWS credentials are not present locally.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
