### PR TITLE
Add support for composite datasets

### DIFF
--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -107,7 +107,7 @@ def _format_composite(df: pd.DataFrame, prefix: str, sep: str) -> None:
         )
     if sep in prefix:
         raise InputValidationError(
-            f"More than one delimeter '{sep}' in {prefix=}.",
+            f"More than one delimeter '{sep}' in prefix: '{prefix}'.",
         )
 
     composite_columns = df.filter(regex=rf"^{prefix}", axis=1).columns.to_list()

--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -86,7 +86,11 @@ def _infer_datatype_value(x: str) -> str:
 
 def add_datatype(df: pd.DataFrame) -> None:
     """Adds `data_type` column(s) to input DataFrame."""
-    prefixes = {column.rsplit(sep=".", maxsplit=1)[0] + "." for column in df.columns.values if "." in column}
+    prefixes = {
+        column.rsplit(sep=".", maxsplit=1)[0] + "."
+        for column in df.columns.values
+        if isinstance(column, str) and "." in column
+    }
     if prefixes:
         df[DATA_TYPE_FIELD] = DatapointType.COMPOSITE.value
         for prefix in prefixes:

--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -113,7 +113,7 @@ def _format_composite(df: pd.DataFrame, prefix: str, sep: str) -> None:
     composite_columns = df.filter(regex=rf"^{prefix}", axis=1).columns.to_list()
     composite = df.loc[:, composite_columns]
     df.drop(columns=composite_columns, inplace=True)
-    composite.rename(columns=lambda col: col.removeprefix(prefix + sep), inplace=True)
+    composite.rename(columns=lambda col: col.split(sep)[-1], inplace=True)
     composite[DATA_TYPE_FIELD] = _infer_datatype(composite)
     df[prefix] = composite.to_dict("records")
     df[prefix] = df[prefix].apply(json.dumps)

--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -152,7 +152,7 @@ def _flatten_composite(df: pd.DataFrame) -> pd.DataFrame:
     for key, value in df.iloc[0].items():
         if isinstance(value, dict) and DatapointType.has_value(value.get(DATA_TYPE_FIELD)):
             flattened = pd.json_normalize(df[key]).rename(
-                columns=lambda col: f"{key}.{col}",
+                columns=lambda col: f"{key}{SEP}{col}",
             )
             df = df.join(flattened)
             df.drop(columns=[key], inplace=True)

--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -54,6 +54,10 @@ class DatapointType(str, Enum):
     TEXT = "DATAPOINT/TEXT"
     VIDEO = "DATAPOINT/VIDEO"
 
+    @classmethod
+    def has_value(cls, item) -> bool:
+        return item in cls.__members__.values()
+
 
 _DATAPOINT_TYPE_MAP = {
     "image": DatapointType.IMAGE.value,
@@ -146,7 +150,7 @@ def _to_deserialized_dataframe(df: pd.DataFrame, column: str) -> pd.DataFrame:
 
 def _flatten_composite(df: pd.DataFrame) -> pd.DataFrame:
     for key, value in df.iloc[0].items():
-        if isinstance(value, dict) and DATA_TYPE_FIELD in value:
+        if isinstance(value, dict) and DatapointType.has_value(value.get(DATA_TYPE_FIELD)):
             flattened = pd.json_normalize(df[key]).rename(
                 columns=lambda col: f"{key}.{col}",
             )

--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -100,6 +100,11 @@ def _add_datatype(df: pd.DataFrame) -> None:
     if prefixes:
         df[DATA_TYPE_FIELD] = DatapointType.COMPOSITE.value
         for prefix in prefixes:
+            if not prefix.strip():
+                raise InputValidationError(
+                    "Empty prefix encountered when parsing composite dataset. "
+                    f"Columns must lead with at least one non-whitespace character prior to delimeter '{SEP}'.",
+                )
             if prefix in df.columns:
                 raise InputValidationError(
                     f"Conflicting column '{prefix}' encountered when formatting composite dataset.",

--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -151,7 +151,7 @@ def _to_deserialized_dataframe(df: pd.DataFrame, column: str) -> pd.DataFrame:
 def _flatten_composite(df: pd.DataFrame) -> pd.DataFrame:
     for key, value in df.iloc[0].items():
         if isinstance(value, dict) and DatapointType.has_value(value.get(DATA_TYPE_FIELD)):
-            flattened = pd.json_normalize(df[key]).rename(
+            flattened = pd.json_normalize(df[key], max_level=0).rename(
                 columns=lambda col: f"{key}{SEP}{col}",
             )
             df = df.join(flattened)

--- a/tests/integration/_experimental/dataset/test_dataset.py
+++ b/tests/integration/_experimental/dataset/test_dataset.py
@@ -88,7 +88,7 @@ def test__register_dataset__composite() -> None:
             "b.word_count": 2 * i,
             "a.char_length": 10 * i,
             "b.char_length": 15 * i,
-            "c": {"text": "nested " * i, "word_count": 3 * i, "char_length": 7 * i},
+            "c": dict(text="nested " * i, word_count=3 * i, char_length=7 * i),
             "total_word_count": 3 * i,
             "total_char_length": 25 * i,
             "word_count_diff": i,

--- a/tests/integration/_experimental/dataset/test_dataset.py
+++ b/tests/integration/_experimental/dataset/test_dataset.py
@@ -78,6 +78,39 @@ def test__register_dataset() -> None:
     assert_frame_equal(loaded_datapoints, expected)
 
 
+def test__register_dataset__composite() -> None:
+    name = with_test_prefix(f"{__file__}::test__register_dataset__composite")
+    datapoints = [
+        {
+            "a.text": "Something " * i,
+            "b.text": "Something else " * i,
+            "a.word_count": 1 * i,
+            "b.word_count": 2 * i,
+            "a.char_length": 10 * i,
+            "b.char_length": 15 * i,
+            "total_word_count": 3 * i,
+            "total_char_length": 25 * i,
+            "word_count_diff": i,
+            "char_length_diff": 5 * i,
+        }
+        for i in range(1, 20)
+    ]
+    columns = datapoints[0].keys()
+
+    df = pd.DataFrame(datapoints[:10], columns=columns)
+    register_dataset(name, df)
+
+    loaded_datapoints = fetch_dataset(name).sort_values("total_word_count", ignore_index=True).reindex(columns=columns)
+    assert_frame_equal(df, loaded_datapoints)
+
+    # update dataset
+    df = pd.DataFrame(datapoints[:5] + datapoints[7:15], columns=columns)
+    register_dataset(name, df)
+
+    loaded_datapoints = fetch_dataset(name).sort_values("total_word_count", ignore_index=True).reindex(columns=columns)
+    assert_frame_equal(df, loaded_datapoints)
+
+
 def test__fetch_dataset__not_exist() -> None:
     name = with_test_prefix(f"{__file__}::test__fetch_dataset__not_exist")
     with pytest.raises(NotFoundError):

--- a/tests/integration/_experimental/dataset/test_dataset.py
+++ b/tests/integration/_experimental/dataset/test_dataset.py
@@ -88,6 +88,7 @@ def test__register_dataset__composite() -> None:
             "b.word_count": 2 * i,
             "a.char_length": 10 * i,
             "b.char_length": 15 * i,
+            "c": {"text": "nested " * i, "word_count": 3 * i, "char_length": 7 * i},
             "total_word_count": 3 * i,
             "total_char_length": 25 * i,
             "word_count_diff": i,
@@ -100,7 +101,8 @@ def test__register_dataset__composite() -> None:
     df = pd.DataFrame(datapoints[:10], columns=columns)
     register_dataset(name, df)
 
-    loaded_datapoints = fetch_dataset(name).sort_values("total_word_count", ignore_index=True).reindex(columns=columns)
+    loaded_datapoints = fetch_dataset(name)
+    loaded_datapoints = loaded_datapoints.sort_values("total_word_count", ignore_index=True).reindex(columns=columns)
     assert_frame_equal(df, loaded_datapoints)
 
     # update dataset

--- a/tests/unit/_experimental/dataset/data.py
+++ b/tests/unit/_experimental/dataset/data.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 a_text = [
     "A plane is taking off.",
     "A man is playing a large flute.",

--- a/tests/unit/_experimental/dataset/data.py
+++ b/tests/unit/_experimental/dataset/data.py
@@ -1,0 +1,11 @@
+a_text = [
+    "A plane is taking off.",
+    "A man is playing a large flute.",
+    "A man is spreading shredded cheese on a pizza.",
+]
+
+b_text = [
+    "An air plane is taking off.",
+    "A man is playing a flute.",
+    "A man is spreading shredded cheese on an uncooked pizza.",
+]

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -100,8 +100,8 @@ def test__add_datatype__composite() -> None:
 def test__flatten_composite():
     composite_dataset = pd.DataFrame(
         {
-            "a": [{"text": text, DATA_TYPE_FIELD: DatapointType.TEXT} for text in a_text],
-            "b": [{"text": text, DATA_TYPE_FIELD: DatapointType.TEXT} for text in b_text],
+            "a": [{"text": text, DATA_TYPE_FIELD: DatapointType.TEXT.value} for text in a_text],
+            "b": [{"text": text, DATA_TYPE_FIELD: DatapointType.TEXT.value} for text in b_text],
             "c": [dict(text=a + b) for a, b in zip(a_text, b_text)],  # Should not flatten because no DATA_TYPE_FIELD
             DATA_TYPE_FIELD: DatapointType.COMPOSITE,
         },

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -370,6 +370,20 @@ def test__dataframe__serde_none() -> None:
     assert_frame_equal(df_deserialized, df_expected)
 
 
+def test__dataframe__serde_none__composite() -> None:
+    column_name = COL_RESULT
+    data = [
+        ['{"a.city": "London"}'],
+        ['{"a.city": "Tokyo"}'],
+        [None],
+    ]
+    df_serialized = pd.DataFrame(data, columns=[column_name])
+
+    df_expected = pd.DataFrame([["London"], ["Tokyo"], [np.nan]], columns=["a.city"])
+    df_deserialized = _to_deserialized_dataframe(df_serialized, column=column_name)
+    assert_frame_equal(df_deserialized, df_expected)
+
+
 def test__dataframe__data_type_field_not_exist() -> None:
     column_name = COL_RESULT
     df_expected = pd.DataFrame([["a", "b", "c"], ["d", "e", "f"]])

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -66,6 +66,10 @@ def test__add_datatype() -> None:
 
 
 def test__add_datatype__composite() -> None:
+    def assert_datatype(dataset: pd.DataFrame, expected_datatype: DatapointType, prefix: str = "") -> None:
+        for value in dataset[prefix + DATA_TYPE_FIELD]:
+            assert value == expected_datatype
+
     composite_dataset = pd.DataFrame(
         {
             "a.text": [
@@ -73,21 +77,22 @@ def test__add_datatype__composite() -> None:
                 "A man is playing a large flute.",
                 "A man is spreading shredded cheese on a pizza.",
             ],
-            "b.text": [
-                "An air plane is taking off.",
-                "A man is playing a flute.",
-                "A man is spreading shredded cheese on an uncooked pizza.",
-            ],
-            "similarity": [5.0, 3.799999952316284, 3.799999952316284],
         },
     )
     add_datatype(composite_dataset)
-    for data_type in composite_dataset[DATA_TYPE_FIELD]:
-        assert data_type == DatapointType.COMPOSITE
-    for data_type in composite_dataset["a." + DATA_TYPE_FIELD]:
-        assert data_type == DatapointType.TEXT
-    for data_type in composite_dataset["b." + DATA_TYPE_FIELD]:
-        assert data_type == DatapointType.TEXT
+    assert_datatype(composite_dataset, DatapointType.COMPOSITE)
+    assert_datatype(composite_dataset, DatapointType.TEXT, prefix="a.")
+
+    composite_dataset["b.text"] = [
+        "An air plane is taking off.",
+        "A man is playing a flute.",
+        "A man is spreading shredded cheese on an uncooked pizza.",
+    ]
+    composite_dataset["similarity"] = [5.0, 3.799999952316284, 3.799999952316284]
+    add_datatype(composite_dataset)
+    assert_datatype(composite_dataset, DatapointType.COMPOSITE)
+    assert_datatype(composite_dataset, DatapointType.TEXT, prefix="a.")
+    assert_datatype(composite_dataset, DatapointType.TEXT, prefix="b.")
 
 
 def test__infer_datatype() -> None:

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -139,6 +139,14 @@ def test__add_datatype__invalid():
     with pytest.raises(InputValidationError):
         _add_datatype(composite_dataset)
 
+    composite_dataset = pd.DataFrame(
+        {
+            ".empty_prefix": [i for i in range(5)],
+        },
+    )
+    with pytest.raises(InputValidationError):
+        _add_datatype(composite_dataset)
+
 
 def test__infer_datatype() -> None:
     assert _infer_datatype(

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -79,10 +79,7 @@ def test__add_datatype__composite() -> None:
 
     assert "a.text" not in composite_dataset
     assert (composite_dataset[DATA_TYPE_FIELD] == DatapointType.COMPOSITE).all()
-    for val, exp in zip(composite_dataset["a"], a_text):
-        a = json.loads(val)
-        assert a["text"] == exp
-        assert a[DATA_TYPE_FIELD] == DatapointType.TEXT
+    assert (composite_dataset["a"] == [{"text": text, DATA_TYPE_FIELD: DatapointType.TEXT} for text in a_text]).all()
 
     similarity = [5.0, 3.799999952316284, 3.799999952316284]
     composite_dataset = pd.DataFrame(
@@ -96,24 +93,16 @@ def test__add_datatype__composite() -> None:
 
     assert (composite_dataset[DATA_TYPE_FIELD] == DatapointType.COMPOSITE).all()
     assert (composite_dataset["similarity"] == similarity).all()
-    for val, exp in zip(composite_dataset["a"], a_text):
-        a = json.loads(val)
-        assert a["text"] == exp
-        assert a[DATA_TYPE_FIELD] == DatapointType.TEXT
-    for val, exp in zip(composite_dataset["b"], b_text):
-        b = json.loads(val)
-        assert b["text"] == exp
-        assert b[DATA_TYPE_FIELD] == DatapointType.TEXT
+    assert (composite_dataset["a"] == [{"text": text, DATA_TYPE_FIELD: DatapointType.TEXT} for text in a_text]).all()
+    assert (composite_dataset["b"] == [{"text": text, DATA_TYPE_FIELD: DatapointType.TEXT} for text in b_text]).all()
 
 
 def test__flatten_composite():
     composite_dataset = pd.DataFrame(
         {
-            "a": [json.dumps({"text": text, DATA_TYPE_FIELD: DatapointType.TEXT}) for text in a_text],
-            "b": [json.dumps({"text": text, DATA_TYPE_FIELD: DatapointType.TEXT}) for text in b_text],
-            "c": [
-                json.dumps({"text": text}) for text in zip(a_text, b_text)
-            ],  # Should not flatten because no DATA_TYPE_FIELD
+            "a": [{"text": text, DATA_TYPE_FIELD: DatapointType.TEXT} for text in a_text],
+            "b": [{"text": text, DATA_TYPE_FIELD: DatapointType.TEXT} for text in b_text],
+            "c": [dict(text=a + b) for a, b in zip(a_text, b_text)],  # Should not flatten because no DATA_TYPE_FIELD
             DATA_TYPE_FIELD: DatapointType.COMPOSITE,
         },
     )
@@ -125,7 +114,7 @@ def test__flatten_composite():
             f"a.{DATA_TYPE_FIELD}": DatapointType.TEXT,
             "b.text": b_text,
             f"b.{DATA_TYPE_FIELD}": DatapointType.TEXT,
-            "c": [json.dumps({"text": text}) for text in zip(a_text, b_text)],
+            "c": [dict(text=a + b) for a, b in zip(a_text, b_text)],
             DATA_TYPE_FIELD: DatapointType.COMPOSITE,
         },
     )


### PR DESCRIPTION
### Linked issue(s):
Towards KOL-3558

### What change does this PR introduce and why?
Adds support for composite datasets with `DATAPOINT/COMPOSITE` value and tags nested datasets with their corresponding dataset type.

The below screenshot illustrates this change. The dataset consists of nested text datasets `a` and `b`. The top level `data_type` is marked `DATASET/COMPOSITE` while the nested datasets `a` and `b` have their `data_type` marked `DATASET/TEXT`
![Screenshot 2023-12-11 at 1 19 19 PM](https://github.com/kolenaIO/kolena/assets/25123885/f21c320e-1154-493c-819d-dcdef50ed0fb)

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
