### PR TITLE
Update KeypointDetection test to use a random suite name

### DIFF
--- a/examples/workflow/keypoint_detection/tests/test_keypoint_detection.py
+++ b/examples/workflow/keypoint_detection/tests/test_keypoint_detection.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import string
+import random
 from argparse import Namespace
 from collections.abc import Iterator
 
@@ -27,13 +29,17 @@ def with_init() -> Iterator[None]:
     with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
         yield
 
+@pytest.fixture(scope="module")
+def suite_name() -> str:
+    TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))
+    return f"{TEST_PREFIX} - 300-W :: complete"
 
-def test__seed_test_suite() -> None:
-    args = Namespace(test_suite="300-W :: complete")
+def test__seed_test_suite(suite_name) -> None:
+    args = Namespace(test_suite=suite_name)
     seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__seed_test_suite"])
-def test__seed_test_run() -> None:
-    args = Namespace(model_name="Point Randomizer", test_suite="300-W :: complete")
+def test__seed_test_run(suite_name) -> None:
+    args = Namespace(model_name="Point Randomizer", test_suite=suite_name)
     seed_test_run_main(args)

--- a/examples/workflow/keypoint_detection/tests/test_keypoint_detection.py
+++ b/examples/workflow/keypoint_detection/tests/test_keypoint_detection.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import string
 import random
+import string
 from argparse import Namespace
 from collections.abc import Iterator
 
@@ -29,17 +29,19 @@ def with_init() -> Iterator[None]:
     with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
         yield
 
+
 @pytest.fixture(scope="module")
 def suite_name() -> str:
     TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))
     return f"{TEST_PREFIX} - 300-W :: complete"
 
-def test__seed_test_suite(suite_name) -> None:
+
+def test__seed_test_suite(suite_name: str) -> None:
     args = Namespace(test_suite=suite_name)
     seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__seed_test_suite"])
-def test__seed_test_run(suite_name) -> None:
+def test__seed_test_run(suite_name: str) -> None:
     args = Namespace(model_name="Point Randomizer", test_suite=suite_name)
     seed_test_run_main(args)


### PR DESCRIPTION
### Linked issue(s):
Towards KOL-4255

### What change does this PR introduce and why?
This commit updates the Keypoint Detection example test to use a randomized test suite name. Previously the test suite name was not randomized causing parallel test runs to share a test suite and produce false negatives.

Example flake: https://app.circleci.com/pipelines/github/kolenaIO/kolena/3055/workflows/8008a8ca-ca5f-4f36-9b75-255d55a35e07/jobs/64796

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added