### PR TITLE
fix: robust uniqueness checking

### DIFF
--- a/kolena/_experimental/dataset/common.py
+++ b/kolena/_experimental/dataset/common.py
@@ -45,6 +45,11 @@ def validate_id_fields(id_fields: List[str], existing_id_fields: List[str] = Non
             )
 
 
+def _convert_non_int_str_to_str(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.applymap(lambda x: str(x) if (not isinstance(x, (int, str))) else x)
+    return df
+
+
 def validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
     for id_field in id_fields:
         if id_field not in df.columns:
@@ -52,7 +57,7 @@ def validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
                 f"invalid id_fields: field '{id_field}' does not exist in dataframe",
             )
     # check uniqueness of the id columns
-    unique_id_fields = df[id_fields].drop_duplicates()
+    unique_id_fields = _convert_non_int_str_to_str(df[id_fields]).drop_duplicates()
     if len(unique_id_fields) != len(df):
         raise InputValidationError(
             f"invalid id_fields: " f"input dataframe's id field values are not unique for {id_fields}",

--- a/kolena/_experimental/dataset/common.py
+++ b/kolena/_experimental/dataset/common.py
@@ -45,9 +45,11 @@ def validate_id_fields(id_fields: List[str], existing_id_fields: List[str] = Non
             )
 
 
-def _convert_non_int_str_to_str(df: pd.DataFrame) -> pd.DataFrame:
-    df = df.applymap(lambda x: str(x) if (not isinstance(x, (int, str))) else x)
-    return df
+def _convert_to_single_column(df):
+    # create a new dataframe with dictionary in each row
+    new_df = pd.DataFrame(df.apply(lambda x: x.to_dict(), axis=1))
+
+    return new_df
 
 
 def validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
@@ -57,7 +59,7 @@ def validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
                 f"invalid id_fields: field '{id_field}' does not exist in dataframe",
             )
     # check uniqueness of the id columns
-    unique_id_fields = _convert_non_int_str_to_str(df[id_fields]).drop_duplicates()
+    unique_id_fields = _convert_to_single_column(df[id_fields]).drop_duplicates()
     if len(unique_id_fields) != len(df):
         raise InputValidationError(
             f"invalid id_fields: " f"input dataframe's id field values are not unique for {id_fields}",

--- a/kolena/_experimental/dataset/common.py
+++ b/kolena/_experimental/dataset/common.py
@@ -45,11 +45,11 @@ def validate_id_fields(id_fields: List[str], existing_id_fields: List[str] = Non
             )
 
 
-def _convert_to_single_column(df):
-    # create a new dataframe with dictionary in each row
-    new_df = pd.DataFrame(df.apply(lambda x: x.to_dict(), axis=1))
-
-    return new_df
+def _validate_dataframe_ids_uniqueness(df: pd.DataFrame, id_fields: List[str]) -> None:
+    if df[id_fields].apply(lambda x: x.to_dict(), axis=1).duplicated().any():
+        raise InputValidationError(
+            f"invalid id_fields: " f"input dataframe's id field values are not unique for {id_fields}",
+        )
 
 
 def validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
@@ -58,9 +58,4 @@ def validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
             raise InputValidationError(
                 f"invalid id_fields: field '{id_field}' does not exist in dataframe",
             )
-    # check uniqueness of the id columns
-    unique_id_fields = _convert_to_single_column(df[id_fields]).drop_duplicates()
-    if len(unique_id_fields) != len(df):
-        raise InputValidationError(
-            f"invalid id_fields: " f"input dataframe's id field values are not unique for {id_fields}",
-        )
+    _validate_dataframe_ids_uniqueness(df, id_fields)

--- a/tests/unit/_experimental/dataset/test_common.py
+++ b/tests/unit/_experimental/dataset/test_common.py
@@ -59,8 +59,8 @@ def test__validate_id_fields__validation_error(
     [
         (pd.DataFrame(dict(a=[1, 2, 3], b=[1, 2, 1])), ["a", "b"]),
         (pd.DataFrame({"a.text": [1, 2, 3], "b.text": [1, 2, 1]}), ["a.text", "b.text"]),
-        (pd.DataFrame(dict(a=[{"c": i * j for i in range(3)} for j in range(3)], b=[1, 2, 1])), ["a", "b"]),
-        (pd.DataFrame(dict(a=[[i * j for i in range(3)] for j in range(3)], b=[1, 2, 1])), ["a", "b"]),
+        (pd.DataFrame(dict(a=[dict(c=i) for i in range(3)], b=[1, 2, 1])), ["a", "b"]),
+        (pd.DataFrame(dict(a=[[1], [2], [3]], b=[1, 2, 1])), ["a", "b"]),
         # the key sequence difference will make it unique
         (
             pd.DataFrame(dict(a=[dict(c=42, d=43, e=44), dict(d=43, e=44, c=42), dict(e=44, d=43, c=42)], b=[1, 2, 1])),

--- a/tests/unit/_experimental/dataset/test_common.py
+++ b/tests/unit/_experimental/dataset/test_common.py
@@ -61,11 +61,6 @@ def test__validate_id_fields__validation_error(
         (pd.DataFrame({"a.text": [1, 2, 3], "b.text": [1, 2, 1]}), ["a.text", "b.text"]),
         (pd.DataFrame(dict(a=[dict(c=i) for i in range(3)], b=[1, 2, 1])), ["a", "b"]),
         (pd.DataFrame(dict(a=[[1], [2], [3]], b=[1, 2, 1])), ["a", "b"]),
-        # the key sequence difference will make it unique
-        (
-            pd.DataFrame(dict(a=[dict(c=42, d=43, e=44), dict(d=43, e=44, c=42), dict(e=44, d=43, c=42)], b=[1, 2, 1])),
-            ["a", "b"],
-        ),
     ],
 )
 def test__validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
@@ -80,6 +75,21 @@ def test__validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None
         # dataframe values in id_fields is not unique
         (pd.DataFrame(dict(a=[1, 2, 1], b=[1, 2, 1])), ["a", "b"]),
         (pd.DataFrame(dict(a=[[1], [1], [1]], b=[1, 2, 1])), ["a", "b"]),
+        # the key sequence difference will not make it unique
+        (pd.DataFrame(dict(a=[{"a": 1, "b": 2}, {"a": 2, "b": 1}, {"b": 2, "a": 1}], b=[1, 2, 1])), ["a", "b"]),
+        (
+            pd.DataFrame(
+                dict(
+                    a=[
+                        dict(c=42, d=43, e=dict(f=44, g=45)),
+                        dict(d=43, e=dict(g=44, f=45), c=42),
+                        dict(e=dict(f=44, g=45), d=43, c=42),
+                    ],
+                    b=[1, 2, 1],
+                ),
+            ),
+            ["a"],
+        ),
     ],
 )
 def test__validate_dataframe_ids__error(df: pd.DataFrame, id_fields: List[str]) -> None:


### PR DESCRIPTION
### Linked issue(s):

https://linear.app/kolena/issue/KOL-4137/sdk-client-enforce-id-columns-to-only-be-scalar-of-string-and-integer

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
