### PR TITLE
Implement `__str__` in Annotation base class

### DIFF
--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -34,6 +34,7 @@ rendered on top of the image.
 """  # noqa: E501
 import dataclasses
 from abc import ABCMeta
+from abc import abstractmethod
 from functools import reduce
 from typing import Dict
 from typing import List
@@ -67,8 +68,17 @@ class _AnnotationType(DataType):
 class Annotation(TypedDataObject[_AnnotationType], metaclass=ABCMeta):
     """The base class for all annotation types."""
 
+    @abstractmethod
+    def _data_type() -> _AnnotationType:
+        ...
+
     def __init_subclass__(cls, **kwargs):
         _register_data_type(cls)
+
+    def __str__(self) -> str:
+        _dict = dataclasses.asdict(self)
+        _dict["data_type"] = f"{_AnnotationType._data_category()}/{self._data_type().value}"
+        return str(_dict)
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/annotation.py
+++ b/kolena/workflow/annotation.py
@@ -33,6 +33,7 @@ For example, when viewing images in the Studio, any annotations (such as lists o
 rendered on top of the image.
 """  # noqa: E501
 import dataclasses
+import json
 from abc import ABCMeta
 from abc import abstractmethod
 from functools import reduce
@@ -78,7 +79,7 @@ class Annotation(TypedDataObject[_AnnotationType], metaclass=ABCMeta):
     def __str__(self) -> str:
         _dict = dataclasses.asdict(self)
         _dict["data_type"] = f"{_AnnotationType._data_category()}/{self._data_type().value}"
-        return str(_dict)
+        return json.dumps(_dict)
 
 
 @dataclass(frozen=True, config=ValidatorConfig)


### PR DESCRIPTION
### Linked issue(s):
Towards KOL-4420

### What change does this PR introduce and why?
Provides an implementation of `__str__` for the Annotation base class which outputs valid JSON so the annotation can be parsed by the Kolena platform.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
