### PR TITLE
List dataset commit history and get snapshots

### DIFF
--- a/kolena/_api/v2/dataset.py
+++ b/kolena/_api/v2/dataset.py
@@ -14,6 +14,7 @@
 from enum import Enum
 from typing import List
 
+from pydantic import conint
 from pydantic.dataclasses import dataclass
 
 from kolena._api.v1.batched_load import BatchedLoad
@@ -23,6 +24,7 @@ class Path(str, Enum):
     REGISTER = "/dataset/register"
     LOAD_DATAPOINTS = "/dataset/load-datapoints"
     LOAD_DATASET = "/dataset/load-by-name"
+    LIST_COMMITS = "/dataset/list-commits"
 
 
 @dataclass(frozen=True)
@@ -48,3 +50,29 @@ class EntityData:
     name: str
     description: str
     id_fields: List[str]
+
+
+@dataclass(frozen=True)
+class ListCommitHistoryRequest:
+    name: str
+    desc: bool = False
+    offset: conint(strict=True, ge=0) = 0
+    limit: conint(strict=True, ge=0, le=100) = 50
+
+
+@dataclass(frozen=True)
+class CommitData:
+    commit: str
+    timestamp: int
+    user: str
+    n_removed: int
+    n_added: int
+
+
+@dataclass(frozen=True)
+class ListCommitHistoryResponse:
+    records: List[CommitData]
+    total_count: int
+    desc: bool
+    offset: int
+    limit: int

--- a/kolena/_api/v2/dataset.py
+++ b/kolena/_api/v2/dataset.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from enum import Enum
 from typing import List
+from typing import Optional
 
 from pydantic import conint
 from pydantic.dataclasses import dataclass
@@ -37,6 +38,7 @@ class RegisterRequest:
 @dataclass(frozen=True)
 class LoadDatapointsRequest(BatchedLoad.BaseInitDownloadRequest):
     name: str
+    commit: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/kolena/_api/v2/dataset.py
+++ b/kolena/_api/v2/dataset.py
@@ -57,7 +57,7 @@ class EntityData:
 @dataclass(frozen=True)
 class ListCommitHistoryRequest:
     name: str
-    desc: bool = False
+    descending: bool = False
     offset: conint(strict=True, ge=0) = 0
     limit: conint(strict=True, ge=0, le=100) = 50
 
@@ -75,6 +75,6 @@ class CommitData:
 class ListCommitHistoryResponse:
     records: List[CommitData]
     total_count: int
-    desc: bool
+    descending: bool
     offset: int
     limit: int

--- a/kolena/_experimental/dataset/__init__.py
+++ b/kolena/_experimental/dataset/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # noreorder
-from kolena._experimental.dataset._dataset import fetch_commits
+from kolena._experimental.dataset._dataset import fetch_dataset_history
 from kolena._experimental.dataset._dataset import fetch_dataset
 from kolena._experimental.dataset._dataset import register_dataset
 from kolena._experimental.dataset._evaluation import fetch_results
@@ -20,7 +20,7 @@ from kolena._experimental.dataset._evaluation import test
 
 __all__ = [
     "register_dataset",
-    "fetch_commits",
+    "fetch_dataset_history",
     "fetch_dataset",
     "fetch_results",
     "test",

--- a/kolena/_experimental/dataset/__init__.py
+++ b/kolena/_experimental/dataset/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # noreorder
+from kolena._experimental.dataset._dataset import fetch_commits
 from kolena._experimental.dataset._dataset import fetch_dataset
 from kolena._experimental.dataset._dataset import register_dataset
 from kolena._experimental.dataset._evaluation import fetch_results
@@ -19,6 +20,7 @@ from kolena._experimental.dataset._evaluation import test
 
 __all__ = [
     "register_dataset",
+    "fetch_commits",
     "fetch_dataset",
     "fetch_results",
     "test",

--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -313,26 +313,36 @@ def _list_commits(name: str, desc: bool = False, offset: int = 0, limit: int = 5
     return from_dict(ListCommitHistoryResponse, response.json())
 
 
-def _iter_commits(name: str, desc: bool = False, limit: int = None) -> Iterator[Tuple[int, List[CommitData]]]:
+def _iter_commits(
+    name: str,
+    desc: bool = False,
+    limit: int = None,
+    page_size: int = 50,
+) -> Iterator[Tuple[int, List[CommitData]]]:
     """
     Get an iterator over the commit history of the dataset.
     """
-    initial_response = _list_commits(name, desc=desc)
+    initial_response = _list_commits(name, desc=desc, limit=page_size)
     total_commit_count = initial_response.total_count
     if not limit:
         limit = total_commit_count
     yield total_commit_count, initial_response.records
     current_count = len(initial_response.records)
     while current_count < min(limit, total_commit_count):
-        yield total_commit_count, _list_commits(name, desc=desc, offset=current_count).records
+        yield total_commit_count, _list_commits(name, desc=desc, offset=current_count, limit=page_size).records
         current_count += len(initial_response.records)
 
 
-def fetch_commits(name: str, desc: bool = False, limit: int = None) -> Tuple[int, List[CommitData]]:
+def fetch_commits(
+    name: str,
+    desc: bool = False,
+    limit: int = None,
+    page_size: int = 50,
+) -> Tuple[int, List[CommitData]]:
     """
     Get the commit history of a dataset.
     """
-    iter_commit_responses = list(_iter_commits(name, desc, limit))
+    iter_commit_responses = list(_iter_commits(name, desc, limit, page_size))
     total_commit_count = iter_commit_responses[0][0]
     commits = [commit for response in iter_commit_responses for commit in response[1]][:limit]
     return total_commit_count, commits

--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -262,12 +262,15 @@ def register_dataset(
 
 def _iter_dataset_raw(
     name: str,
+    commit: str = None,
     batch_size: int = BatchSize.LOAD_SAMPLES.value,
 ) -> Iterator[pd.DataFrame]:
     validate_batch_size(batch_size)
     init_request = LoadDatapointsRequest(
         name=name,
+        commit=commit,
         batch_size=batch_size,
+
     )
     yield from _BatchedLoader.iter_data(
         init_request=init_request,
@@ -279,23 +282,25 @@ def _iter_dataset_raw(
 
 def _iter_dataset(
     name: str,
+    commit: str = None,
     batch_size: int = BatchSize.LOAD_SAMPLES.value,
 ) -> Iterator[pd.DataFrame]:
     """
     Get an iterator over datapoints in the dataset.
     """
-    for df_batch in _iter_dataset_raw(name, batch_size):
+    for df_batch in _iter_dataset_raw(name, commit, batch_size):
         yield _to_deserialized_dataframe(df_batch, column=COL_DATAPOINT)
 
 
 def fetch_dataset(
     name: str,
+    commit: str = None,
     batch_size: int = BatchSize.LOAD_SAMPLES.value,
 ) -> pd.DataFrame:
     """
     Fetch an entire dataset given its name.
     """
-    df_batches = list(_iter_dataset(name, batch_size))
+    df_batches = list(_iter_dataset(name, commit, batch_size))
     return pd.concat(df_batches, ignore_index=True) if df_batches else pd.DataFrame()
 
 

--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -270,7 +270,6 @@ def _iter_dataset_raw(
         name=name,
         commit=commit,
         batch_size=batch_size,
-
     )
     yield from _BatchedLoader.iter_data(
         init_request=init_request,

--- a/tests/integration/_experimental/dataset/test_dataset.py
+++ b/tests/integration/_experimental/dataset/test_dataset.py
@@ -32,7 +32,7 @@ from tests.integration.helper import with_test_prefix
 
 
 TEST_COMMIT_HISTORY_NAME = with_test_prefix(f"{__file__}::test__commit_history")
-TEST_COMMIT_HISTORY_VERSIONS = 60
+TEST_COMMIT_HISTORY_VERSIONS = 10
 
 
 def test__register_dataset__empty() -> None:
@@ -201,6 +201,15 @@ def test__fetch_commits(with_dataset_commits: Tuple[int, List[CommitData]]) -> N
 
 
 @pytest.mark.depends(on=["test__fetch_commits"])
+def test__fetch_commits__pagination(with_dataset_commits: Tuple[int, List[CommitData]]) -> None:
+    # check fetch_commits with desc arg
+    total_commits, commits = with_dataset_commits
+    total_commits_pagination, commits_pagination = fetch_commits(TEST_COMMIT_HISTORY_NAME, page_size=1)
+    assert total_commits_pagination == total_commits
+    assert commits_pagination == commits
+
+
+@pytest.mark.depends(on=["test__fetch_commits"])
 def test__fetch_commits__desc(with_dataset_commits: Tuple[int, List[CommitData]]) -> None:
     # check fetch_commits with desc arg
     total_commits, commits = with_dataset_commits
@@ -243,10 +252,12 @@ def test__fetch_dataset__versions(with_dataset_commits: Tuple[int, List[CommitDa
     total_commits, commits = with_dataset_commits
     for version, commit in enumerate(commits):
         loaded_datapoints = fetch_dataset(TEST_COMMIT_HISTORY_NAME, commit.commit).sort_values(
-            "locator", ignore_index=True
+            "locator",
+            ignore_index=True,
         )
         expected_datapoints = pd.DataFrame([dict(locator=f"{version}-{i}") for i in range(version + 1)]).sort_values(
-            "locator", ignore_index=True
+            "locator",
+            ignore_index=True,
         )
         assert_frame_equal(loaded_datapoints, expected_datapoints)
 

--- a/tests/integration/_experimental/dataset/test_dataset.py
+++ b/tests/integration/_experimental/dataset/test_dataset.py
@@ -183,7 +183,7 @@ def test__fetch_dataset__not_exist() -> None:
 def with_dataset_commits() -> Tuple[int, List[CommitData]]:
     for version in range(TEST_COMMIT_HISTORY_VERSIONS):
         # remove all previous datapoints and add (version + 1) new datapoints in each iteration
-        datapoints = [dict(locator=f"{version}-{i}") for i in range(version+1)]
+        datapoints = [dict(locator=f"{version}-{i}") for i in range(version + 1)]
         register_dataset(TEST_COMMIT_HISTORY_NAME, pd.DataFrame(datapoints), id_fields=["locator"])
     return fetch_commits(TEST_COMMIT_HISTORY_NAME)
 
@@ -222,7 +222,7 @@ def test__fetch_commits__limit(with_dataset_commits: Tuple[int, List[CommitData]
 def test__fetch_commits__limit_more_than_versions(with_dataset_commits: Tuple[int, List[CommitData]]) -> None:
     # check fetch_commits with limit arg greater than number of revisions
     total_commits, commits = with_dataset_commits
-    total_commits_limit, commits_limit = fetch_commits(TEST_COMMIT_HISTORY_NAME, limit=TEST_COMMIT_HISTORY_VERSIONS+1)
+    total_commits_limit, commits_limit = fetch_commits(TEST_COMMIT_HISTORY_NAME, limit=TEST_COMMIT_HISTORY_VERSIONS + 1)
     assert total_commits_limit == total_commits
     assert len(commits) == TEST_COMMIT_HISTORY_VERSIONS
     assert commits_limit == commits
@@ -242,10 +242,12 @@ def test__fetch_dataset__versions(with_dataset_commits: Tuple[int, List[CommitDa
     # check fetch_dataset with commit arg
     total_commits, commits = with_dataset_commits
     for version, commit in enumerate(commits):
-        loaded_datapoints = (fetch_dataset(TEST_COMMIT_HISTORY_NAME, commit.commit)
-                             .sort_values("locator", ignore_index=True))
-        expected_datapoints = (pd.DataFrame([dict(locator=f"{version}-{i}") for i in range(version+1)])
-                               .sort_values("locator", ignore_index=True))
+        loaded_datapoints = fetch_dataset(TEST_COMMIT_HISTORY_NAME, commit.commit).sort_values(
+            "locator", ignore_index=True
+        )
+        expected_datapoints = pd.DataFrame([dict(locator=f"{version}-{i}") for i in range(version + 1)]).sort_values(
+            "locator", ignore_index=True
+        )
         assert_frame_equal(loaded_datapoints, expected_datapoints)
 
 

--- a/tests/integration/_experimental/dataset/test_dataset.py
+++ b/tests/integration/_experimental/dataset/test_dataset.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 import random
 from typing import Iterator
+from typing import List
+from typing import Tuple
 
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
+from kolena._api.v2.dataset import CommitData
+from kolena._experimental.dataset import fetch_commits
 from kolena._experimental.dataset import fetch_dataset
 from kolena._experimental.dataset import register_dataset
 from kolena.errors import NotFoundError
@@ -25,6 +29,10 @@ from kolena.workflow.annotation import BoundingBox
 from kolena.workflow.annotation import LabeledBoundingBox
 from tests.integration.helper import fake_locator
 from tests.integration.helper import with_test_prefix
+
+
+TEST_COMMIT_HISTORY_NAME = with_test_prefix(f"{__file__}::test__commit_history")
+TEST_COMMIT_HISTORY_VERSIONS = 60
 
 
 def test__register_dataset__empty() -> None:
@@ -169,3 +177,79 @@ def test__fetch_dataset__not_exist() -> None:
     name = with_test_prefix(f"{__file__}::test__fetch_dataset__not_exist")
     with pytest.raises(NotFoundError):
         fetch_dataset(name)
+
+
+@pytest.fixture(scope="module")
+def with_dataset_commits() -> Tuple[int, List[CommitData]]:
+    for version in range(TEST_COMMIT_HISTORY_VERSIONS):
+        # remove all previous datapoints and add (version + 1) new datapoints in each iteration
+        datapoints = [dict(locator=f"{version}-{i}") for i in range(version+1)]
+        register_dataset(TEST_COMMIT_HISTORY_NAME, pd.DataFrame(datapoints), id_fields=["locator"])
+    return fetch_commits(TEST_COMMIT_HISTORY_NAME)
+
+
+def test__fetch_commits(with_dataset_commits: Tuple[int, List[CommitData]]) -> None:
+    # check fetch_commits without optional args
+    total_commits, commits = with_dataset_commits
+    assert total_commits == TEST_COMMIT_HISTORY_VERSIONS
+    previous_commit_time = -1
+    for version, commit in enumerate(commits):
+        assert commit.timestamp >= previous_commit_time
+        assert commit.n_removed == version
+        assert commit.n_added == version + 1
+        previous_commit_time = commit.timestamp
+
+
+@pytest.mark.depends(on=["test__fetch_commits"])
+def test__fetch_commits__desc(with_dataset_commits: Tuple[int, List[CommitData]]) -> None:
+    # check fetch_commits with desc arg
+    total_commits, commits = with_dataset_commits
+    total_commits_desc, commits_desc = fetch_commits(TEST_COMMIT_HISTORY_NAME, desc=True)
+    assert total_commits_desc == total_commits
+    assert commits_desc == commits[::-1]
+
+
+@pytest.mark.depends(on=["test__fetch_commits"])
+def test__fetch_commits__limit(with_dataset_commits: Tuple[int, List[CommitData]]) -> None:
+    # check fetch_commits with limit arg
+    total_commits, commits = with_dataset_commits
+    total_commits_limit, commits_limit = fetch_commits(TEST_COMMIT_HISTORY_NAME, limit=10)
+    assert total_commits_limit == total_commits
+    assert commits_limit == commits[:10]
+
+
+@pytest.mark.depends(on=["test__fetch_commits"])
+def test__fetch_commits__limit_more_than_versions(with_dataset_commits: Tuple[int, List[CommitData]]) -> None:
+    # check fetch_commits with limit arg greater than number of revisions
+    total_commits, commits = with_dataset_commits
+    total_commits_limit, commits_limit = fetch_commits(TEST_COMMIT_HISTORY_NAME, limit=TEST_COMMIT_HISTORY_VERSIONS+1)
+    assert total_commits_limit == total_commits
+    assert len(commits) == TEST_COMMIT_HISTORY_VERSIONS
+    assert commits_limit == commits
+
+
+@pytest.mark.depends(on=["test__fetch_commits"])
+def test__fetch_commits__desc_limit(with_dataset_commits: Tuple[int, List[CommitData]]) -> None:
+    # check fetch_commits with both desc and limit args
+    total_commits, commits = with_dataset_commits
+    total_commits_desc_limit, commits_desc_limit = fetch_commits(TEST_COMMIT_HISTORY_NAME, desc=True, limit=10)
+    assert total_commits_desc_limit == total_commits
+    assert commits_desc_limit == commits[-1:-11:-1]
+
+
+@pytest.mark.depends(on=["test__fetch_commits"])
+def test__fetch_dataset__versions(with_dataset_commits: Tuple[int, List[CommitData]]) -> None:
+    # check fetch_dataset with commit arg
+    total_commits, commits = with_dataset_commits
+    for version, commit in enumerate(commits):
+        loaded_datapoints = (fetch_dataset(TEST_COMMIT_HISTORY_NAME, commit.commit)
+                             .sort_values("locator", ignore_index=True))
+        expected_datapoints = (pd.DataFrame([dict(locator=f"{version}-{i}") for i in range(version+1)])
+                               .sort_values("locator", ignore_index=True))
+        assert_frame_equal(loaded_datapoints, expected_datapoints)
+
+
+def test__fetch_dataset__commit_not_exist(with_dataset_commits: Tuple[int, List[CommitData]]) -> None:
+    # check fetch_dataset with a commit that does not exist
+    with pytest.raises(NotFoundError):
+        fetch_dataset(TEST_COMMIT_HISTORY_NAME, "non-existent-commit")


### PR DESCRIPTION
### Linked issue(s):
https://linear.app/kolena/issue/KOL-3548/sdk-load-previous-version-dataset

### What change does this PR introduce and why?
- Add client-side functionalities to retrieve the commit history of a dataset
- Update the `fetch_dataset` method to allow passing in a commit to get historical snapshots

Note that CI will fail until https://github.com/kolenaIO/shipyard/pull/1742 reaches prod.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
