### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -311,13 +311,13 @@ workflows:
           name: ci-base-<< matrix.python-version >>-<< matrix.extras >>
           matrix:
             parameters:
-              python-version: [ "3.7.17", "3.8.18", "3.9.18", "3.10.13", "3.11.6" ]
+              python-version: [ "3.8.18", "3.9.18", "3.10.13", "3.11.6" ]
               extras: ["none", "metrics"]
       - unit-test:
           name: unit-test-<< matrix.python-version >>-<< matrix.extras >>
           matrix:
             parameters:
-              python-version: [ "3.7.17", "3.8.18", "3.9.18", "3.10.13", "3.11.6" ]
+              python-version: [ "3.8.18", "3.9.18", "3.10.13", "3.11.6" ]
               extras: ["none", "metrics"]
           requires:
             - ci-base-<< matrix.python-version >>-<< matrix.extras >>

--- a/docs/installing-kolena.md
+++ b/docs/installing-kolena.md
@@ -90,11 +90,11 @@ Additional logging can be configured by specifying `initialize(..., verbose=True
 
 `kolena` is compatible with all active Python versions.
 
-| :fontawesome-brands-python: Python Version                        | :kolena-logo: Compatible `kolena` Versions   |
-| ----------------------------------------------------------------- |-------------------------------------------------|
-| 3.11                                                              | ≥0.69                                           |
-| 3.10                                                              | _All Versions_                                  |
-| 3.9                                                               | _All Versions_                                  |
-| 3.8                                                               | _All Versions_                                  |
-| 3.7                                                               | _All Versions_                                  |
-| 3.6 (EOL: [December 2021](https://devguide.python.org/versions/)) | ≤0.46                                           |
+| :fontawesome-brands-python: Python Version                        | :kolena-logo: Compatible `kolena` Versions |
+|-------------------------------------------------------------------|--------------------------------------------|
+| 3.11                                                              | ≥0.69                                      |
+| 3.10                                                              | _All Versions_                             |
+| 3.9                                                               | _All Versions_                             |
+| 3.8                                                               | _All Versions_                             |
+| 3.7 (EOL: [June 2023](https://devguide.python.org/versions/))     | ≤0.98                                      |
+| 3.6 (EOL: [December 2021](https://devguide.python.org/versions/)) | ≤0.46                                      |

--- a/docs/installing-kolena.md
+++ b/docs/installing-kolena.md
@@ -96,5 +96,5 @@ Additional logging can be configured by specifying `initialize(..., verbose=True
 | 3.10                                                              | _All Versions_                             |
 | 3.9                                                               | _All Versions_                             |
 | 3.8                                                               | _All Versions_                             |
-| 3.7 (EOL: [June 2023](https://devguide.python.org/versions/))     | ≤0.98                                      |
+| 3.7 (EOL: [June 2023](https://devguide.python.org/versions/))     | ≤0.99                                      |
 | 3.6 (EOL: [December 2021](https://devguide.python.org/versions/)) | ≤0.46                                      |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,13 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7.1,<3.12"
+python = ">=3.8,<3.12"
 numpy = [
-    { version = ">=1.19", python = ">=3.7,<3.11" },
+    { version = ">=1.19", python = ">=3.8,<3.11" },
     { version = ">=1.23", python = ">=3.11" },
 ]
 pandas = [
-    { version = ">=1.1,<1.6", python = ">=3.7,<3.11" },
+    { version = ">=1.1,<1.6", python = ">=3.8,<3.11" },
     { version = ">=1.5,<1.6", python = ">=3.11" },
 ]
 pandera = ">=0.9.0,<0.16"
@@ -39,23 +39,15 @@ pydantic = ">=1.10,<2"
 dacite = ">=1.6,<2"
 requests = ">=2.20,<2.30"  # TODO: revert upper bound when urllib3 situation sorts out: https://github.com/psf/requests/issues/6432
 requests-toolbelt = "*"
-importlib-metadata = { version = "*", python = "<3.8" }
 tqdm = ">=4,<5"
-Pillow = [
-    { version = "^9.1.1", python = "<3.8" },
-    { version = "^10.0.1", python = ">=3.8" },
-]
+Pillow = "^10.0.1"
 retrying = "^1.3.3"
 Shapely = "^1.8.5"
 deprecation = "^2.1.0"
 termcolor = "^1.1.0"
 pyarrow = ">=8"
-typing-extensions = { version = "^4.5.0", python = "<3.8" }
 click = ">=8"
-scikit-learn = [
-    { version = ">=1.0,<1.0.3", python = ">=3.7.1,<3.8", optional = true },
-    { version = ">=1.2,<2", python = ">=3.8", optional = true },
-]
+scikit-learn = { version = ">=1.2,<2", optional = true }
 
 [tool.poetry.extras]
 metrics = ["scikit-learn"]
@@ -66,12 +58,12 @@ black = { version = "^22.1.0", allow-prereleases = true }
 pytest = "^7"
 pytest-cov = "^4.0.0"
 pytest-depends = "^1.0.1"
-mkdocs = { version = "^1.4.3", python = ">=3.8" }
-cairosvg = { version = "^2.7.0", python = ">=3.8" }
-mkdocs-material = { version = ">=9.2,<10", python = ">=3.8" }  # insiders fork installed out-of-band in docs/setup_insiders.sh
-mkdocstrings = { version = ">0.20,<1", extras = ["python"], python = ">=3.8" }
-mkdocs-git-committers-plugin-2 = { version = "^1", python = ">=3.8" }
-mkdocs-git-revision-date-localized-plugin = { version = "^1", python = ">=3.8" }
+mkdocs = "^1.4.3"
+cairosvg = "^2.7.0"
+mkdocs-material = ">=9.2,<10"  # insiders fork installed out-of-band in docs/setup_insiders.sh
+mkdocstrings = { version = ">0.20,<1", extras = ["python"] }
+mkdocs-git-committers-plugin-2 = "^1"
+mkdocs-git-revision-date-localized-plugin = "^1"
 
 [tool.poetry.scripts]
 kolena = 'kolena._utils.cli:run'


### PR DESCRIPTION
Remove support for EOL Python 3.7 now that it is [no longer supported by AWS SDKs](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/). 3.7 has been [officially deprecated since June 2023](https://devguide.python.org/versions/).

Fixes KOL-2344