### PR TITLE
Fix speaker diarization workflow ci test

### DIFF
--- a/examples/workflow/speaker_diarization/speaker_diarization/seed_test_run.py
+++ b/examples/workflow/speaker_diarization/speaker_diarization/seed_test_run.py
@@ -81,8 +81,8 @@ def main(args: Namespace) -> None:
     mod = "gcp-stt-video"
 
     print("loading test suite")
-    if "suite_name" in args:
-        test_suites = [TestSuite.load(args.suite_name)]
+    if "test_suite" in args:
+        test_suites = [TestSuite.load(args.test_suite)]
     else:
         test_suites = TestSuite.load_all(tags={DATASET})
     for test_suite in test_suites:
@@ -96,5 +96,10 @@ if __name__ == "__main__":
         type=bool,
         default=False,
         help="Specify whether to perform speaker alignment between the GT and Inf in the preprocessing step.",
+    )
+    ap.add_argument(
+        "--test-suite",
+        type=str,
+        help="Optionally specify a test suite to test. Test against all available test suites when unspecified.",
     )
     main(ap.parse_args())


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?
Speaker diarization workflow example tests are failing now: [example run](https://app.circleci.com/pipelines/github/kolenaIO/kolena/3558/workflows/966fc1a7-1967-4420-b78e-ae9134928f6a/jobs/78327).

This is because the [test passed in arg as `test_suite`](https://github.com/kolenaIO/kolena/blob/a2ef6ae1c454cf0a90a013eb40ab3763ece2af71/examples/workflow/speaker_diarization/tests/test_speaker_diarization.py#L45) while [the script expected `suite_name`](https://github.com/kolenaIO/kolena/blob/a2ef6ae1c454cf0a90a013eb40ab3763ece2af71/examples/workflow/speaker_diarization/speaker_diarization/seed_test_run.py#L85). This caused the script to [fallback](https://github.com/kolenaIO/kolena/blob/a2ef6ae1c454cf0a90a013eb40ab3763ece2af71/examples/workflow/speaker_diarization/speaker_diarization/seed_test_run.py#L87) to testing all test suites which include all historical versions that grew over time, hence getting timeouts.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
