### PR TITLE
Update CI token count to eight

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -30,7 +30,7 @@ parameters:
     default: false
   token_count:
     type: integer
-    default: 4
+    default: 8
 
 executors:
   python:


### PR DESCRIPTION
### What change does this PR introduce and why?
Updates the number of tokens CI round robins between from four to eight.

