### PR TITLE
Update "Speech Recognition" test to use a random suite name

### DIFF
--- a/examples/workflow/automatic_speech_recognition/automatic_speech_recognition/seed_test_suite.py
+++ b/examples/workflow/automatic_speech_recognition/automatic_speech_recognition/seed_test_suite.py
@@ -175,9 +175,9 @@ def main(args: Namespace) -> None:
     complete_tc = seed_complete_test_case(args)
 
     test_suite_names: Dict[str, Callable[[str, TestCase], TestSuite]] = {
-        f"{DATASET} :: audio duration": seed_test_suite_duration,
-        f"{DATASET} :: speaker sex": seed_test_suite_speaker_sex,
-        f"{DATASET} :: tempo (words per second)": seed_test_suite_tempo,
+        f"{args.suite_name} :: audio duration": seed_test_suite_duration,
+        f"{args.suite_name} :: speaker sex": seed_test_suite_speaker_sex,
+        f"{args.suite_name} :: tempo (words per second)": seed_test_suite_tempo,
     }
 
     seed_test_suites(test_suite_names, complete_tc)
@@ -191,5 +191,10 @@ if __name__ == "__main__":
         default=f"s3://{BUCKET}/{DATASET}/metadata.csv",
         help="CSV file specifying dataset. See default CSV for details",
     )
-
+    ap.add_argument(
+        "--suite_name",
+        type=str,
+        default=DATASET,
+        help="Optionally specify a name for the created test suites.",
+    )
     main(ap.parse_args())

--- a/examples/workflow/automatic_speech_recognition/tests/test_automatic_speech_recognition.py
+++ b/examples/workflow/automatic_speech_recognition/tests/test_automatic_speech_recognition.py
@@ -23,6 +23,7 @@ from automatic_speech_recognition.seed_test_suite import main as seed_test_suite
 BUCKET = "kolena-public-datasets"
 DATASET = "LibriSpeech"
 
+
 @pytest.fixture(scope="module")
 def suite_name() -> str:
     TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))

--- a/examples/workflow/automatic_speech_recognition/tests/test_automatic_speech_recognition.py
+++ b/examples/workflow/automatic_speech_recognition/tests/test_automatic_speech_recognition.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import random
+import string
 from argparse import Namespace
 
 import pytest
@@ -21,18 +23,24 @@ from automatic_speech_recognition.seed_test_suite import main as seed_test_suite
 BUCKET = "kolena-public-datasets"
 DATASET = "LibriSpeech"
 
+@pytest.fixture(scope="module")
+def suite_name() -> str:
+    TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))
+    return f"{TEST_PREFIX} - {DATASET}"
 
-def test__seed_test_suite__smoke() -> None:
+
+def test__seed_test_suite__smoke(suite_name: str) -> None:
     args = Namespace(
         dataset_csv=f"s3://{BUCKET}/{DATASET}/metadata_test.csv",
+        suite_name=suite_name,
     )
     seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__seed_test_suite__smoke"])
-def test__seed_test_run__smoke() -> None:
+def test__seed_test_run__smoke(suite_name: str) -> None:
     args = Namespace(
         model="wav2vec2-base-960h",
-        test_suite=f"{DATASET} :: audio duration",
+        test_suite=f"{suite_name} :: audio duration",
     )
     seed_test_run_main(args)


### PR DESCRIPTION
### Linked issue(s):
Towards KOL-4255

### What change does this PR introduce and why?
This PR updates the Speech Recognition example test to use a randomized test suite name. Previously the test suite name was not randomized causing parallel test runs to share a test suite and produce false negatives.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
