### PR TITLE
Update keypoint detection example

### DIFF
--- a/examples/dataset/keypoint_detection/keypoint_detection/upload_dataset.py
+++ b/examples/dataset/keypoint_detection/keypoint_detection/upload_dataset.py
@@ -24,10 +24,12 @@ BUCKET = "kolena-public-examples"
 
 
 def main() -> None:
-    df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/meta/metadata.csv", index_col=0, storage_options={"anon": True})
+    df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/raw/{DATASET}.csv", index_col=0, storage_options={"anon": True})
     df["face"] = df["points"].apply(lambda points: Keypoints(points=json.loads(points)))
+    df["condition"] = df["locator"].apply(lambda locator: "indoor" if "indoor" in locator else "outdoor")
+
     kolena.initialize(verbose=True)
-    register_dataset(DATASET, df[["locator", "face", "normalization_factor"]])
+    register_dataset(DATASET, df[["locator", "face", "normalization_factor", "condition"]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Linked issue(s):
https://linear.app/kolena/issue/KOL-4481/points-array-not-parsed-when-uploading-300-w-dataset-through-ui

### What change does this PR introduce and why?
Updated data upload logic after folder structure change in `s3://kolena-public-examples/300-W/`

Tested by running the following locally on this dataset
```
poetry run python3 upload_dataset.py
poetry run python3 upload_results.py random
```

<img width="1083" alt="image" src="https://github.com/kolenaIO/kolena/assets/145366880/37ef0070-63dc-4f87-802c-e7ffc48586fc">


Additionally, verified UI uploads with processed files to [this dataset](https://trunk.kolena.io/nan/dataset?datasetId=247):
- Created dataset with `s3://kolena-public-examples/300-W/300-W.csv`
- Uploaded result with  `s3://kolena-public-examples/300-W/results/random.csv`

<img width="1083" alt="image" src="https://github.com/kolenaIO/kolena/assets/145366880/4243300c-b39a-4ed5-956d-627efacd667e">



### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
