### PR TITLE
Update "Classification" test to use a random suite name

### DIFF
--- a/examples/workflow/classification/scripts/binary/seed_test_suite.py
+++ b/examples/workflow/classification/scripts/binary/seed_test_suite.py
@@ -78,7 +78,7 @@ def main(args: Namespace) -> int:
         )
 
     test_suite = TestSuite(
-        f"image size :: {DATASET}",
+        f"image size :: {args.suite_name}",
         test_cases=[complete_test_case, *test_cases],
         reset=True,
     )
@@ -94,5 +94,11 @@ if __name__ == "__main__":
         type=str,
         default=f"s3://{BUCKET}/{DATASET}/meta/metadata.csv",
         help="CSV file with a list of image `locator` and its `label`. See default CSV for details",
+    )
+    ap.add_argument(
+        "--suite_name",
+        type=str,
+        default=DATASET,
+        help="Optionally specify a name for the created test suite.",
     )
     sys.exit(main(ap.parse_args()))

--- a/examples/workflow/classification/scripts/multiclass/seed_test_suite.py
+++ b/examples/workflow/classification/scripts/multiclass/seed_test_suite.py
@@ -91,7 +91,7 @@ def main(args: Namespace) -> int:
         )
 
     test_suite = TestSuite(
-        f"image properties :: {DATASET}",
+        f"image properties :: {args.suite_name}",
         test_cases=[complete_test_case, *test_cases],
         reset=True,
     )
@@ -107,5 +107,11 @@ if __name__ == "__main__":
         type=str,
         default=f"s3://{BUCKET}/{DATASET}/meta/metadata.csv",
         help="CSV file with a list of image `locator` and its `label`. See default CSV for details",
+    )
+    ap.add_argument(
+        "--suite_name",
+        type=str,
+        default=DATASET,
+        help="Optionally specify a name for the created test suite.",
     )
     sys.exit(main(ap.parse_args()))

--- a/examples/workflow/classification/tests/conftest.py
+++ b/examples/workflow/classification/tests/conftest.py
@@ -15,10 +15,8 @@ import random
 import string
 
 import pytest
-from scripts.binary.seed_test_suite import DATASET
 
 
-@pytest.fixture(scope="module")
-def suite_name() -> str:
-    TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))
-    return f"{TEST_PREFIX} - {DATASET}"
+@pytest.fixture(scope="package")
+def test_prefix() -> str:
+    return "".join(random.choices(string.ascii_uppercase + string.digits, k=12))

--- a/examples/workflow/classification/tests/conftest.py
+++ b/examples/workflow/classification/tests/conftest.py
@@ -1,8 +1,22 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import random
 import string
 
 import pytest
 from scripts.binary.seed_test_suite import DATASET
+
 
 @pytest.fixture(scope="module")
 def suite_name() -> str:

--- a/examples/workflow/classification/tests/conftest.py
+++ b/examples/workflow/classification/tests/conftest.py
@@ -1,0 +1,10 @@
+import random
+import string
+
+import pytest
+from scripts.binary.seed_test_suite import DATASET
+
+@pytest.fixture(scope="module")
+def suite_name() -> str:
+    TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))
+    return f"{TEST_PREFIX} - {DATASET}"

--- a/examples/workflow/classification/tests/test_binary_classification.py
+++ b/examples/workflow/classification/tests/test_binary_classification.py
@@ -18,12 +18,12 @@ from scripts.binary.seed_test_run import main as seed_test_run_main
 from scripts.binary.seed_test_suite import main as seed_test_suite_main
 
 
-def test__seed_test_suite__smoke() -> None:
-    args = Namespace(dataset_csv="s3://kolena-public-datasets/dogs-vs-cats/meta/metadata.tiny5.csv")
+def test__seed_test_suite__smoke(suite_name: str) -> None:
+    args = Namespace(dataset_csv="s3://kolena-public-datasets/dogs-vs-cats/meta/metadata.tiny5.csv", suite_name=suite_name)
     seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__seed_test_suite__smoke"])
-def test__seed_test_run__smoke() -> None:
-    args = Namespace(models=["inceptionv3"], test_suites=["image size :: dogs-vs-cats"], multiclass=False)
+def test__seed_test_run__smoke(suite_name: str) -> None:
+    args = Namespace(models=["inceptionv3"], test_suites=[f"image size :: {suite_name}"], multiclass=False)
     seed_test_run_main(args)

--- a/examples/workflow/classification/tests/test_binary_classification.py
+++ b/examples/workflow/classification/tests/test_binary_classification.py
@@ -19,7 +19,10 @@ from scripts.binary.seed_test_suite import main as seed_test_suite_main
 
 
 def test__seed_test_suite__smoke(suite_name: str) -> None:
-    args = Namespace(dataset_csv="s3://kolena-public-datasets/dogs-vs-cats/meta/metadata.tiny5.csv", suite_name=suite_name)
+    args = Namespace(
+        dataset_csv="s3://kolena-public-datasets/dogs-vs-cats/meta/metadata.tiny5.csv",
+        suite_name=suite_name,
+    )
     seed_test_suite_main(args)
 
 

--- a/examples/workflow/classification/tests/test_binary_classification.py
+++ b/examples/workflow/classification/tests/test_binary_classification.py
@@ -15,7 +15,13 @@ from argparse import Namespace
 
 import pytest
 from scripts.binary.seed_test_run import main as seed_test_run_main
+from scripts.binary.seed_test_suite import DATASET
 from scripts.binary.seed_test_suite import main as seed_test_suite_main
+
+
+@pytest.fixture(scope="module")
+def suite_name(test_prefix: str) -> str:
+    return f"{test_prefix} - {DATASET}"
 
 
 def test__seed_test_suite__smoke(suite_name: str) -> None:

--- a/examples/workflow/classification/tests/test_multiclass_classification.py
+++ b/examples/workflow/classification/tests/test_multiclass_classification.py
@@ -19,7 +19,10 @@ from scripts.multiclass.seed_test_suite import main as seed_test_suite_main
 
 
 def test__seed_test_suite__smoke(suite_name: str) -> None:
-    args = Namespace(dataset_csv="s3://kolena-public-datasets/cifar10/test/meta/metadata.tiny5.csv", suite_name=suite_name)
+    args = Namespace(
+        dataset_csv="s3://kolena-public-datasets/cifar10/test/meta/metadata.tiny5.csv",
+        suite_name=suite_name,
+    )
     seed_test_suite_main(args)
 
 

--- a/examples/workflow/classification/tests/test_multiclass_classification.py
+++ b/examples/workflow/classification/tests/test_multiclass_classification.py
@@ -15,7 +15,13 @@ from argparse import Namespace
 
 import pytest
 from scripts.multiclass.seed_test_run import main as seed_test_run_main
+from scripts.multiclass.seed_test_suite import DATASET
 from scripts.multiclass.seed_test_suite import main as seed_test_suite_main
+
+
+@pytest.fixture(scope="module")
+def suite_name(test_prefix: str) -> str:
+    return f"{test_prefix} - {DATASET}"
 
 
 def test__seed_test_suite__smoke(suite_name: str) -> None:

--- a/examples/workflow/classification/tests/test_multiclass_classification.py
+++ b/examples/workflow/classification/tests/test_multiclass_classification.py
@@ -18,12 +18,12 @@ from scripts.multiclass.seed_test_run import main as seed_test_run_main
 from scripts.multiclass.seed_test_suite import main as seed_test_suite_main
 
 
-def test__seed_test_suite__smoke() -> None:
-    args = Namespace(dataset_csv="s3://kolena-public-datasets/cifar10/test/meta/metadata.tiny5.csv")
+def test__seed_test_suite__smoke(suite_name: str) -> None:
+    args = Namespace(dataset_csv="s3://kolena-public-datasets/cifar10/test/meta/metadata.tiny5.csv", suite_name=suite_name)
     seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__seed_test_suite__smoke"])
-def test__seed_test_run__smoke() -> None:
-    args = Namespace(models=["inceptionv3"], test_suites=["image properties :: cifar10/test"])
+def test__seed_test_run__smoke(suite_name: str) -> None:
+    args = Namespace(models=["inceptionv3"], test_suites=[f"image properties :: {suite_name}"])
     seed_test_run_main(args)


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?
This PR updates the Classification example test to use a randomized test suite name. Previously the test suite name was not randomized causing parallel test runs to share a test suite and produce false negatives.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added