### PR TITLE
Update "Question Answering" test to use a random suite name

### DIFF
--- a/examples/workflow/question_answering/question_answering/seed_test_suite.py
+++ b/examples/workflow/question_answering/question_answering/seed_test_suite.py
@@ -37,7 +37,11 @@ def clean_name(name: str) -> str:
     return name[9:] if name.startswith("metadata_") else name
 
 
-def create_test_suite_by_question(dataset: TestCase, data: List[Tuple[TestSample, GroundTruth]]) -> None:
+def create_test_suite_by_question(
+    suite_name: str,
+    dataset: TestCase,
+    data: List[Tuple[TestSample, GroundTruth]],
+) -> None:
     question_types = ["what", "who", "how", "did", "where", "was", "when", "is", "why", "other"]
     samples_by_question_type = {value: [] for value in question_types}
 
@@ -56,14 +60,18 @@ def create_test_suite_by_question(dataset: TestCase, data: List[Tuple[TestSample
     )
 
     test_suite = TestSuite(
-        f"question types :: {DATASET}",
+        f"question types :: {suite_name}",
         test_cases=[dataset, *test_cases],
         reset=True,
     )
     print(f"created test suite: {test_suite.name} v{test_suite.version}")
 
 
-def create_test_suite_by_conversation_length(dataset: TestCase, data: List[Tuple[TestSample, GroundTruth]]) -> None:
+def create_test_suite_by_conversation_length(
+    suite_name: str,
+    dataset: TestCase,
+    data: List[Tuple[TestSample, GroundTruth]],
+) -> None:
     depths = sorted({test_sample.turn for test_sample, _ in data})
     samples_by_turn = {value: [] for value in depths}
 
@@ -82,7 +90,7 @@ def create_test_suite_by_conversation_length(dataset: TestCase, data: List[Tuple
     )
 
     test_suite = TestSuite(
-        f"conversation depths :: {DATASET}",
+        f"conversation depths :: {suite_name}",
         test_cases=[dataset, *test_cases],
         reset=True,
     )
@@ -145,8 +153,9 @@ def main(args: Namespace) -> int:
         reset=True,
     )
 
-    create_test_suite_by_question(complete_test_case, test_samples_and_ground_truths)
-    create_test_suite_by_conversation_length(complete_test_case, test_samples_and_ground_truths)
+    suite_name = args.suite_name
+    create_test_suite_by_question(suite_name, complete_test_case, test_samples_and_ground_truths)
+    create_test_suite_by_conversation_length(suite_name, complete_test_case, test_samples_and_ground_truths)
 
     return 0
 
@@ -158,5 +167,11 @@ if __name__ == "__main__":
         type=str,
         default=f"s3://{BUCKET}/{DATASET}/metadata/metadata.csv",
         help="CSV file with a stories, questions, and answers.",
+    )
+    ap.add_argument(
+        "suite_name",
+        type=str,
+        default=DATASET,
+        help="Optionally specify a name for the created test suites.",
     )
     sys.exit(main(ap.parse_args()))

--- a/examples/workflow/question_answering/tests/test_question_answering.py
+++ b/examples/workflow/question_answering/tests/test_question_answering.py
@@ -11,19 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import random
+import string
 from argparse import Namespace
 
 import pytest
 from question_answering.seed_test_run import main as seed_test_run_main
+from question_answering.seed_test_suite import DATASET
 from question_answering.seed_test_suite import main as seed_test_suite_main
 
 
-def test__qa_seed_test_suite__smoke() -> None:
-    args = Namespace(dataset_csv="s3://kolena-public-datasets/CoQA/metadata/metadata_head.csv")
+@pytest.fixture(scope="module")
+def suite_name() -> str:
+    TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))
+    return f"{TEST_PREFIX} - {DATASET}"
+
+
+def test__qa_seed_test_suite__smoke(suite_name) -> None:
+    args = Namespace(dataset_csv="s3://kolena-public-datasets/CoQA/metadata/metadata_head.csv", suite_name=suite_name)
     seed_test_suite_main(args)
 
 
 @pytest.mark.depends(on=["test__qa_seed_test_suite__smoke"])
-def test__qa_seed_test_run__smoke() -> None:
-    args = Namespace(model="gpt-3.5-turbo_head", test_suite="question types :: CoQA")
+def test__qa_seed_test_run__smoke(suite_name) -> None:
+    args = Namespace(model="gpt-3.5-turbo_head", test_suite="question types :: CoQA", suite_name=suite_name)
     seed_test_run_main(args)


### PR DESCRIPTION
### Linked issue(s):
Towards KOL-4255

### What change does this PR introduce and why?
This PR updates the Question Answering example test to use a randomized test suite name. Previously the test suite name was not randomized causing parallel test runs to share a test suite and produce false negatives.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added