### PR TITLE
fix bucket name typo in dataset quickstart

### DIFF
--- a/docs/dataset/quickstart.md
+++ b/docs/dataset/quickstart.md
@@ -50,7 +50,7 @@ creating test cases.
 === "Web App"
 
     To import the 300-W dataset, select `Import datasets` then `Select from cloud storage`. Using the explorer, navigate to
-    `s3://kolena-pubic-examples/300-W/` and select `300-W.csv`.
+    `s3://kolena-public-examples/300-W/` and select `300-W.csv`.
 
     ??? note "Generating Datasets"
         See the [`keypoint_detection/upload_dataset.py`](https://github.com/kolenaIO/kolena/blob/trunk/examples/dataset/keypoint_detection/keypoint_detection/upload_dataset.py)


### PR DESCRIPTION
### Linked issue(s)

### What change does this PR introduce and why?
Noticed this typo will looking through the docs earlier.
### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
