### PR TITLE
Dataset quickstart docs cleanup

### DIFF
--- a/docs/dataset/quickstart.md
+++ b/docs/dataset/quickstart.md
@@ -49,22 +49,24 @@ creating test cases.
 
 === "Web App"
 
-    To import the 300-W dataset, select “Import datasets” then “Select from cloud storage”. Using the explorer, navigate to
+    To import the 300-W dataset, select `Import datasets` then `Select from cloud storage`. Using the explorer, navigate to
     `s3://kolena-pubic-examples/300-W/` and select `300-W.csv`.
 
     ??? note "Generating Datasets"
         See the [`keypoint_detection/upload_dataset.py`](https://github.com/kolenaIO/kolena/blob/trunk/examples/dataset/keypoint_detection/keypoint_detection/upload_dataset.py)
         script in the code example for details on how the dataset was generated.
 
-    Note: The keypoints in `300-W.csv` have been defined using `kolena.annotation.Keypoints` from
-    the `kolena` SDK. See the `keypoint_detection/upload_dataset.py` script for example usage.
+    The keypoints in `300-W.csv` have been defined using `kolena.annotation.Keypoints` from
+    the `kolena` SDK.
+    See the [`keypoint_detection/upload_dataset.py`](https://github.com/kolenaIO/kolena/blob/trunk/examples/dataset/keypoint_detection/keypoint_detection/upload_dataset.py)
+    script for example usage.
 
     You will now see a preview of how the information is going to be consumed by Kolena.
 
     Give your dataset a name and select `locator` as the ID column. The ID column is used to uniquely identify a datapoint
     and is used when uploading model results to associate inferences with datapoints.
 
-    Click “Confirm” to import the dataset. Once the dataset has been added, you can add description and tags to them to organize the workspace.
+    Click `Confirm` to import the dataset. Once the dataset has been added, you can add description and tags to them to organize the workspace.
 
     <figure markdown>
         ![Example Dataset Upload](../assets/images/quickstart-upload-dataset-workflow.gif)
@@ -92,7 +94,7 @@ creating test cases.
     poetry run python3 keypoint_detection/upload_dataset.py
     ```
 
-    After this script has completed, a new dataset named "300-W" will be created, which you can
+    After this script has completed, a new dataset named `300-W` will be created, which you can
     see in [:kolena-dataset-20: Datasets](https://app.kolena.io/redirect/datasets).
 
 
@@ -104,8 +106,8 @@ keypoint detection model and a random keypoint model.
 
 === "Web App"
 
-    To upload new model results, from the Details tab of the dataset, click on “Upload Model Results” in the upper right.
-    Then, select “Upload from cloud storage”. Using the explorer, navigate to `s3://kolena-public-datasets/300-W/results/`
+    To upload new model results, from the Details tab of the dataset, click on `Upload Model Results` in the upper right.
+    Then, select `Upload from cloud storage`. Using the explorer, navigate to `s3://kolena-public-datasets/300-W/results/`
     and select `random.csv`, This CSV file contains model results for the random keypoints
     model for each of the datapoints we uploaded to the dataset.
 
@@ -113,7 +115,7 @@ keypoint detection model and a random keypoint model.
         See the [`keypoint_detection/upload_results.py`](https://github.com/kolenaIO/kolena/blob/trunk/examples/dataset/keypoint_detection/keypoint_detection/upload_results.py)
         script in the code example for details on how results were generated.
 
-    You will now see a preview of how Kolena will ingest the model results. Give your model a name, and click “Confirm” to
+    You will now see a preview of how Kolena will ingest the model results. Give your model a name, and click `Confirm` to
     upload the model results.
 
     <figure markdown>
@@ -133,20 +135,20 @@ keypoint detection model and a random keypoint model.
     poetry run python3 keypoint_detection/upload_results.py random
     ```
 
-    Results for two models named "RetinaFace" and "random" should now appear <somewhere>
+    Results for two models named `RetinaFace` and `random` should now appear <somewhere>
 
 ## Step 3: Explore Data and Results
 
 Once you have uploaded your dataset and model results, you can visualize the data using Kolena’s plotting tools.
 
-You can quickly see the distribution of any datapoint or model inference field in the “Distributions” tab.
+You can quickly see the distribution of any datapoint or model inference field in the `Distributions` tab.
 
 <figure markdown>
 ![Distribution Plots](../assets/images/quickstart-distribution.jpg)
 <figcaption>Distribution Plots</figcaption>
 </figure>
 
-Additionally, you can create custom plots in the "Debugger" tab. For example, click “Add Model” in the top left and
+Additionally, you can create custom plots in the `Debugger` tab. For example, click `Add Model` in the top left and
 select the random model. In the plotting widget at the bottom, select `datapoint.normalization_factor` as the x-axis
 and `result.mse > mean` as the y-axis to plot these two fields against each other.
 
@@ -162,7 +164,7 @@ Test Cases, which organize your data into key scenarios, and Metric, which defin
 
 ### Define Test Cases
 
-To configure test cases, navigate to the "Quality Standards" tab and click on “Divide Dataset By”. Select
+To configure test cases, navigate to the `Quality Standards` tab and click on `Divide Dataset By`. Select
 `datapoint.condition` to create test cases based on the condition field. Click the check mark to
 save your test cases to your Quality Standard.
 
@@ -176,8 +178,8 @@ Criteria you define will be calculated on each test case.
 
 ### Define Metrics
 
-To configure Evaluation Criteria, from the Quality Standards tab, click "Define Metrics" and select `result.mse > mean`.
-Rename the metric to "Average MSE", and select "Lower is better" as the highlight. Repeat these steps for `result.nmse > mean`.
+To configure Evaluation Criteria, from the Quality Standards tab, click `Define Metrics` and select `result.mse > mean`.
+Rename the metric to `Average MSE`, and select `Lower is better` as the highlight. Repeat these steps for `result.nmse > mean`.
 
 <figure markdown>
 ![Defining Metrics](../assets/images/quickstart-define-metrics.gif)
@@ -187,9 +189,9 @@ Rename the metric to "Average MSE", and select "Lower is better" as the highligh
 ## Step 5: Compare Models
 
 Once you have configured a Quality Standard, the Metrics you define will be calculated across all Test Cases.
-To compare the results across models, navigate to the "Quality Standards" tab and add "random" model to the
-table using the "Add Models" button in the top right. Then, add the "RetinaFace" model to compare its performance
-to the "random" model.
+To compare the results across models, navigate to the `Quality Standards` tab and add `random` model to the
+table using the `Add Models` button in the top right. Then, add the `RetinaFace` model to compare its performance
+to the `random` model.
 
 You will now see all metrics in the Quality Standard computed on every test case in the Quality Standard.
 Metrics in this view will also be highlighted according to how much they improve/worsen compared to the

--- a/docs/dataset/quickstart.md
+++ b/docs/dataset/quickstart.md
@@ -56,7 +56,7 @@ creating test cases.
         See the [`keypoint_detection/upload_dataset.py`](https://github.com/kolenaIO/kolena/blob/trunk/examples/dataset/keypoint_detection/keypoint_detection/upload_dataset.py)
         script in the code example for details on how the dataset was generated.
 
-    Note: The keypoints in `300-W.csv` have been defined using `kolena.workflow.annotation.Keypoints` from
+    Note: The keypoints in `300-W.csv` have been defined using `kolena.annotation.Keypoints` from
     the `kolena` SDK. See the `keypoint_detection/upload_dataset.py` script for example usage.
 
     You will now see a preview of how the information is going to be consumed by Kolena.


### PR DESCRIPTION
### Linked issue(s):
N/A

### What change does this PR introduce and why?
Dataset quickstart docs cleanup
- Use backticks instead of quotes for filenames and button text
- Remove reference to `kolena.workflow.annotation`

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
