### PR TITLE
chore: add validate_dataframe_have_other_columns_besides_ids for results

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -230,7 +230,7 @@ jobs:
                     TESTFILES=$(circleci tests glob tests/integration/test_*.py |
                       circleci tests split --split-by=timings --timings-type=filename)
                   else
-                    TESTFILES=$(circleci tests glob tests/integration/$TEST_GROUP/**/test_*.py |
+                    TESTFILES=$(find tests/integration/$TEST_GROUP -name "test_*.py" |
                       circleci tests split --split-by=timings --timings-type=filename)
                   fi
                   poetry run pytest --cache-clear -vv --durations=10 --cov=kolena --cov-branch --ignore=examples \

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -230,7 +230,7 @@ jobs:
                     TESTFILES=$(circleci tests glob tests/integration/test_*.py |
                       circleci tests split --split-by=timings --timings-type=filename)
                   else
-                    TESTFILES=$(find tests/integration/$TEST_GROUP -name "test_*.py" |
+                    TESTFILES=$(circleci tests glob tests/integration/$TEST_GROUP/**/test_*.py |
                       circleci tests split --split-by=timings --timings-type=filename)
                   fi
                   poetry run pytest --cache-clear -vv --durations=10 --cov=kolena --cov-branch --ignore=examples \

--- a/kolena/dataset/common.py
+++ b/kolena/dataset/common.py
@@ -60,3 +60,8 @@ def validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
                 f"invalid id_fields: field '{id_field}' does not exist in dataframe",
             )
     _validate_dataframe_ids_uniqueness(df, id_fields)
+
+
+def validate_dataframe_have_other_columns_besides_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
+    if set(df.columns) == set(id_fields):
+        raise InputValidationError("dataframe only contains id fields")

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -192,7 +192,7 @@ def upload_results(
             for df_result in df_result_input:
                 if not id_column_validated:
                     validate_dataframe_ids(df_result, id_fields)
-                    validate_dataframe_have_other_columns_besides_ids(df_result_input, id_fields)
+                    validate_dataframe_have_other_columns_besides_ids(df_result, id_fields)
                     id_column_validated = True
                 df_results = _process_result(config, df_result, id_fields)
                 upload_data_frame(df=df_results, batch_size=BatchSize.UPLOAD_RECORDS.value, load_uuid=load_uuid)

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -40,6 +40,7 @@ from kolena.dataset.common import COL_DATAPOINT_ID_OBJECT
 from kolena.dataset.common import COL_EVAL_CONFIG
 from kolena.dataset.common import COL_RESULT
 from kolena.dataset.common import validate_batch_size
+from kolena.dataset.common import validate_dataframe_have_other_columns_besides_ids
 from kolena.dataset.common import validate_dataframe_ids
 from kolena.dataset.dataset import _to_deserialized_dataframe
 from kolena.dataset.dataset import _to_serialized_dataframe
@@ -172,6 +173,8 @@ def upload_results(
     if not existing_dataset:
         raise NotFoundError(f"dataset {dataset} does not exist")
 
+    id_fields = existing_dataset.id_fields
+
     if isinstance(results, pd.DataFrame) or isinstance(results, Iterator):
         results = [(None, results)]
     load_uuid = init_upload().uuid
@@ -180,16 +183,18 @@ def upload_results(
     for config, df_result_input in results:
         log.info(f"uploading test results with configuration {config}" if config else "uploading test results")
         if isinstance(df_result_input, pd.DataFrame):
-            validate_dataframe_ids(df_result_input, existing_dataset.id_fields)
-            df_results = _process_result(config, df_result_input, existing_dataset.id_fields)
+            validate_dataframe_ids(df_result_input, id_fields)
+            validate_dataframe_have_other_columns_besides_ids(df_result_input, id_fields)
+            df_results = _process_result(config, df_result_input, id_fields)
             upload_data_frame(df=df_results, batch_size=BatchSize.UPLOAD_RECORDS.value, load_uuid=load_uuid)
         else:
             id_column_validated = False
             for df_result in df_result_input:
                 if not id_column_validated:
-                    validate_dataframe_ids(df_result, existing_dataset.id_fields)
+                    validate_dataframe_ids(df_result, id_fields)
+                    validate_dataframe_have_other_columns_besides_ids(df_result_input, id_fields)
                     id_column_validated = True
-                df_results = _process_result(config, df_result, existing_dataset.id_fields)
+                df_results = _process_result(config, df_result, id_fields)
                 upload_data_frame(df=df_results, batch_size=BatchSize.UPLOAD_RECORDS.value, load_uuid=load_uuid)
 
     _upload_results(model, load_uuid, existing_dataset.id)

--- a/tests/unit/dataset/test_common.py
+++ b/tests/unit/dataset/test_common.py
@@ -16,6 +16,7 @@ from typing import List
 import pandas as pd
 import pytest
 
+from kolena.dataset.common import validate_dataframe_have_other_columns_besides_ids
 from kolena.dataset.common import validate_dataframe_ids
 from kolena.dataset.common import validate_id_fields
 from kolena.errors import InputValidationError
@@ -95,3 +96,26 @@ def test__validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None
 def test__validate_dataframe_ids__error(df: pd.DataFrame, id_fields: List[str]) -> None:
     with pytest.raises(InputValidationError):
         validate_dataframe_ids(df, id_fields)
+
+
+@pytest.mark.parametrize(
+    "df, id_fields",
+    [
+        (pd.DataFrame(dict(a=[1, 2, 3], b=[1, 2, 1])), ["a"]),
+        (pd.DataFrame({"a.text": [1, 2, 3], "b.text": [1, 2, 1]}), ["a.text"]),
+    ],
+)
+def test__validate_dataframe_have_other_columns_besides_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
+    validate_dataframe_have_other_columns_besides_ids(df, id_fields)
+
+
+@pytest.mark.parametrize(
+    "df, id_fields",
+    [
+        (pd.DataFrame(dict(a=[1, 2, 3], b=[1, 2, 1])), ["a", "b"]),
+        (pd.DataFrame({"a.text": [1, 2, 3], "b.text": [1, 2, 1]}), ["a.text", "b.text"]),
+    ],
+)
+def test__validate_dataframe_have_other_columns_besides_ids__error(df: pd.DataFrame, id_fields: List[str]) -> None:
+    with pytest.raises(InputValidationError):
+        validate_dataframe_have_other_columns_besides_ids(df, id_fields)


### PR DESCRIPTION
### Linked issue(s):

https://linear.app/kolena/issue/KOL-4334/kolena-sdk-should-validate-required-fields-for-datasetresults-upload

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
