### PR TITLE
[DO NOT REVIEW] ci poke

### DIFF
--- a/tests/integration/workflow/dummy.py
+++ b/tests/integration/workflow/dummy.py
@@ -23,7 +23,7 @@ from kolena.workflow import Image
 from kolena.workflow import Inference
 from kolena.workflow.annotation import BoundingBox
 
-DUMMY_WORKFLOW_NAME = "Dummy Workflow 🤖"
+DUMMY_WORKFLOW_NAME = "Dummy Workflow 🤖 ci poke"
 
 
 @dataclass(frozen=True, order=True)


### PR DESCRIPTION
### Linked issue(s):

will close after verifying

- [integration-test-dataset-3.9.18-none](https://circleci.com/gh/kolenaIO/kolena/75319?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) is skipped for workflow only change
- might need to add the similar condition for workflow integration tests to skip when `pipeline.parameters.workflow` and `pipeline.parameters.all` are false

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
