### PR TITLE
Update Text Summarization test to use a random suite name

### DIFF
--- a/examples/workflow/text_summarization/tests/test_text_summarization.py
+++ b/examples/workflow/text_summarization/tests/test_text_summarization.py
@@ -11,19 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import random
+import string
 from argparse import Namespace
 
 import pytest
 from text_summarization.seed_test_run import main as seed_test_run_main
 from text_summarization.seed_test_suite import main as seed_test_suite_main
+from text_summarization.seed_test_suite import DATASET
 
 
-def test__seed_test_suite__smoke() -> None:
-    args = Namespace(dataset_csv="s3://kolena-public-datasets/CNN-DailyMail/metadata/metadata.tiny1.csv")
+@pytest.fixture(scope="module")
+def suite_prefix() -> str:
+    TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))
+    return f"{TEST_PREFIX} - {DATASET}"
+
+
+def test__seed_test_suite__smoke(suite_prefix: str) -> None:
+    args = Namespace(dataset_csv="s3://kolena-public-datasets/CNN-DailyMail/metadata/metadata.tiny1.csv", suite_prefix=suite_prefix)
     seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__seed_test_suite__smoke"])
-def test__seed_test_run__smoke() -> None:
-    args = Namespace(model="ada", test_suite="CNN-DailyMail :: text length", local_csv=None)
+def test__seed_test_run__smoke(suite_prefix: str) -> None:
+    args = Namespace(model="ada", test_suite=f"{suite_prefix} :: text length", local_csv=None)
     seed_test_run_main(args)

--- a/examples/workflow/text_summarization/tests/test_text_summarization.py
+++ b/examples/workflow/text_summarization/tests/test_text_summarization.py
@@ -17,8 +17,8 @@ from argparse import Namespace
 
 import pytest
 from text_summarization.seed_test_run import main as seed_test_run_main
-from text_summarization.seed_test_suite import main as seed_test_suite_main
 from text_summarization.seed_test_suite import DATASET
+from text_summarization.seed_test_suite import main as seed_test_suite_main
 
 
 @pytest.fixture(scope="module")
@@ -28,7 +28,10 @@ def suite_prefix() -> str:
 
 
 def test__seed_test_suite__smoke(suite_prefix: str) -> None:
-    args = Namespace(dataset_csv="s3://kolena-public-datasets/CNN-DailyMail/metadata/metadata.tiny1.csv", suite_prefix=suite_prefix)
+    args = Namespace(
+        dataset_csv="s3://kolena-public-datasets/CNN-DailyMail/metadata/metadata.tiny1.csv",
+        suite_prefix=suite_prefix,
+    )
     seed_test_suite_main(args)
 
 

--- a/examples/workflow/text_summarization/text_summarization/seed_test_suite.py
+++ b/examples/workflow/text_summarization/text_summarization/seed_test_suite.py
@@ -193,23 +193,30 @@ def seed_test_suites(
 def main(args: Namespace) -> None:
     kolena.initialize(verbose=True)
     complete_tc = seed_complete_test_case(args)
+    suite_prefix = args.suite_prefix
 
     test_suite_names: Dict[str, Callable[[str, TestCase], TestSuite]] = {
-        f"{DATASET} :: text length": seed_test_suite_by_text,
-        f"{DATASET} :: moderation score": seed_test_suite_by_moderation,
-        f"{DATASET} :: text X ground truth length": seed_test_suite_by_text_x_gt,
-        f"{DATASET} :: news category": seed_test_suite_by_category,
+        f"{suite_prefix} :: text length": seed_test_suite_by_text,
+        f"{suite_prefix} :: moderation score": seed_test_suite_by_moderation,
+        f"{suite_prefix} :: text X ground truth length": seed_test_suite_by_text_x_gt,
+        f"{suite_prefix} :: news category": seed_test_suite_by_category,
     }
     seed_test_suites(test_suite_names, complete_tc)
 
 
 if __name__ == "__main__":
     ap = ArgumentParser()
+
     ap.add_argument(
         "--dataset_csv",
         type=str,
         default="s3://kolena-public-datasets/CNN-DailyMail/metadata/CNN_DailyMail_metadata.csv",
         help="CSV file specifying dataset. See default CSV for details",
     )
-
+    ap.add_argument(
+        "--suite_prefix",
+        type=str,
+        default=DATASET,
+        help="Optionally specify a prefix for the created test suite names.",
+    )
     main(ap.parse_args())


### PR DESCRIPTION
### Linked issue(s):
Towards KOL-4255

### What change does this PR introduce and why?
This commit updates the Text Summarization example test to use a randomized test suite name. Previously the test suite name was not randomized causing parallel test runs to share a test suite and produce false negatives.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added