### PR TITLE
Update "Face Recognition" test to use a random suite name

### DIFF
--- a/examples/workflow/face_recognition_11/face_recognition_11/seed_test_suite.py
+++ b/examples/workflow/face_recognition_11/face_recognition_11/seed_test_suite.py
@@ -124,7 +124,7 @@ def main(args: Namespace) -> int:
                 ),
             )
         TestSuite(
-            name=f"{DATASET} :: {category} [FR]",
+            name=f"{args.suite_name} :: {category} [FR]",
             test_cases=[complete_test_case, *test_cases],
             reset=True,
         )
@@ -149,5 +149,11 @@ if __name__ == "__main__":
         type=str,
         default=f"s3://{BUCKET}/{DATASET}/meta/metadata.csv",
         help="CSV file containing the metadata of each image. See default CSV for details.",
+    )
+    ap.add_argument(
+        "--suite_name",
+        type=str,
+        default=DATASET,
+        help="Optionally specify a name for the created test suite.",
     )
     sys.exit(main(ap.parse_args()))

--- a/examples/workflow/face_recognition_11/tests/test_face_recognition_11.py
+++ b/examples/workflow/face_recognition_11/tests/test_face_recognition_11.py
@@ -22,9 +22,6 @@ from face_recognition_11.seed_test_run import main as seed_test_run_main
 from face_recognition_11.seed_test_suite import main as seed_test_suite_main
 
 
-BUCKET = "kolena-public-datasets"
-DATASET = "labeled-faces-in-the-wild"
-
 @pytest.fixture(scope="module")
 def suite_name() -> str:
     TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))

--- a/examples/workflow/face_recognition_11/tests/test_face_recognition_11.py
+++ b/examples/workflow/face_recognition_11/tests/test_face_recognition_11.py
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import random
+import string
 from argparse import Namespace
 
 import pytest
+from face_recognition_11.seed_test_run import BUCKET
+from face_recognition_11.seed_test_run import DATASET
 from face_recognition_11.seed_test_run import main as seed_test_run_main
 from face_recognition_11.seed_test_suite import main as seed_test_suite_main
 
@@ -21,21 +25,27 @@ from face_recognition_11.seed_test_suite import main as seed_test_suite_main
 BUCKET = "kolena-public-datasets"
 DATASET = "labeled-faces-in-the-wild"
 
+@pytest.fixture(scope="module")
+def suite_name() -> str:
+    TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))
+    return f"{TEST_PREFIX} - {DATASET}"
 
-def test__seed_test_suite__smoke() -> None:
+
+def test__seed_test_suite__smoke(suite_name: str) -> None:
     args = Namespace(
         dataset_csv=f"s3://{BUCKET}/{DATASET}/meta/pairs.sample.csv",
         bbox_keypoints_csv=f"s3://{BUCKET}/{DATASET}/meta/bbox_keypoints.csv",
         metadata_csv=f"s3://{BUCKET}/{DATASET}/meta/metadata.csv",
+        suite_name=suite_name,
     )
     seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__seed_test_suite__smoke"])
-def test__seed_test_run__smoke() -> None:
+def test__seed_test_run__smoke(suite_name: str) -> None:
     args = Namespace(
         models=["sample"],
         detectors=["sample"],
-        test_suites=[f"{DATASET} :: gender [FR]"],
+        test_suites=[f"{suite_name} :: gender [FR]"],
     )
     seed_test_run_main(args)


### PR DESCRIPTION
### Linked issue(s):
Towards KOL-4255

### What change does this PR introduce and why?
This PR updates the Face Recognition example test to use a randomized test suite name. Previously the test suite name was not randomized causing parallel test runs to share a test suite and produce false negatives.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added