### PR TITLE
Update "Age Estimation" test to use a random suite name 

### DIFF
--- a/examples/workflow/age_estimation/age_estimation/seed_test_suite.py
+++ b/examples/workflow/age_estimation/age_estimation/seed_test_suite.py
@@ -65,7 +65,7 @@ def main(args: Namespace) -> int:
     ]
 
     test_suite = TestSuite(
-        f"age :: {DATASET} [age estimation]",
+        f"age :: {args.suite_name} [age estimation]",
         test_cases=[complete_test_case, *test_cases_by_age],
         reset=True,
     )
@@ -81,7 +81,7 @@ def main(args: Namespace) -> int:
         for gender in ["man", "woman"]
     ]
     test_suite = TestSuite(
-        f"gender :: {DATASET} [age estimation]",
+        f"gender :: {args.suite_name} [age estimation]",
         test_cases=[complete_test_case, *test_cases_by_gender],
         reset=True,
     )
@@ -98,7 +98,7 @@ def main(args: Namespace) -> int:
         for race in races
     ]
     test_suite = TestSuite(
-        f"race :: {DATASET} [age estimation]",
+        f"race :: {args.suite_name} [age estimation]",
         test_cases=[complete_test_case, *test_cases_by_race],
         reset=True,
     )
@@ -114,5 +114,11 @@ if __name__ == "__main__":
         nargs="?",
         default=f"s3://{BUCKET}/{DATASET}/meta/metadata.csv",
         help="CSV file specifying dataset. See default CSV for details",
+    )
+    ap.add_argument(
+        "suite_name",
+        type=str,
+        default=DATASET,
+        help="Optionally specify a name for the created test suites.",
     )
     sys.exit(main(ap.parse_args()))

--- a/examples/workflow/age_estimation/tests/test_age_estimation.py
+++ b/examples/workflow/age_estimation/tests/test_age_estimation.py
@@ -28,7 +28,10 @@ def suite_name() -> str:
 
 
 def test__seed_test_suite__smoke(suite_name: str) -> None:
-    args = Namespace(dataset_csv="s3://kolena-public-datasets/labeled-faces-in-the-wild/meta/metadata.tiny5.csv", suite_name=suite_name)
+    args = Namespace(
+        dataset_csv="s3://kolena-public-datasets/labeled-faces-in-the-wild/meta/metadata.tiny5.csv",
+        suite_name=suite_name,
+    )
     seed_test_suite_main(args)
 
 

--- a/examples/workflow/age_estimation/tests/test_age_estimation.py
+++ b/examples/workflow/age_estimation/tests/test_age_estimation.py
@@ -11,19 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import random
+import string
 from argparse import Namespace
 
 import pytest
 from age_estimation.seed_test_run import main as seed_test_run_main
+from age_estimation.seed_test_suite import DATASET
 from age_estimation.seed_test_suite import main as seed_test_suite_main
 
 
-def test__seed_test_suite__smoke() -> None:
-    args = Namespace(dataset_csv="s3://kolena-public-datasets/labeled-faces-in-the-wild/meta/metadata.tiny5.csv")
+@pytest.fixture(scope="module")
+def suite_name() -> str:
+    TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))
+    return f"{TEST_PREFIX} - {DATASET}"
+
+
+def test__seed_test_suite__smoke(suite_name: str) -> None:
+    args = Namespace(dataset_csv="s3://kolena-public-datasets/labeled-faces-in-the-wild/meta/metadata.tiny5.csv", suite_name=suite_name)
     seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__seed_test_suite__smoke"])
-def test__seed_test_run__smoke() -> None:
-    args = Namespace(model="ssrnet", test_suites=["age :: labeled-faces-in-the-wild [age estimation]"])
+def test__seed_test_run__smoke(suite_name: str) -> None:
+    args = Namespace(model="ssrnet", test_suites=[f"age :: {suite_name} [age estimation]"])
     seed_test_run_main(args)


### PR DESCRIPTION
### Linked issue(s):
Towards KOL-4255

### What change does this PR introduce and why?
This PR updates the Age Estimation example test to use a randomized test suite name. Previously the test suite name was not randomized causing parallel test runs to share a test suite and produce false negatives.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
