### PR TITLE
Make S3 reads from public buckets via pandas anonymous

### DIFF
--- a/docs/building-a-workflow.md
+++ b/docs/building-a-workflow.md
@@ -30,7 +30,7 @@ import pandas as pd
 DATASET = "300-W"
 BUCKET = "s3://kolena-public-datasets"
 
-df = pd.read_csv(f"{BUCKET}/{DATASET}/meta/metadata.csv")
+df = pd.read_csv(f"{BUCKET}/{DATASET}/meta/metadata.csv", storage_options={"anon": True})
 ```
 
 !!! note "Note: `s3fs` dependency"

--- a/examples/age_estimation/age_estimation/seed_test_run.py
+++ b/examples/age_estimation/age_estimation/seed_test_run.py
@@ -31,7 +31,7 @@ DATASET = "labeled-faces-in-the-wild"
 
 
 def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
-    df_results = pd.read_csv(f"s3://{BUCKET}/{DATASET}/predictions/{model_name}.csv")
+    df_results = pd.read_csv(f"s3://{BUCKET}/{DATASET}/predictions/{model_name}.csv", storage_options={"anon": True})
 
     def infer(test_sample: TestSample) -> Inference:
         age = df_results[df_results["image_path"] == test_sample.locator]["age"].values[0]

--- a/examples/age_estimation/age_estimation/seed_test_suite.py
+++ b/examples/age_estimation/age_estimation/seed_test_suite.py
@@ -30,7 +30,7 @@ DATASET = "labeled-faces-in-the-wild"
 def main(args: Namespace) -> int:
     kolena.initialize(verbose=True)
 
-    df_metadata = pd.read_csv(args.dataset_csv)
+    df_metadata = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
 
     non_metadata_fields = {"locator", "age"}
     test_samples_and_ground_truths = [

--- a/examples/automatic_speech_recognition/automatic_speech_recognition/seed_test_run.py
+++ b/examples/automatic_speech_recognition/automatic_speech_recognition/seed_test_run.py
@@ -100,7 +100,7 @@ def main(args: Namespace) -> None:
         "inference_whisper-1-translate",
         "inference_wav2vec2-base-960h",
     ]
-    df_results = pd.read_csv(csv_to_use, usecols=columns_of_interest)
+    df_results = pd.read_csv(csv_to_use, usecols=columns_of_interest, storage_options={"anon": True})
 
     if args.test_suite is None:
         print("loading test suite")

--- a/examples/automatic_speech_recognition/automatic_speech_recognition/seed_test_suite.py
+++ b/examples/automatic_speech_recognition/automatic_speech_recognition/seed_test_suite.py
@@ -117,7 +117,7 @@ def seed_test_suite_tempo(
 
 
 def seed_complete_test_case(args: Namespace) -> TestCase:
-    df = pd.read_csv(args.dataset_csv)
+    df = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
     df = df.where(pd.notnull(df), None)  # read missing cells as None
     df.columns = df.columns.str.replace(r"(\s|\.)+", "_", regex=True)  # sanitize column names to use underscores
 

--- a/examples/classification/scripts/binary/seed_test_run.py
+++ b/examples/classification/scripts/binary/seed_test_run.py
@@ -35,7 +35,7 @@ NEGATIVE_LABEL = "cat"
 
 
 def seed_test_run(model_name: str, test_suite_names: List[str], multiclass: bool = False) -> None:
-    df_results = pd.read_csv(f"s3://{BUCKET}/{DATASET}/results/predictions_{model_name}.csv")
+    df_results = pd.read_csv(f"s3://{BUCKET}/{DATASET}/results/predictions_{model_name}.csv", storage_options={"anon": True})
 
     def infer(test_sample: TestSample) -> Inference:
         sample_result = df_results[df_results["locator"] == test_sample.locator].iloc[0]

--- a/examples/classification/scripts/binary/seed_test_run.py
+++ b/examples/classification/scripts/binary/seed_test_run.py
@@ -35,7 +35,10 @@ NEGATIVE_LABEL = "cat"
 
 
 def seed_test_run(model_name: str, test_suite_names: List[str], multiclass: bool = False) -> None:
-    df_results = pd.read_csv(f"s3://{BUCKET}/{DATASET}/results/predictions_{model_name}.csv", storage_options={"anon": True})
+    df_results = pd.read_csv(
+        f"s3://{BUCKET}/{DATASET}/results/predictions_{model_name}.csv",
+        storage_options={"anon": True},
+    )
 
     def infer(test_sample: TestSample) -> Inference:
         sample_result = df_results[df_results["locator"] == test_sample.locator].iloc[0]

--- a/examples/classification/scripts/binary/seed_test_suite.py
+++ b/examples/classification/scripts/binary/seed_test_suite.py
@@ -33,7 +33,7 @@ POSITIVE_LABEL = "dog"
 def main(args: Namespace) -> int:
     kolena.initialize(verbose=True)
 
-    df_metadata = pd.read_csv(args.dataset_csv)
+    df_metadata = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
 
     non_metadata_fields = {"locator", "label"}
     test_samples_and_ground_truths = [

--- a/examples/classification/scripts/multiclass/seed_test_run.py
+++ b/examples/classification/scripts/multiclass/seed_test_run.py
@@ -33,7 +33,7 @@ DATASET = "cifar10/test"
 
 
 def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
-    df_results = pd.read_csv(f"s3://{BUCKET}/{DATASET}/results/{model_name}.csv")
+    df_results = pd.read_csv(f"s3://{BUCKET}/{DATASET}/results/{model_name}.csv", storage_options={"anon": True})
 
     labels = set(df_results.columns) - {"locator"}
 

--- a/examples/classification/scripts/multiclass/seed_test_suite.py
+++ b/examples/classification/scripts/multiclass/seed_test_suite.py
@@ -32,7 +32,7 @@ DATASET = "cifar10/test"
 def main(args: Namespace) -> int:
     kolena.initialize(verbose=True)
 
-    df_metadata = pd.read_csv(args.dataset_csv)
+    df_metadata = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
 
     non_metadata_fields = {"locator", "label"}
     test_samples_and_ground_truths = [

--- a/examples/face_recognition_11/face_recognition_11/seed_test_run.py
+++ b/examples/face_recognition_11/face_recognition_11/seed_test_run.py
@@ -35,7 +35,7 @@ DATASET = "labeled-faces-in-the-wild"
 
 
 def seed_test_run(model_name: str, detector: str, test_suite_names: List[str]) -> None:
-    df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/predictions/predictions_{model_name}.csv")
+    df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/predictions/predictions_{model_name}.csv", storage_options={"anon": True})
 
     def infer(test_sample: TestSample) -> Inference:
         similarities = []

--- a/examples/face_recognition_11/face_recognition_11/seed_test_run.py
+++ b/examples/face_recognition_11/face_recognition_11/seed_test_run.py
@@ -35,7 +35,10 @@ DATASET = "labeled-faces-in-the-wild"
 
 
 def seed_test_run(model_name: str, detector: str, test_suite_names: List[str]) -> None:
-    df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/predictions/predictions_{model_name}.csv", storage_options={"anon": True})
+    df = pd.read_csv(
+        f"s3://{BUCKET}/{DATASET}/predictions/predictions_{model_name}.csv",
+        storage_options={"anon": True},
+    )
 
     def infer(test_sample: TestSample) -> Inference:
         similarities = []

--- a/examples/face_recognition_11/face_recognition_11/seed_test_suite.py
+++ b/examples/face_recognition_11/face_recognition_11/seed_test_suite.py
@@ -35,9 +35,9 @@ DATASET = "labeled-faces-in-the-wild"
 def main(args: Namespace) -> int:
     kolena.initialize(verbose=True)
 
-    df = pd.read_csv(args.dataset_csv)
-    df_metadata = pd.read_csv(args.metadata_csv)
-    df_bbox_keypoints = pd.read_csv(args.bbox_keypoints_csv)
+    df = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
+    df_metadata = pd.read_csv(args.metadata_csv, storage_options={"anon": True})
+    df_bbox_keypoints = pd.read_csv(args.bbox_keypoints_csv, storage_options={"anon": True})
 
     metadata_by_locator = {}
     locator_normalization_factor = {}

--- a/examples/keypoint_detection/keypoint_detection/seed_test_suite.py
+++ b/examples/keypoint_detection/keypoint_detection/seed_test_suite.py
@@ -29,7 +29,7 @@ BUCKET = "s3://kolena-public-datasets"
 
 
 def run(args: Namespace) -> None:
-    df = pd.read_csv(f"{BUCKET}/{DATASET}/meta/metadata.csv")
+    df = pd.read_csv(f"{BUCKET}/{DATASET}/meta/metadata.csv", storage_options={"anon": True})
 
     test_samples = [TestSample(locator) for locator in df["locator"]]
     ground_truths = [

--- a/examples/object_detection_2d/object_detection_2d/extended/seed_test_suite.py
+++ b/examples/object_detection_2d/object_detection_2d/extended/seed_test_suite.py
@@ -72,7 +72,7 @@ def load_transportation_data() -> Dict[str, List[ExtendedBoundingBox]]:
 def create_complete_transportation_case(args: Namespace) -> TestCase:
     print("loading S3 files...")
     image_to_boxes = load_transportation_data()
-    data = pd.read_csv(args.metadata)
+    data = pd.read_csv(args.metadata, storage_options={"anon": True})
 
     # create a test sample object and a ground truth object per image
     test_samples_and_ground_truths: List[Tuple[TestSample, GroundTruth]] = []

--- a/examples/object_detection_2d/object_detection_2d/seed_test_run.py
+++ b/examples/object_detection_2d/object_detection_2d/seed_test_run.py
@@ -69,6 +69,7 @@ def load_results(model_alias: str) -> pd.DataFrame:
                 "max_x": object,
                 "max_y": object,
             },
+            storage_options={"anon": True},
         )
     except OSError as e:
         print(e, "\nPlease ensure you have set up AWS credentials.")

--- a/examples/object_detection_2d/object_detection_2d/seed_test_suite.py
+++ b/examples/object_detection_2d/object_detection_2d/seed_test_suite.py
@@ -72,7 +72,7 @@ def load_transportation_data() -> Dict[str, List[LabeledBoundingBox]]:
 def create_complete_transportation_case(args: Namespace) -> TestCase:
     print("loading S3 files...")
     image_to_boxes = load_transportation_data()
-    data = pd.read_csv(args.metadata)
+    data = pd.read_csv(args.metadata, storage_options={"anon": True})
 
     # create a test sample object and a ground truth object per image
     test_samples_and_ground_truths: List[Tuple[TestSample, GroundTruth]] = []

--- a/examples/question_answering/question_answering/seed_test_run.py
+++ b/examples/question_answering/question_answering/seed_test_run.py
@@ -36,7 +36,7 @@ def main(args: Namespace) -> int:
 
     inference_mapping = {}
     model_file_path = f"s3://kolena-public-datasets/CoQA/results/{args.model}.csv"
-    df = pd.read_csv(model_file_path)
+    df = pd.read_csv(model_file_path, storage_options={"anon": True})
 
     # populate inference_mapping
     for _, row in df.iterrows():

--- a/examples/question_answering/question_answering/seed_test_suite.py
+++ b/examples/question_answering/question_answering/seed_test_suite.py
@@ -92,7 +92,7 @@ def create_test_suite_by_conversation_length(dataset: TestCase, data: List[Tuple
 def main(args: Namespace) -> int:
     kolena.initialize(verbose=True)
 
-    df_metadata = pd.read_csv(args.dataset_csv)
+    df_metadata = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
     context_dict = defaultdict(list)
 
     # Store the conversation context for each story (data_id)

--- a/examples/semantic_segmentation/semantic_segmentation/seed_test_suite.py
+++ b/examples/semantic_segmentation/semantic_segmentation/seed_test_suite.py
@@ -53,7 +53,7 @@ def seed_stratified_test_cases(complete_test_case: TestCase, test_suite_name) ->
 
 
 def seed_complete_test_case(args: Namespace) -> TestCase:
-    df = pd.read_csv(args.dataset_csv)
+    df = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
     test_samples = []
     for record in tqdm(df.itertuples(index=False), total=len(df)):
         test_sample = TestSample(  # type: ignore

--- a/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_run.py
+++ b/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_run.py
@@ -31,7 +31,7 @@ DATASET = "sts-benchmark"
 
 
 def seed_test_run(model_name: str, test_suite_names: List[str]) -> None:
-    df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/results/{model_name}.csv")
+    df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/results/{model_name}.csv", storage_options={"anon": True})
 
     required_columns = {"sentence1", "sentence2", "cos_similarity"}
     assert all(required_column in set(df.columns) for required_column in required_columns)

--- a/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_suite.py
+++ b/examples/semantic_textual_similarity/semantic_textual_similarity/seed_test_suite.py
@@ -28,7 +28,7 @@ DATASET = "sts-benchmark"
 
 
 def seed_complete_test_case(args: Namespace) -> TestCase:
-    df = pd.read_csv(args.dataset_csv)
+    df = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
     required_columns = {"sentence1", "sentence2"}
     assert all(required_column in set(df.columns) for required_column in required_columns)
 

--- a/examples/speaker_diarization/speaker_diarization/seed_test_run.py
+++ b/examples/speaker_diarization/speaker_diarization/seed_test_run.py
@@ -52,10 +52,11 @@ def seed_test_run(
 ) -> None:
     def infer(sample: TestSample) -> Inference:
         inference_path = sample.metadata["transcription_path"].replace("audio/", f"{mod}_inferences/")
-        inference_df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/{inference_path}/")
+        inference_df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/{inference_path}/", storage_options={"anon": True})
         if align_speakers:
             gt_df = pd.read_csv(
                 f"s3://{BUCKET}/{DATASET}/{sample.metadata['transcription_path'][:-4] + '_cleaned.csv'}",
+                storage_options={"anon": True}
             )
             realign_labels(gt_df, inference_df)
 

--- a/examples/speaker_diarization/speaker_diarization/seed_test_run.py
+++ b/examples/speaker_diarization/speaker_diarization/seed_test_run.py
@@ -56,7 +56,7 @@ def seed_test_run(
         if align_speakers:
             gt_df = pd.read_csv(
                 f"s3://{BUCKET}/{DATASET}/{sample.metadata['transcription_path'][:-4] + '_cleaned.csv'}",
-                storage_options={"anon": True}
+                storage_options={"anon": True},
             )
             realign_labels(gt_df, inference_df)
 

--- a/examples/speaker_diarization/speaker_diarization/seed_test_suite.py
+++ b/examples/speaker_diarization/speaker_diarization/seed_test_suite.py
@@ -59,7 +59,7 @@ def seed_test_suite_by_avg_amp(
 
 
 def seed_complete_test_case(args: Namespace) -> TestCase:
-    df = pd.read_csv(args.dataset_csv)
+    df = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
     df = df.where(pd.notnull(df), None)  # read missing cells as None
     df.columns = df.columns.str.replace(r"(\s|\.)+", "_", regex=True)  # sanitize column names to use underscores
 
@@ -82,7 +82,7 @@ def seed_complete_test_case(args: Namespace) -> TestCase:
             locator=f"s3://{BUCKET}/{DATASET}/{record.audio_path}",
             metadata={f: getattr(record, f) for f in required_columns},
         )
-        transcription_df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/{record.transcription_path[:-4] + '_cleaned.csv'}")
+        transcription_df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/{record.transcription_path[:-4] + '_cleaned.csv'}", storage_options={"anon": True})
         ground_truth = GroundTruth(
             transcription=[
                 LabeledTimeSegment(

--- a/examples/speaker_diarization/speaker_diarization/seed_test_suite.py
+++ b/examples/speaker_diarization/speaker_diarization/seed_test_suite.py
@@ -82,7 +82,10 @@ def seed_complete_test_case(args: Namespace) -> TestCase:
             locator=f"s3://{BUCKET}/{DATASET}/{record.audio_path}",
             metadata={f: getattr(record, f) for f in required_columns},
         )
-        transcription_df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/{record.transcription_path[:-4] + '_cleaned.csv'}", storage_options={"anon": True})
+        transcription_df = pd.read_csv(
+            f"s3://{BUCKET}/{DATASET}/{record.transcription_path[:-4] + '_cleaned.csv'}",
+            storage_options={"anon": True},
+        )
         ground_truth = GroundTruth(
             transcription=[
                 LabeledTimeSegment(

--- a/examples/text_summarization/text_summarization/seed_test_run.py
+++ b/examples/text_summarization/text_summarization/seed_test_run.py
@@ -154,7 +154,7 @@ def main(args: Namespace) -> None:
         "tokens_used",
         "cost",
     ]
-    df_results = pd.read_csv(csv_to_use, usecols=columns_of_interest)
+    df_results = pd.read_csv(csv_to_use, usecols=columns_of_interest, storage_options={"anon": True})
 
     if args.test_suite is None:
         print("loading test suite")

--- a/examples/text_summarization/text_summarization/seed_test_suite.py
+++ b/examples/text_summarization/text_summarization/seed_test_suite.py
@@ -146,7 +146,7 @@ def seed_test_suite_by_moderation(
 
 
 def seed_complete_test_case(args: Namespace) -> TestCase:
-    df = pd.read_csv(args.dataset_csv)
+    df = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
     df = df.where(pd.notnull(df), None)  # read missing cells as None
     df.columns = df.columns.str.replace(r"(\s|\.)+", "_", regex=True)  # sanitize column names to use underscores
     required_columns = {"article_id", "article", "article_summary", "text_word_count", "summary_word_count"}


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?

Passes `anon: True` to all calls to `pd.read_csv` reading from our public bucket in the examples - this now fails by default if the user does not have AWS credentials, even though they are not required for access.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
