### PR TITLE
Update circleci integration step to ignore examples folder

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -242,8 +242,8 @@ jobs:
                     TESTFILES=$(find tests/integration/$TEST_GROUP -name "test_*.py" |
                       circleci tests split --split-by=timings --timings-type=filename)
                   fi
-                  poetry run pytest --cache-clear -vv --durations=10 --cov=kolena --cov-branch -o junit_family=legacy \
-                    --junitxml=test-results/result.xml $TESTFILES
+                  poetry run pytest --cache-clear -vv --durations=10 --cov=kolena --cov-branch --ignore=examples \
+                    -o junit_family=legacy --junitxml=test-results/result.xml $TESTFILES
       - when:
           condition:
             equal: [ "metrics", << parameters.extras >> ]


### PR DESCRIPTION
### What change does this PR introduce and why?
This commit updates the pytest invocation to ignore any test cases in the examples folder. Examples should not be run as part of this step. Prior to this commit there was a test flake when the above `TESTFILES` variable is empty due to running examples folder.
