### PR TITLE
Added a script to register both QA datasets

### DIFF
--- a/examples/question_answering/pyproject.toml
+++ b/examples/question_answering/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-kolena = ">=0.94.0,<1"
+kolena = ">=0.99.0,<1"
 s3fs = "^2022.7.1"
 torch = [
   {markers = "sys_platform == 'darwin' and platform_machine == 'arm64'", url = "https://download.pytorch.org/whl/cpu/torch-2.0.1-cp39-none-macosx_11_0_arm64.whl"},

--- a/examples/question_answering/question_answering/constants.py
+++ b/examples/question_answering/question_answering/constants.py
@@ -1,0 +1,17 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BUCKET = "kolena-public-datasets"
+TRUTHFULQA = "TruthfulQA"
+HALUEVALQA = "HaluEval-QA"

--- a/examples/question_answering/question_answering/register_dataset.py
+++ b/examples/question_answering/question_answering/register_dataset.py
@@ -1,0 +1,49 @@
+# Copyright 2021-2023 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+from argparse import Namespace
+
+from question_answering.constants import HALUEVALQA
+from question_answering.constants import TRUTHFULQA
+
+import kolena
+from kolena._experimental.dataset import register_dataset
+from kolena.workflow.io import dataframe_from_csv
+
+BUCKET = "kolena-public-datasets"
+DATASETS = {
+    TRUTHFULQA: f"s3://{BUCKET}/TruthfulQA/v1/TruthfulQA_QA.csv",
+    HALUEVALQA: f"s3://{BUCKET}/HaLuEval/data/v1/qa_data.csv",
+}
+
+
+def main(args: Namespace) -> None:
+    kolena.initialize(verbose=True)
+    for dataset in args.datasets:
+        print(f"Loading {dataset}...")
+        df_datapoint = dataframe_from_csv(DATASETS[dataset])
+        register_dataset(dataset, df_datapoint, id_fields=["id"])
+
+
+if __name__ == "__main__":
+    ap = ArgumentParser()
+    ap.add_argument(
+        "--datasets",
+        nargs="+",
+        default=DATASETS.keys(),
+        choices=DATASETS.keys(),
+        help="Name(s) of the dataset(s) to register.",
+    )
+
+    main(ap.parse_args())

--- a/examples/question_answering/question_answering/register_dataset.py
+++ b/examples/question_answering/question_answering/register_dataset.py
@@ -14,6 +14,7 @@
 from argparse import ArgumentParser
 from argparse import Namespace
 
+from question_answering.constants import BUCKET
 from question_answering.constants import HALUEVALQA
 from question_answering.constants import TRUTHFULQA
 
@@ -21,7 +22,6 @@ import kolena
 from kolena._experimental.dataset import register_dataset
 from kolena.workflow.io import dataframe_from_csv
 
-BUCKET = "kolena-public-datasets"
 DATASETS = {
     TRUTHFULQA: f"s3://{BUCKET}/TruthfulQA/v1/TruthfulQA_QA.csv",
     HALUEVALQA: f"s3://{BUCKET}/HaLuEval/data/v1/qa_data.csv",


### PR DESCRIPTION
### Linked issue(s):
Fixes KOL-4118

### What change does this PR introduce and why?
Added a script that registers TruthfulQA and HaluEvalQA datasets.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
