### PR TITLE
Updating the missing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ $ poetry run pre-commit install
 The documentation for `kolena`, hosted at [docs.kolena.io](https://docs.kolena.io/), is built out of this repo using
 [MkDocs](https://www.mkdocs.org/).
 Building the documentation locally requires installing the Poetry dependencies for `kolena` as well as additional
-[OS-level dependencies for mkdocs-material](https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/#cairo-graphics).
+[OS-level dependencies for mkdocs-material](https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/).
 
 To run the documentation server locally, run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ $ poetry run pre-commit install
 The documentation for `kolena`, hosted at [docs.kolena.io](https://docs.kolena.io/), is built out of this repo using
 [MkDocs](https://www.mkdocs.org/).
 Building the documentation locally requires installing the Poetry dependencies for `kolena` as well as additional
-[OS-level dependencies for mkdocs-material](https://squidfunk.github.io/mkdocs-material/setup/dependencies/image-processing/).
+[OS-level dependencies for mkdocs-material](https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/#cairo-graphics).
 
 To run the documentation server locally, run:
 


### PR DESCRIPTION
Link is missing on mkdocs dependencies. This should fix that.

### Linked issue(s): KOL-4262

### What change does this PR introduce and why? added the missing link

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
