### PR TITLE
Use existing id_fields if id_fields is not provided

### DIFF
--- a/kolena/_experimental/dataset/_dataset.py
+++ b/kolena/_experimental/dataset/_dataset.py
@@ -219,7 +219,7 @@ def resolve_id_fields(
         existing_id_fields = existing_dataset.id_fields
     if not id_fields:
         if existing_id_fields:
-            raise InputValidationError("id_fields is required for updating an existing dataset")
+            return existing_id_fields
         else:
             id_fields = _infer_id_fields(df)
     return id_fields

--- a/tests/unit/_experimental/dataset/test_dataset.py
+++ b/tests/unit/_experimental/dataset/test_dataset.py
@@ -436,13 +436,21 @@ def test__infer_id_fields() -> None:
 def test__resolve_id_fields() -> None:
     df = pd.DataFrame(dict(id=["a", "b", "c"], newid=["d", "e", "f"]))
     dataset = EntityData(id=1, name="foo", description="", id_fields=["id"])
+    inferrable_df = pd.DataFrame(dict(locator=["x", "y", "z"]))
+
     # new dataset without id_fields
     with pytest.raises(InputValidationError):
         resolve_id_fields(df, None, None)
 
-    # existing dataset without id_fields
-    with pytest.raises(InputValidationError):
-        resolve_id_fields(df, None, dataset)
+    # existing dataset without id_fields, different inferred id_fields, should use existing id_fields
+    assert resolve_id_fields(inferrable_df, None, dataset) == ["id"]
+
+    # existing dataset without id_fields, same inferred id_fields
+    assert resolve_id_fields(
+        inferrable_df,
+        None,
+        EntityData(id=1, name="foo", description="", id_fields=["locator"]),
+    ) == ["locator"]
 
     # new dataset with explicit id_fields should resolve to explicit id_fields
     assert resolve_id_fields(df, ["id"], None) == ["id"]
@@ -454,4 +462,4 @@ def test__resolve_id_fields() -> None:
     assert resolve_id_fields(df, ["newid"], dataset) == ["newid"]
 
     # new dataset with implicit datatype support, e.g. locator, without id_fields
-    assert resolve_id_fields(pd.DataFrame(dict(locator=["x", "y", "z"])), None, None) == ["locator"]
+    assert resolve_id_fields(inferrable_df, None, None) == ["locator"]


### PR DESCRIPTION
### Linked issue(s):

Fix id_fields resolution logic. `id_fields` is now only required when first creating a dataset and id_fields detection heuristic cannot find one.

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
