### PR TITLE
add read retry for GET/PUT/DELETE calls

### DIFF
--- a/kolena/_utils/krequests.py
+++ b/kolena/_utils/krequests.py
@@ -52,6 +52,9 @@ CONNECTION_READ_TIMEOUT = 60 * 60  # Give kolena server 1 hour to respond to cli
 # Using the Retry object to configure a backoff which is not supported by using an int here.
 MAX_RETRIES = Retry(total=3, connect=3, read=0, redirect=0, status=0, backoff_factor=2)
 
+# This retries for read errors in addition to the ones mentioned above.
+MAX_RETRIES_WITH_READ = Retry(total=3, connect=3, read=3, redirect=0, status=0, backoff_factor=2)
+
 
 class JWTAuth(requests.auth.AuthBase):
     """Attaches JWT Authorization to the given Request object"""
@@ -102,7 +105,7 @@ def get(
 ) -> requests.Response:
     url = get_endpoint(endpoint_path=endpoint_path, api_version=api_version)
     with requests.Session() as s:
-        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_RETRIES))
+        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_RETRIES_WITH_READ))
         return s.get(url=url, params=params, **_with_default_kwargs(**kwargs))
 
 
@@ -130,7 +133,7 @@ def put(
 ) -> requests.Response:
     url = get_endpoint(endpoint_path=endpoint_path, api_version=api_version)
     with requests.Session() as s:
-        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_RETRIES))
+        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_RETRIES_WITH_READ))
         return s.put(url=url, data=data, json=json, **_with_default_kwargs(**kwargs))
 
 
@@ -138,7 +141,7 @@ def put(
 def delete(endpoint_path: str, api_version: str = DEFAULT_API_VERSION, **kwargs: Any) -> requests.Response:
     url = get_endpoint(endpoint_path=endpoint_path, api_version=api_version)
     with requests.Session() as s:
-        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_RETRIES))
+        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_RETRIES_WITH_READ))
         return requests.delete(url=url, **_with_default_kwargs(**kwargs))
 
 

--- a/kolena/_utils/krequests.py
+++ b/kolena/_utils/krequests.py
@@ -53,7 +53,8 @@ CONNECTION_READ_TIMEOUT = 60 * 60  # Give kolena server 1 hour to respond to cli
 MAX_RETRIES = Retry(total=3, connect=3, read=0, redirect=0, status=0, backoff_factor=2)
 
 # This retries for read errors in addition to the ones mentioned above.
-MAX_RETRIES_WITH_READ = Retry(total=3, connect=3, read=3, redirect=0, status=0, backoff_factor=2)
+# Should only be used for idempotent operations.
+MAX_IDEMPOTENT_RETRIES = Retry(total=3, connect=3, read=3, redirect=0, status=0, backoff_factor=2)
 
 
 class JWTAuth(requests.auth.AuthBase):
@@ -105,7 +106,7 @@ def get(
 ) -> requests.Response:
     url = get_endpoint(endpoint_path=endpoint_path, api_version=api_version)
     with requests.Session() as s:
-        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_RETRIES_WITH_READ))
+        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_IDEMPOTENT_RETRIES))
         return s.get(url=url, params=params, **_with_default_kwargs(**kwargs))
 
 
@@ -133,7 +134,7 @@ def put(
 ) -> requests.Response:
     url = get_endpoint(endpoint_path=endpoint_path, api_version=api_version)
     with requests.Session() as s:
-        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_RETRIES_WITH_READ))
+        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_IDEMPOTENT_RETRIES))
         return s.put(url=url, data=data, json=json, **_with_default_kwargs(**kwargs))
 
 
@@ -141,7 +142,7 @@ def put(
 def delete(endpoint_path: str, api_version: str = DEFAULT_API_VERSION, **kwargs: Any) -> requests.Response:
     url = get_endpoint(endpoint_path=endpoint_path, api_version=api_version)
     with requests.Session() as s:
-        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_RETRIES_WITH_READ))
+        s.mount("https://", socket_options.TCPKeepAliveAdapter(max_retries=MAX_IDEMPOTENT_RETRIES))
         return requests.delete(url=url, **_with_default_kwargs(**kwargs))
 
 


### PR DESCRIPTION
### Linked issue(s):
https://linear.app/kolena/issue/KOL-4717/sdk-server-timeout-even-with-retries

### What change does this PR introduce and why?
We currently retry requests only for connection-related error but not for read errors; this is the right thing to do assuming that read errors are only raised after requests were received by the server. However, the `urllib3` and `requests` packages have issues where `ReadTimeoutError` is thrown for failing to establish connections (example issues: [#1](https://github.com/psf/requests/issues/5544), [#2](https://github.com/urllib3/urllib3/issues/1366)), leading to no retries attempted.

As a workaround, his PR adds a retry on read error for `GET/PUT/DELETE` assuming idempotency of these operations. `POST` is left as is in case of unexpected resource creation. 

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
