### PR TITLE
Added note to tell users that core concept are not for dataset, they should refer to the new doc

### DIFF
--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -6,6 +6,8 @@ hide:
 
 # :kolena-area-of-interest-20: Core Concepts
 
+!!! note "Note: If you are using Kolena dataset, this is not relevant, please follow the datasets core concept document."
+
 In this section, we'll get acquainted with the core concepts on Kolena, and learn in-depth about the various features
 offered. For a brief introduction, see the [Quickstart Guide](../quickstart.md) or the
 [Building a Workflow](../building-a-workflow.md) tutorial. For code-level API documentation, see the

--- a/docs/core-concepts/model.md
+++ b/docs/core-concepts/model.md
@@ -6,6 +6,8 @@ search:
 
 # :kolena-model-20: Model
 
+!!! note "Note: If you are using Kolena dataset, this is not relevant, please follow the datasets core concept document."
+
 In Kolena, a model is a deterministic transformation from [test samples](workflow.md#test-sample) to
 [inferences](workflow.md#inference).
 

--- a/docs/core-concepts/test-suite.md
+++ b/docs/core-concepts/test-suite.md
@@ -6,6 +6,8 @@ search:
 
 # :kolena-test-suite-20: Test Case & Test Suite
 
+!!! note "Note: If you are using Kolena dataset, this is not relevant, please follow the datasets core concept document."
+
 Test cases and test suites are used to organize test data in Kolena.
 
 A **test case** is a collection of [test samples](workflow.md#test-sample) and their associated

--- a/docs/core-concepts/workflow.md
+++ b/docs/core-concepts/workflow.md
@@ -6,6 +6,8 @@ search:
 
 # :kolena-workflow-20: Workflow
 
+!!! note "Note: If you are using Kolena dataset, this is not relevant, please follow the datasets core concept document."
+
 Testing in Kolena is broken down by the type of ML problem you're solving, called a **workflow**. Any ML problem that
 can be tested can be modeled as a workflow in Kolena.
 


### PR DESCRIPTION
### TODO: Attach the link once the dataset core document is ready
### What change does this PR introduce and why?
Added this note to all core concept doc pages to direct users to the new doc.
<img width="1343" alt="Screenshot 2024-01-02 at 1 27 32 PM" src="https://github.com/kolenaIO/kolena/assets/146848587/374aedce-c8d2-4bc8-9d91-74fa7130af87">


### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
