### PR TITLE
Fix s3 reference in docs

### DIFF
--- a/docs/dataset/quickstart.md
+++ b/docs/dataset/quickstart.md
@@ -107,7 +107,7 @@ keypoint detection model and a random keypoint model.
 === "Web App"
 
     To upload new model results, from the Details tab of the dataset, click on `Upload Model Results` in the upper right.
-    Then, select `Upload from cloud storage`. Using the explorer, navigate to `s3://kolena-public-datasets/300-W/results/`
+    Then, select `Upload from cloud storage`. Using the explorer, navigate to `s3://kolena-public-examples/300-W/results/`
     and select `random.csv`, This CSV file contains model results for the random keypoints
     model for each of the datapoints we uploaded to the dataset.
 


### PR DESCRIPTION
### Linked issue(s):

Fixes [KOL-4724](https://linear.app/kolena/issue/KOL-4724/update-quickstart-to-reference-kolena-public-examples)

### What change does this PR introduce and why?

Fixes incorrect s3 path. Example lives in `kolena-public-examples`

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
