### PR TITLE
Add docs for previously empty pages

### DIFF
--- a/docs/dataset/core-concepts/index.md
+++ b/docs/dataset/core-concepts/index.md
@@ -6,14 +6,27 @@ hide:
 
 # :kolena-area-of-interest-20: Core Concepts
 
-In this section, we explore Kolena's core concepts, focusing on the key features that facilitate model evaluation and testing. For a quick overview, refer to the [Quickstart Guide](../quickstart.md).
+In this section, we explore Kolena's core concepts, focusing on the key features that facilitate model evaluation and
+testing. For a quick overview, refer to the [Quickstart Guide](../quickstart.md).
 
 
 <div class="grid cards" markdown>
-- [:kolena-model-16: Dataset](dataset.md)
+- [:kolena-dataset-16: Dataset](dataset.md)
 
     ---
 
-    A **Dataset** represents a structured assembly of datapoints, essential for model evaluation. Each datapoint within a dataset combines various data types, such as images or text, traditionally segmented into test samples and metadata. This structure is immutable, ensuring data integrity and simplifying version management. Datasets provide a cohesive framework for organizing and processing model testing data, enhancing efficiency and clarity in user interaction.
+    A **Dataset** represents a structured assembly of datapoints, essential for model evaluation. Each datapoint
+    within a dataset combines various data types, such as images or text, traditionally segmented into test samples and
+    metadata.
+
+</div>
+
+<div class="grid cards" markdown>
+- [:kolena-quality-standard-16: Quality Standard](quality-standard.md)
+
+    ---
+
+    A **Quality Standard** tracks a standardized process for how a team evaluates a model's performance on a dataset.
+    Users may configure quality standards in Kolena Datasets by defining **Test Cases** and **Metrics**.
 
 </div>

--- a/docs/dataset/core-concepts/index.md
+++ b/docs/dataset/core-concepts/index.md
@@ -15,7 +15,7 @@ testing. For a quick overview, refer to the [Quickstart Guide](../quickstart.md)
 
     ---
 
-    A **Dataset** represents a structured assembly of datapoints, essential for model evaluation. Each datapoint
+    A Dataset represents a structured assembly of datapoints, essential for model evaluation. Each datapoint
     within a dataset combines various data types, such as images or text, traditionally segmented into test samples and
     metadata.
 
@@ -26,7 +26,7 @@ testing. For a quick overview, refer to the [Quickstart Guide](../quickstart.md)
 
     ---
 
-    A **Quality Standard** tracks a standardized process for how a team evaluates a model's performance on a dataset.
-    Users may configure quality standards in Kolena Datasets by defining **Test Cases** and **Metrics**.
+    A Quality Standard tracks a standardized process for how a team evaluates a model's performance on a dataset.
+    Users may configure quality standards in Kolena Datasets by defining Test Cases and Metrics.
 
 </div>

--- a/docs/dataset/core-concepts/quality-standard.md
+++ b/docs/dataset/core-concepts/quality-standard.md
@@ -5,3 +5,55 @@ search:
 ---
 
 # :kolena-quality-standard-20: Quality Standard
+
+A **Quality Standard** tracks a standardized process for how a team evaluates a model's performance on a dataset.
+Users may define and manage quality standards for a dataset in the Kolena web application from a that dataset's
+`Quality Standards` tab. Once defined, a quality standard provides a well-defined framework for easily understanding and
+comparing future model results.
+
+A Quality Standard is composed of [Test Cases](#test-cases) and [Metrics](#metrics).
+
+## Test Cases
+
+Test cases allow users to evaluate their datasets at various levels of division, providing visibility into how models
+perform at differing subsets of the full dataset, and mitigating failures caused by
+[hidden stratifications](https://www.kolena.com/blog/best-practices-for-ml-model-testing).
+
+Kolena supports easy test case creation through dividing a dataset along categorical or numeric datapoint properties.
+For example, if you have a dataset with images of faces of individuals, you may wish to create a set of test cases that
+divides your dataset by `datapoint.race` (categorical) or `datapoint.age` (numeric).
+
+The datasets quickstart provides a more hands-on example of
+[defining test cases](../quickstart.md/#define-test-cases).
+
+## Metrics
+
+Metrics describe the criteria used to evaluate the performance of a model and compare it with other models over a given
+dataset and its test cases.
+
+Kolena supports defining metrics by applying standard aggregations over datapoint level results or by leveraging
+common machine learning aggregations, such as [Precision](../../../metrics/precision) or
+[F1 Score](../../../metrics/f1-score). Once defined, users may also specify highlighting for metrics, indicating if
+`Higher is better`, or if `Lower is better`.
+
+The datasets quickstart provides a more hands-on example of
+[defining metrics](../quickstart.md/#define-metrics).
+
+## Model Comparison
+
+Once you've defined your test cases and metrics, you can view and compare model results in the `Quality Standards` tab,
+which provides a quick and standardized high level overview of which models perform best over your different test cases.
+
+For step-by-step instructions, take a look at the quickstart for
+[model comparison](../quickstart.md/#step-5-compare-models).
+
+## Debugging
+
+The `Debugger` tab of a dataset allows users to experiment with test cases and metrics without saving them off to the
+team level quality standards. This allows users to search for meaningful test cases and experiment with different
+metrics with the confidence that they can safely save these updated values to their quality standards when comfortable,
+without the risk of accidentally replacing what the team has previously defined. This also provides a view for
+visualizing results and relations in plots.
+
+For step-by-step instructions, take a look at the quickstart for
+[results exploration](../quickstart.md/#step-3-explore-data-and-results).

--- a/docs/dataset/index.md
+++ b/docs/dataset/index.md
@@ -9,8 +9,6 @@ hide:
 Kolena Datasets provides a framework and tooling for exploration of data, evaluation of model results, and
 standardization and comparison of multiple models.
 
----
-
 <div class="grid cards" markdown>
 - [:kolena-flame-16: Quickstart](./quickstart.md)
 

--- a/docs/dataset/index.md
+++ b/docs/dataset/index.md
@@ -5,3 +5,31 @@ hide:
 ---
 
 # :kolena-dataset-20: Datasets
+
+Kolena Datasets provides a framework and tooling for exploration of data, evaluation of model results, and
+standardization and comparison of multiple models.
+
+---
+
+<div class="grid cards" markdown>
+- [:kolena-flame-16: Quickstart](./quickstart.md)
+
+    ---
+
+    Get started with a quick and easy example for connecting data to Kolena, using either the web application or the Python SDK.
+</div>
+
+<div class="grid cards" markdown>
+- [:kolena-dataset-16: Dataset](./core-concepts/dataset.md)
+
+    ---
+
+    A **Dataset** represents a structured assembly of datapoints, essential for model evaluation.
+
+- [:kolena-quality-standard-16: Quality Standard](./core-concepts/quality-standard.md)
+
+    ---
+
+    A **Quality Standard** tracks a standardized process for how a team evaluates a model's performance on a dataset.
+
+</div>

--- a/docs/dataset/index.md
+++ b/docs/dataset/index.md
@@ -24,12 +24,12 @@ standardization and comparison of multiple models.
 
     ---
 
-    A **Dataset** represents a structured assembly of datapoints, essential for model evaluation.
+    A Dataset represents a structured assembly of datapoints, essential for model evaluation.
 
 - [:kolena-quality-standard-16: Quality Standard](./core-concepts/quality-standard.md)
 
     ---
 
-    A **Quality Standard** tracks a standardized process for how a team evaluates a model's performance on a dataset.
+    A Quality Standard tracks a standardized process for how a team evaluates a model's performance on a dataset.
 
 </div>

--- a/docs/workflow/building-a-workflow.md
+++ b/docs/workflow/building-a-workflow.md
@@ -8,7 +8,8 @@ search:
 
 !!! note
     Kolena Workflows are simplified in Kolena Datasets.
-    If you are setting up your Kolena environments for the first time, please refer to [Datasets Quickstart](../dataset/quickstart.md)
+    If you are setting up your Kolena environments for the first time, please refer to the
+    [Datasets Quickstart](../dataset/quickstart.md).
 
 
 In this tutorial we'll learn how to use the [`kolena.workflow`](../reference/workflow/index.md) workflow builder

--- a/docs/workflow/core-concepts/index.md
+++ b/docs/workflow/core-concepts/index.md
@@ -6,6 +6,11 @@ hide:
 
 # :kolena-area-of-interest-20: Core Concepts
 
+!!! note
+    Kolena Workflows are simplified in Kolena Datasets.
+    If you are setting up your Kolena environments for the first time, please refer to
+    [Kolena Datasets](../../dataset/core-concepts/index.md).
+
 In this section, we'll get acquainted with the core concepts on Kolena, and learn in-depth about the various features
 offered. For a brief introduction, see the [Quickstart Guide](../quickstart.md) or the
 [Building a Workflow](../building-a-workflow.md) tutorial. For code-level API documentation, see the

--- a/docs/workflow/index.md
+++ b/docs/workflow/index.md
@@ -5,3 +5,8 @@ hide:
 ---
 
 # :kolena-cube-20: Workflows
+
+!!! note
+    Kolena Workflows are simplified in Kolena Datasets.
+    If you are setting up your Kolena environments for the first time, please refer to
+    [Kolena Datasets](../dataset/index.md).

--- a/docs/workflow/index.md
+++ b/docs/workflow/index.md
@@ -10,3 +10,43 @@ hide:
     Kolena Workflows are simplified in Kolena Datasets.
     If you are setting up your Kolena environments for the first time, please refer to
     [Kolena Datasets](../dataset/index.md).
+
+Kolena Workflows provides a framework for rigorously describing your ML evaluation process and integration your data
+and evaluation process into the Kolena web application.
+
+---
+
+<div class="grid cards" markdown>
+- [:kolena-flame-16: Quickstart](./quickstart.md)
+
+    ---
+
+    Get started with a quick and easy example for connecting data to Kolena, using either the web application or the Python SDK.
+</div>
+
+<div class="grid cards" markdown>
+- [:kolena-area-of-interest-16: Core Concepts](./core-concepts/index.md)
+
+    ---
+
+    Learn about the building blocks for Kolena Workflows, such as the [Workflow](./core-concepts/workflow.md),
+    [Test Cases & Test Suites](./core-concepts/test-suite.md), and [Models](./core-concepts/model.md).
+
+- [:kolena-cube-16: Building a Workflow](./building-a-workflow.md)
+
+    ---
+
+    Assemble a Kolena Workflow by describing the structure of your data and model results.
+</div>
+
+<div class="grid cards" markdown>
+- [:kolena-rocket-16: Advanced Usage](./advanced-usage/index.md)
+
+    ---
+
+    Leverage advanced capabilities in the Kolena platform such as
+    [natural language search](./advanced-usage/set-up-natural-language-search.md),
+    [automatic workflow evaluation](./advanced-usage/packaging-for-automated-evaluation.md),
+    [nesting test case level metrics](./advanced-usage/nesting-test-case-metrics.md),
+    and [displaying activation maps](./advanced-usage/uploading-activation-maps.md).
+</div>

--- a/docs/workflow/index.md
+++ b/docs/workflow/index.md
@@ -14,8 +14,6 @@ hide:
 Kolena Workflows provides a framework for rigorously describing your ML evaluation process and integration your data
 and evaluation process into the Kolena web application.
 
----
-
 <div class="grid cards" markdown>
 - [:kolena-flame-16: Quickstart](./quickstart.md)
 

--- a/docs/workflow/index.md
+++ b/docs/workflow/index.md
@@ -11,8 +11,8 @@ hide:
     If you are setting up your Kolena environments for the first time, please refer to
     [Kolena Datasets](../dataset/index.md).
 
-Kolena Workflows provides a framework for rigorously describing your ML evaluation process and integration your data
-and evaluation process into the Kolena web application.
+Kolena Workflows provides a framework for rigorously describing your data and model evaluation process and integrating
+it into the Kolena web application for analysis and exploration.
 
 <div class="grid cards" markdown>
 - [:kolena-flame-16: Quickstart](./quickstart.md)

--- a/docs/workflow/quickstart.md
+++ b/docs/workflow/quickstart.md
@@ -4,6 +4,11 @@ icon: kolena/flame-16
 
 # :kolena-flame-20: Quickstart
 
+!!! note
+    Kolena Workflows are simplified in Kolena Datasets.
+    If you are setting up your Kolena environments for the first time, please refer to the
+    [Datasets Quickstart](../dataset/quickstart.md).
+
 Install Kolena to set up rigorous and repeatable model testing in minutes.
 
 In this quickstart guide, we'll use the


### PR DESCRIPTION
### Linked issue(s):

### What change does this PR introduce and why?

Add docs for previously empty pages:

- [x] http://localhost:8999/dataset/
- [x] http://localhost:8999/dataset/core-concepts/
- [x] http://localhost:8999/dataset/core-concepts/quality-standard/
- [x] http://localhost:8999/workflow/

Also put the Kolena Workflows -> Kolena Datasets callout on more pages.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
