### PR TITLE
Liuyuan/kol 4391 speaker diarization for dataset

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -409,7 +409,7 @@ workflows:
       - example-test-dataset:
           matrix:
             parameters:
-              subproject: [ rain_forecast ]
+              subproject: [ rain_forecast, speaker_diarization ]
               resource-class: [ small ]
               python-version: [ "3.9.18" ]
       - example-test-workflow:

--- a/examples/dataset/README.md
+++ b/examples/dataset/README.md
@@ -14,3 +14,4 @@ This directory contains example Kolena Datasets integrations for different machi
   [CNN-DailyMail](https://paperswithcode.com/dataset/cnn-daily-mail-1) dataset for text summarization workflow
 - [Rain Forecast](./rain_forecast): rain forecast models tested using the
   [Rain in Australia](https://www.kaggle.com/datasets/jsphyg/weather-dataset-rattle-package)
+- [Speaker Diarization](./speaker_diarization/): speaker diarization using the [ICSI-Corpus](https://groups.inf.ed.ac.uk/ami/icsi/) dataset

--- a/examples/dataset/speaker_diarization/README.md
+++ b/examples/dataset/speaker_diarization/README.md
@@ -1,0 +1,67 @@
+# Example Integration: Speaker Diarization
+
+This example integration uses the Google Cloud Speech-To-Text model,
+and [ICSI-Corpus dataset](https://groups.inf.ed.ac.uk/ami/icsi/) to demonstrate how to test speaker diarization problems
+on Kolena.
+
+## Setup
+
+This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
+
+```shell
+poetry update && poetry install
+```
+
+## Usage
+
+The data for this example integration lives in the publicly accessible S3 bucket `s3://kolena-public-examples`.
+
+First, ensure that the `KOLENA_TOKEN` environment variable is populated in your environment. See our
+[initialization documentation](https://docs.kolena.io/installing-kolena/#initialization) for details.
+
+### Speaker Diarization on ICSI-Corpus
+
+This project defines two scripts that perform the following operations:
+
+1. [`upload_dataset.py`](speaker_diarization/upload_dataset.py) creates a dataset named
+   `ICSI-Corpus` by default.
+
+   Run this command to create the default dataset:
+    ```shell
+    poetry run python3 speaker_diarization/upload_dataset.py
+    ```
+
+2. [`upload_results.py`](speaker_diarization/upload_results.py) uploads the results of model
+   `gcp-stt-video` for the above dataset.
+
+   Run this command to upload results of model `gcp-stt-video` for the above dataset:
+    ```shell
+    poetry run python3 speaker_diarization/upload_results.py
+    ```
+
+Command line arguments are defined within each script to specify the dataset name to create or
+upload results for. Run a script using the `--help` flag for more information:
+
+```shell
+$ poetry run python3 speaker_diarization/upload_dataset.py --help
+usage: upload_dataset.py [-h] [--dataset-name DATASET_NAME] [--sample-count SAMPLE_COUNT]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --dataset-name DATASET_NAME
+                        Name of the dataset
+  --sample-count SAMPLE_COUNT
+                        Number of samples to use, all samples are used if 0
+
+$ poetry run python3 speaker_diarization/upload_results.py --help
+usage: upload_results.py [-h] [--dataset-name DATASET_NAME] [--align-speakers] [--sample-count SAMPLE_COUNT]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --dataset-name DATASET_NAME
+                        Name of the dataset.
+  --align-speakers      Specify whether to perform speaker alignment between the ground_truth and inference in the preprocessing step.
+  --sample-count SAMPLE_COUNT
+                        Number of samples to use, all samples are used if 0.
+```

--- a/examples/dataset/speaker_diarization/pyproject.toml
+++ b/examples/dataset/speaker_diarization/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.poetry]
+name = "speaker-diarization"
+version = "0.1.0"
+description = "Example Kolena integration for speaker diarization"
+authors = ["Kolena Engineering <eng@kolena.io>"]
+license = "Apache-2.0"
+
+[tool.poetry.dependencies]
+python = ">=3.9,<3.12"
+kolena = { path = "../../..", develop = true }
+pyannote-metrics = "^3.2.1"
+s3fs = "^2023.10.0"
+pyannote-core = "^5.0.0"
+scipy = "^1.11.3"
+jiwer = "^3.0.3"
+
+[tool.poetry.group.dev.dependencies]
+pre-commit = "^2.17"
+pytest = "^7"
+pytest-depends = "^1.0.1"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/examples/dataset/speaker_diarization/speaker_diarization/__init__.py
+++ b/examples/dataset/speaker_diarization/speaker_diarization/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/dataset/speaker_diarization/speaker_diarization/data_loader.py
+++ b/examples/dataset/speaker_diarization/speaker_diarization/data_loader.py
@@ -28,7 +28,13 @@ S3_STORAGE_OPTIONS = {"anon": True}
 
 def _annotate(df: pd.DataFrame) -> list[LabeledTimeSegment]:
     return [
-        LabeledTimeSegment(start=r.starttime, end=r.endtime, label=r.label, group=r.speaker) for r in df.itertuples()
+        LabeledTimeSegment(
+            start=r.starttime,
+            end=r.endtime,
+            label=r.label,
+            group=r.speaker,  # type: ignore[call-arg]
+        )
+        for r in df.itertuples()
     ]
 
 

--- a/examples/dataset/speaker_diarization/speaker_diarization/data_loader.py
+++ b/examples/dataset/speaker_diarization/speaker_diarization/data_loader.py
@@ -1,0 +1,53 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pandas as pd
+
+from kolena.annotation import LabeledTimeSegment
+
+BUCKET = "kolena-public-examples"
+DATASET = "ICSI-corpus"
+DIR = f"s3://{BUCKET}/{DATASET}"
+DATA_CSV = f"{DIR}/raw/metadata.csv"
+TRANSCRIPTS_CSV = f"{DIR}/raw/transcripts.csv"
+DATA_DIR = f"{DIR}/data"
+RESULTS_RAW_DIR = f"{DIR}/results/raw"
+
+S3_STORAGE_OPTIONS = {"anon": True}
+
+
+def _annotate(df: pd.DataFrame) -> list[LabeledTimeSegment]:
+    return [
+        LabeledTimeSegment(start=r.starttime, end=r.endtime, label=r.label, group=r.speaker) for r in df.itertuples()
+    ]
+
+
+def load_data() -> pd.DataFrame:
+    df = pd.read_csv(DATA_CSV, storage_options=S3_STORAGE_OPTIONS)
+    df = df.where(pd.notnull(df), None)  # read missing cells as None
+    df["locator"] = df["audio_path"].apply(lambda x: f"{DATA_DIR}/{x}")
+
+    transcript_df = pd.read_csv(TRANSCRIPTS_CSV, storage_options=S3_STORAGE_OPTIONS)
+
+    anno_df = transcript_df.groupby("transcription_path").apply(_annotate).reset_index()
+    anno_df.rename(columns={0: "transcripts"}, inplace=True)
+
+    return df.merge(anno_df, on="transcription_path")
+
+
+def load_results(model: str) -> pd.DataFrame:
+    transcript_df = pd.read_csv(f"{RESULTS_RAW_DIR}/{model}.csv", storage_options=S3_STORAGE_OPTIONS)
+    results_df = transcript_df.groupby("transcription_path").apply(_annotate).reset_index()
+    results_df.rename(columns={0: "transcripts"}, inplace=True)
+
+    return results_df

--- a/examples/dataset/speaker_diarization/speaker_diarization/upload_dataset.py
+++ b/examples/dataset/speaker_diarization/speaker_diarization/upload_dataset.py
@@ -1,0 +1,44 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+from argparse import Namespace
+
+from speaker_diarization.data_loader import DATASET
+from speaker_diarization.data_loader import load_data
+
+import kolena
+from kolena.dataset import register_dataset
+
+
+def main(args: Namespace) -> None:
+    kolena.initialize(verbose=True)
+    df = load_data()
+    sample_count = args.sample_count
+    if sample_count:
+        df = df[:sample_count]
+
+    register_dataset(args.dataset_name, df)
+
+
+if __name__ == "__main__":
+    ap = ArgumentParser()
+    ap.add_argument("--dataset-name", type=str, default=DATASET, help="Name of the dataset")
+    ap.add_argument(
+        "--sample-count",
+        type=int,
+        default=0,
+        help="Number of samples to use, all samples are used if 0",
+    )
+
+    main(ap.parse_args())

--- a/examples/dataset/speaker_diarization/speaker_diarization/upload_results.py
+++ b/examples/dataset/speaker_diarization/speaker_diarization/upload_results.py
@@ -1,0 +1,70 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+from argparse import Namespace
+
+import pandas as pd
+from speaker_diarization.data_loader import DATASET
+from speaker_diarization.data_loader import load_data
+from speaker_diarization.data_loader import load_results
+from speaker_diarization.utils import compute_metrics
+from speaker_diarization.utils import realign_labels
+
+import kolena
+from kolena.dataset import test
+
+
+def align_df_speakers(ref: pd.Series, inf: pd.Series) -> pd.Series:
+    return pd.Series([realign_labels(r, i) for r, i in zip(ref.tolist(), inf.tolist())])
+
+
+def main(args: Namespace) -> None:
+    kolena.initialize(verbose=True)
+
+    model = "gcp-stt-video"
+    align_speakers = args.align_speakers
+    sample_count = args.sample_count
+
+    datapoint_df = load_data()
+    transcripts_df = load_results(model)
+    if sample_count:
+        datapoint_df = datapoint_df[:sample_count]
+        transcripts_df = transcripts_df[:sample_count]
+
+    if align_speakers:
+        transcripts_df["transcripts"] = align_df_speakers(datapoint_df["transcripts"], transcripts_df["transcripts"])
+
+    metrics_df = compute_metrics(datapoint_df, transcripts_df)
+    merged_df = pd.concat([transcripts_df, metrics_df], axis=1)
+    results_df = datapoint_df[["locator", "transcription_path"]].merge(merged_df, on="transcription_path")
+    eval_config = {"align-speakers": align_speakers}
+    test(args.dataset_name, model, [(eval_config, results_df)])
+
+
+if __name__ == "__main__":
+    ap = ArgumentParser()
+    ap.add_argument("--dataset-name", type=str, default=DATASET, help="Name of the dataset.")
+    ap.add_argument(
+        "--align-speakers",
+        action="store_true",
+        help="Specify whether to perform speaker alignment between the ground_truth and inference in the "
+        "preprocessing step.",
+    )
+    ap.add_argument(
+        "--sample-count",
+        type=int,
+        default=0,
+        help="Number of samples to use, all samples are used if 0.",
+    )
+    main(ap.parse_args())

--- a/examples/dataset/speaker_diarization/speaker_diarization/upload_results.py
+++ b/examples/dataset/speaker_diarization/speaker_diarization/upload_results.py
@@ -22,7 +22,7 @@ from speaker_diarization.utils import compute_metrics
 from speaker_diarization.utils import realign_labels
 
 import kolena
-from kolena.dataset import test
+from kolena.dataset import upload_results
 
 
 def align_df_speakers(ref: pd.Series, inf: pd.Series) -> pd.Series:
@@ -49,7 +49,7 @@ def main(args: Namespace) -> None:
     merged_df = pd.concat([transcripts_df, metrics_df], axis=1)
     results_df = datapoint_df[["locator", "transcription_path"]].merge(merged_df, on="transcription_path")
     eval_config = {"align-speakers": align_speakers}
-    test(args.dataset_name, model, [(eval_config, results_df)])
+    upload_results(args.dataset_name, model, [(eval_config, results_df)])
 
 
 if __name__ == "__main__":

--- a/examples/dataset/speaker_diarization/tests/test_speaker_diarization.py
+++ b/examples/dataset/speaker_diarization/tests/test_speaker_diarization.py
@@ -1,0 +1,45 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import random
+import string
+from argparse import Namespace
+
+import pytest
+from speaker_diarization.upload_dataset import main as upload_dataset_main
+from speaker_diarization.upload_results import main as upload_results_main
+
+DATASET = "ICSI-corpus"
+
+
+@pytest.fixture(scope="module")
+def dataset_name() -> str:
+    TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))
+    return f"{TEST_PREFIX} - {DATASET}"
+
+
+def test__upload_dataset__smoke(dataset_name: str) -> None:
+    args = Namespace(dataset_name=dataset_name, sample_count=50)
+    upload_dataset_main(args)
+
+
+@pytest.mark.depends(on=["test__upload_dataset__smoke"])
+def test__upload_results__smoke(dataset_name: str) -> None:
+    args = Namespace(dataset_name=dataset_name, sample_count=50, align_speakers=False)
+    upload_results_main(args)
+
+
+@pytest.mark.depends(on=["test__upload_dataset__smoke"])
+def test__upload_results_speaker_aligned__smoke(dataset_name: str) -> None:
+    args = Namespace(dataset_name=dataset_name, sample_count=50, align_speakers=True)
+    upload_results_main(args)


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?

Seeding with SDK (in README.md)

```
$ poetry run python3 speaker_diarization/upload_dataset.py --dataset-name ICSI-corpus-sdk
$ poetry run python3 speaker_diarization/upload_results.py --dataset-name ICSI-corpus-sdk
```

Web UI import: use cloud storage
- data: s3://kolena-public-examples/ICSI-corpus/ICSI-corpus.csv
- model "gcp-stt-video" results
  - not speaker-aligned: s3://kolena-public-examples/ICSI-corpus/results/gcp-stt-video.csv
  - speaker-aligned: s3://kolena-public-examples/ICSI-corpus/results/gcp-stt-video-speaker-aligned.csv

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
