### PR TITLE
Update `_infer_id_fields` to support composite style fields

### DIFF
--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -142,10 +142,17 @@ def _infer_datatype(df: pd.DataFrame) -> Union[pd.DataFrame, str]:
 
 
 def _infer_id_fields(df: pd.DataFrame) -> List[str]:
-    if FIELD_LOCATOR in df.columns:
-        return [FIELD_LOCATOR]
-    elif FIELD_TEXT in df.columns:
-        return [FIELD_TEXT]
+    def get_id_fields_by(field: str) -> List[str]:
+        return [
+            id_field
+            for id_field in df.columns.array
+            if isinstance(id_field, str) and id_field.rsplit(SEP, maxsplit=1)[-1] == field
+        ]
+
+    if id_fields := get_id_fields_by(FIELD_LOCATOR):
+        return id_fields
+    elif id_fields := get_id_fields_by(FIELD_TEXT):
+        return id_fields
     raise InputValidationError("Failed to infer the id_fields, please provide id_fields explicitly")
 
 

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -432,6 +432,10 @@ def test__infer_id_fields() -> None:
             ),
         ),
     ) == ["text"]
+    assert _infer_id_fields(pd.DataFrame({"a.text": ["a", "b"], "b.text": ["c", "d"]})) == [
+        "a.text",
+        "b.text",
+    ]
 
     try:
         assert _infer_id_fields(


### PR DESCRIPTION
### Linked issue(s):
Fixes KOL-4134

### What change does this PR introduce and why?
Currently cannot upload composite datasets through web ui since there is no mechanism to declare id_fields explicitly and the fields cannot be inferred. This PR fixes that issue by updating `_infer_id_fields` to support parsing composite style keys (eg. "prefix.text").



### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added