### PR TITLE
Add optional config flag to choose evaluator for Object Detection

### DIFF
--- a/kolena/_experimental/object_detection/workflow.py
+++ b/kolena/_experimental/object_detection/workflow.py
@@ -213,8 +213,16 @@ class ThresholdConfiguration(EvaluatorConfiguration):
     inferences with low confidence score.
     """
 
+    multiclass: Optional[bool] = None
+    """Optional flag to choose whether the SingleClass or Multiclass evaluator is run.
+    If unset, the evaluator is determined based on the number of distinct labels in test data."""
+
     def display_name(self) -> str:
+        evaluator_name = ""
+        if self.multiclass is not None:
+            evaluator_name = "Multiclass, " if self.multiclass else "SingleClass, "
         return (
+            f"{evaluator_name}"
             f"Confidence Threshold: {self.threshold_strategy}, "
             f"IoU: {self.iou_threshold}, "
             f"min confidence ≥ {self.min_confidence_score}"

--- a/tests/integration/_experimental/object_detection/test_evaluator_multiclass_f1_optimal.py
+++ b/tests/integration/_experimental/object_detection/test_evaluator_multiclass_f1_optimal.py
@@ -534,8 +534,7 @@ def test__object_detection__multiclass_evaluator__f1_optimal() -> None:
     assert len(evaluator.matchings_by_test_case[config.display_name()]) != 0
     num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
     assert (
-        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
-        == len(TEST_DATA) - num_of_ignored
+        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name]) == len(TEST_DATA) - num_of_ignored
     )
     assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
 

--- a/tests/integration/_experimental/object_detection/test_evaluator_multiclass_f1_optimal.py
+++ b/tests/integration/_experimental/object_detection/test_evaluator_multiclass_f1_optimal.py
@@ -526,14 +526,15 @@ def test__object_detection__multiclass_evaluator__f1_optimal() -> None:
         configuration=config,
     )
 
-    assert config.display_name() in eval.evaluator.threshold_cache
-    assert "b" in eval.evaluator.threshold_cache[config.display_name()]
-    assert eval.evaluator.threshold_cache[config.display_name()]["b"] == 0.4
-    assert len(eval.evaluator.matchings_by_test_case) != 0
-    assert len(eval.evaluator.matchings_by_test_case[config.display_name()]) != 0
+    evaluator = eval._get_evaluator(config)
+    assert config.display_name() in evaluator.threshold_cache
+    assert "b" in evaluator.threshold_cache[config.display_name()]
+    assert evaluator.threshold_cache[config.display_name()]["b"] == 0.4
+    assert len(evaluator.matchings_by_test_case) != 0
+    assert len(evaluator.matchings_by_test_case[config.display_name()]) != 0
     num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
     assert (
-        len(eval.evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
+        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
         == len(TEST_DATA) - num_of_ignored
     )
     assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
@@ -545,8 +546,8 @@ def test__object_detection__multiclass_evaluator__f1_optimal() -> None:
         configuration=config,
     )
 
-    assert TEST_CASE.name in eval.evaluator.locators_by_test_case
-    assert len(eval.evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
+    assert TEST_CASE.name in evaluator.locators_by_test_case
+    assert len(evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
     assert_test_case_metrics_equals_expected(test_case_metrics, EXPECTED_COMPUTE_TEST_CASE_METRICS)
 
     # test case plots only use the cached values

--- a/tests/integration/_experimental/object_detection/test_evaluator_multiclass_fixed.py
+++ b/tests/integration/_experimental/object_detection/test_evaluator_multiclass_fixed.py
@@ -840,12 +840,13 @@ def test__object_detection__multiclass_evaluator__fixed() -> None:
         configuration=config,
     )
 
-    assert config.display_name() not in eval.evaluator.threshold_cache
-    assert len(eval.evaluator.matchings_by_test_case) != 0
-    assert len(eval.evaluator.matchings_by_test_case[config.display_name()]) != 0
+    evaluator = eval._get_evaluator(config)
+    assert config.display_name() not in evaluator.threshold_cache
+    assert len(evaluator.matchings_by_test_case) != 0
+    assert len(evaluator.matchings_by_test_case[config.display_name()]) != 0
     num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
     assert (
-        len(eval.evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
+        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
         == len(TEST_DATA) - num_of_ignored
     )
     assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
@@ -857,8 +858,8 @@ def test__object_detection__multiclass_evaluator__fixed() -> None:
         configuration=config,
     )
 
-    assert TEST_CASE.name in eval.evaluator.locators_by_test_case
-    assert len(eval.evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
+    assert TEST_CASE.name in evaluator.locators_by_test_case
+    assert len(evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
     assert_test_case_metrics_equals_expected(test_case_metrics, EXPECTED_COMPUTE_TEST_CASE_METRICS)
 
     # test case plots only use the cached values

--- a/tests/integration/_experimental/object_detection/test_evaluator_multiclass_fixed.py
+++ b/tests/integration/_experimental/object_detection/test_evaluator_multiclass_fixed.py
@@ -846,8 +846,7 @@ def test__object_detection__multiclass_evaluator__fixed() -> None:
     assert len(evaluator.matchings_by_test_case[config.display_name()]) != 0
     num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
     assert (
-        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
-        == len(TEST_DATA) - num_of_ignored
+        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name]) == len(TEST_DATA) - num_of_ignored
     )
     assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
 

--- a/tests/integration/_experimental/object_detection/test_evaluator_single_class_f1_optimal.py
+++ b/tests/integration/_experimental/object_detection/test_evaluator_single_class_f1_optimal.py
@@ -294,13 +294,14 @@ def test__object_detection__multiclass_evaluator__f1_optimal() -> None:
         configuration=config,
     )
 
-    assert config.display_name() in eval.evaluator.threshold_cache
-    assert eval.evaluator.threshold_cache[config.display_name()] == 0.1
-    assert len(eval.evaluator.matchings_by_test_case) != 0
-    assert len(eval.evaluator.matchings_by_test_case[config.display_name()]) != 0
+    evaluator = eval._get_evaluator(config)
+    assert config.display_name() in evaluator.threshold_cache
+    assert evaluator.threshold_cache[config.display_name()] == 0.1
+    assert len(evaluator.matchings_by_test_case) != 0
+    assert len(evaluator.matchings_by_test_case[config.display_name()]) != 0
     num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
     assert (
-        len(eval.evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
+        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
         == len(TEST_DATA) - num_of_ignored
     )
     assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
@@ -312,8 +313,8 @@ def test__object_detection__multiclass_evaluator__f1_optimal() -> None:
         configuration=config,
     )
 
-    assert TEST_CASE.name in eval.evaluator.locators_by_test_case
-    assert len(eval.evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
+    assert TEST_CASE.name in evaluator.locators_by_test_case
+    assert len(evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
     assert_test_case_metrics_equals_expected(test_case_metrics, EXPECTED_COMPUTE_TEST_CASE_METRICS)
 
     # test case plots only use the cached values

--- a/tests/integration/_experimental/object_detection/test_evaluator_single_class_f1_optimal.py
+++ b/tests/integration/_experimental/object_detection/test_evaluator_single_class_f1_optimal.py
@@ -301,8 +301,7 @@ def test__object_detection__multiclass_evaluator__f1_optimal() -> None:
     assert len(evaluator.matchings_by_test_case[config.display_name()]) != 0
     num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
     assert (
-        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
-        == len(TEST_DATA) - num_of_ignored
+        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name]) == len(TEST_DATA) - num_of_ignored
     )
     assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
 

--- a/tests/integration/_experimental/object_detection/test_evaluator_single_class_fixed.py
+++ b/tests/integration/_experimental/object_detection/test_evaluator_single_class_fixed.py
@@ -517,12 +517,13 @@ def test__object_detection__multiclass_evaluator__fixed() -> None:
         configuration=config,
     )
 
-    assert config.display_name() not in eval.evaluator.threshold_cache
-    assert len(eval.evaluator.matchings_by_test_case) != 0
-    assert len(eval.evaluator.matchings_by_test_case[config.display_name()]) != 0
+    evaluator = eval._get_evaluator(config)
+    assert config.display_name() not in evaluator.threshold_cache
+    assert len(evaluator.matchings_by_test_case) != 0
+    assert len(evaluator.matchings_by_test_case[config.display_name()]) != 0
     num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
     assert (
-        len(eval.evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
+        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
         == len(TEST_DATA) - num_of_ignored
     )
     assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
@@ -533,8 +534,8 @@ def test__object_detection__multiclass_evaluator__fixed() -> None:
         metrics=[pair[1] for pair in EXPECTED_COMPUTE_TEST_SAMPLE_METRICS],
         configuration=config,
     )
-    assert TEST_CASE.name in eval.evaluator.locators_by_test_case
-    assert len(eval.evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
+    assert TEST_CASE.name in evaluator.locators_by_test_case
+    assert len(evaluator.locators_by_test_case[TEST_CASE.name]) == len(TEST_DATA)
     assert_test_case_metrics_equals_expected(test_case_metrics, EXPECTED_COMPUTE_TEST_CASE_METRICS)
 
     # test case plots only use the cached values

--- a/tests/integration/_experimental/object_detection/test_evaluator_single_class_fixed.py
+++ b/tests/integration/_experimental/object_detection/test_evaluator_single_class_fixed.py
@@ -523,8 +523,7 @@ def test__object_detection__multiclass_evaluator__fixed() -> None:
     assert len(evaluator.matchings_by_test_case[config.display_name()]) != 0
     num_of_ignored = sum([1 for _, _, inf in TEST_DATA if inf.ignored])
     assert (
-        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name])
-        == len(TEST_DATA) - num_of_ignored
+        len(evaluator.matchings_by_test_case[config.display_name()][TEST_CASE.name]) == len(TEST_DATA) - num_of_ignored
     )
     assert test_sample_metrics == EXPECTED_COMPUTE_TEST_SAMPLE_METRICS
 

--- a/tests/unit/_experimental/object_detection/test_configurations.py
+++ b/tests/unit/_experimental/object_detection/test_configurations.py
@@ -86,7 +86,7 @@ def test__object_detection__multiple_configurations__multiclass() -> None:
 def test__object_detection__multiple_configurations__single_class() -> None:
     ground_truth = GroundTruth(bboxes=[LabeledBoundingBox(top_left=(0, 0), bottom_right=(1, 1), label="a")])
     inference = Inference(
-        bboxes=[ScoredLabeledBoundingBox(top_left=(0, 0), bottom_right=(1, 1), label="a", score=random.random())],
+        bboxes=[ScoredLabeledBoundingBox(top_left=(0, 0), bottom_right=(1, 1), label="b", score=random.random())],
     )
 
     config_one = ThresholdConfiguration(

--- a/tests/unit/_experimental/object_detection/test_configurations.py
+++ b/tests/unit/_experimental/object_detection/test_configurations.py
@@ -35,6 +35,12 @@ evaluator_single_class = pytest.importorskip(
 )
 SingleClassObjectDetectionEvaluator = evaluator_single_class.SingleClassObjectDetectionEvaluator
 
+evaluator = pytest.importorskip(
+    "kolena._experimental.object_detection.evaluator",
+    reason="requires kolena[metrics] extra",
+)
+ObjectDetectionEvaluator = evaluator.ObjectDetectionEvaluator
+
 
 @pytest.mark.metrics
 def test__object_detection__multiple_configurations__multiclass() -> None:
@@ -80,7 +86,7 @@ def test__object_detection__multiple_configurations__multiclass() -> None:
 def test__object_detection__multiple_configurations__single_class() -> None:
     ground_truth = GroundTruth(bboxes=[LabeledBoundingBox(top_left=(0, 0), bottom_right=(1, 1), label="a")])
     inference = Inference(
-        bboxes=[ScoredLabeledBoundingBox(top_left=(0, 0), bottom_right=(1, 1), label="b", score=random.random())],
+        bboxes=[ScoredLabeledBoundingBox(top_left=(0, 0), bottom_right=(1, 1), label="a", score=random.random())],
     )
 
     config_one = ThresholdConfiguration(
@@ -114,3 +120,17 @@ def test__object_detection__multiple_configurations__single_class() -> None:
     assert len(evaluator.matchings_by_test_case[config_one.display_name()]["one"]) == 1
     assert len(evaluator.matchings_by_test_case[config_two.display_name()]) == 1
     assert len(evaluator.matchings_by_test_case[config_two.display_name()]["two"]) == 1
+
+
+@pytest.mark.metrics
+def test__object_detection__explicit_evaluator() -> None:
+    single_class_configuration = ThresholdConfiguration(
+        multiclass=False,
+    )
+    multiclass_configuration = ThresholdConfiguration(
+        multiclass=True,
+    )
+
+    evaluator = ObjectDetectionEvaluator()
+    assert evaluator._get_evaluator(single_class_configuration) == evaluator.single_class_evaluator
+    assert evaluator._get_evaluator(multiclass_configuration) == evaluator.multiclass_evaluator


### PR DESCRIPTION
### Linked issue(s):
Towards KOL-3869

### What change does this PR introduce and why?
Adds an optional boolean to the evaluator configuration used in the prebuilt Object Detection workflow. The flag can be used to explicitly determine if the SingleClass or Multiclass evaluator is run. In the absence of this flag, the evaluator used is determined dynamically based on the number of distinct classification labels found in the ground truths and inferences.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
