### PR TITLE
Fix state handling in experimental object detection evaluator

### DIFF
--- a/kolena/_experimental/object_detection/evaluator.py
+++ b/kolena/_experimental/object_detection/evaluator.py
@@ -31,6 +31,7 @@ from kolena._experimental.object_detection import ThresholdConfiguration
 from kolena._experimental.object_detection.evaluator_multiclass import MulticlassObjectDetectionEvaluator
 from kolena._experimental.object_detection.evaluator_single_class import SingleClassObjectDetectionEvaluator
 from kolena.workflow import Evaluator
+from kolena.workflow import EvaluatorConfiguration
 from kolena.workflow import Plot
 
 
@@ -46,9 +47,12 @@ class ObjectDetectionEvaluator(Evaluator):
     For additional functionality, see the associated [base class documentation][kolena.workflow.evaluator.Evaluator].
     """
 
-    single_class_evaluator = SingleClassObjectDetectionEvaluator()
-    multiclass_evaluator = MulticlassObjectDetectionEvaluator()
     dynamic_evaluator: Union[SingleClassObjectDetectionEvaluator, MulticlassObjectDetectionEvaluator, None] = None
+
+    def __init__(self, configurations: Optional[List[EvaluatorConfiguration]] = None):
+        super().__init__(configurations)
+        self.single_class_evaluator = SingleClassObjectDetectionEvaluator()
+        self.multiclass_evaluator = MulticlassObjectDetectionEvaluator()
 
     def compute_test_sample_metrics(
         self,

--- a/kolena/_experimental/object_detection/evaluator.py
+++ b/kolena/_experimental/object_detection/evaluator.py
@@ -47,12 +47,15 @@ class ObjectDetectionEvaluator(Evaluator):
     For additional functionality, see the associated [base class documentation][kolena.workflow.evaluator.Evaluator].
     """
 
-    dynamic_evaluator: Union[SingleClassObjectDetectionEvaluator, MulticlassObjectDetectionEvaluator, None] = None
-
     def __init__(self, configurations: Optional[List[EvaluatorConfiguration]] = None):
         super().__init__(configurations)
         self.single_class_evaluator = SingleClassObjectDetectionEvaluator()
         self.multiclass_evaluator = MulticlassObjectDetectionEvaluator()
+        self.dynamic_evaluator: Union[
+            SingleClassObjectDetectionEvaluator,
+            MulticlassObjectDetectionEvaluator,
+            None,
+        ] = None
 
     def compute_test_sample_metrics(
         self,

--- a/kolena/_experimental/object_detection/evaluator_multiclass.py
+++ b/kolena/_experimental/object_detection/evaluator_multiclass.py
@@ -39,6 +39,7 @@ from kolena._experimental.object_detection.utils import compute_pr_curve
 from kolena._experimental.object_detection.utils import compute_pr_plot_multiclass
 from kolena._experimental.object_detection.utils import filter_inferences
 from kolena.workflow import Evaluator
+from kolena.workflow import EvaluatorConfiguration
 from kolena.workflow import Plot
 from kolena.workflow.annotation import ScoredLabel
 from kolena.workflow.metrics import f1_score as compute_f1_score
@@ -60,24 +61,28 @@ class MulticlassObjectDetectionEvaluator(Evaluator):
     For additional functionality, see the associated [base class documentation][kolena.workflow.evaluator.Evaluator].
     """
 
-    threshold_cache: Dict[str, Dict[str, float]] = {}  # configuration -> label -> threshold
+    threshold_cache: Dict[str, Dict[str, float]]  # configuration -> label -> threshold
     """
     Assumes that the first test case retrieved for the test suite contains the complete sample set to be used for
     F1-Optimal threshold computation. Subsequent requests for a given threshold strategy (for other test cases) will
     hit this cache and use the previously computed population level confidence thresholds.
     """
 
-    locators_by_test_case: Dict[str, List[str]] = {}
+    locators_by_test_case: Dict[str, List[str]]
     """
     Keeps track of test sample locators for each test case (used for total # of image count in aggregated metrics).
     """
 
-    matchings_by_test_case: Dict[str, Dict[str, List[MulticlassInferenceMatches]]] = defaultdict(
-        lambda: defaultdict(list),
-    )
+    matchings_by_test_case: Dict[str, Dict[str, List[MulticlassInferenceMatches]]]
     """
     Caches matchings per configuration and test case for faster test case metric and plot computation.
     """
+
+    def __init__(self, configurations: Optional[List[EvaluatorConfiguration]] = None):
+        super().__init__(configurations)
+        self.threshold_cache = {}
+        self.locators_by_test_case = {}
+        self.matchings_by_test_case = defaultdict(lambda: defaultdict(list))
 
     def test_sample_metrics_ignored(
         self,

--- a/kolena/_experimental/object_detection/evaluator_multiclass.py
+++ b/kolena/_experimental/object_detection/evaluator_multiclass.py
@@ -268,6 +268,7 @@ class MulticlassObjectDetectionEvaluator(Evaluator):
         recall = compute_recall(tp_count, fn_count)
         f1_score = compute_f1_score(tp_count, fp_count, fn_count)
 
+        # import pdb; pdb.set_trace()
         return ClassMetricsPerTestCase(
             Class=label,
             nImages=samples_count,

--- a/kolena/_experimental/object_detection/evaluator_multiclass.py
+++ b/kolena/_experimental/object_detection/evaluator_multiclass.py
@@ -268,7 +268,6 @@ class MulticlassObjectDetectionEvaluator(Evaluator):
         recall = compute_recall(tp_count, fn_count)
         f1_score = compute_f1_score(tp_count, fp_count, fn_count)
 
-        # import pdb; pdb.set_trace()
         return ClassMetricsPerTestCase(
             Class=label,
             nImages=samples_count,

--- a/kolena/_experimental/object_detection/evaluator_single_class.py
+++ b/kolena/_experimental/object_detection/evaluator_single_class.py
@@ -39,6 +39,7 @@ from kolena._experimental.object_detection.utils import compute_pr_curve
 from kolena._experimental.object_detection.utils import compute_pr_plot
 from kolena._experimental.object_detection.utils import filter_inferences
 from kolena.workflow import Evaluator
+from kolena.workflow import EvaluatorConfiguration
 from kolena.workflow import Plot
 from kolena.workflow.metrics import f1_score as compute_f1_score
 from kolena.workflow.metrics import InferenceMatches
@@ -59,24 +60,28 @@ class SingleClassObjectDetectionEvaluator(Evaluator):
     For additional functionality, see the associated [base class documentation][kolena.workflow.evaluator.Evaluator].
     """
 
-    threshold_cache: Dict[str, float] = {}  # configuration -> threshold
+    threshold_cache: Dict[str, float]  # configuration -> threshold
     """
     Assumes that the first test case retrieved for the test suite contains the complete sample set to be used for
     F1-Optimal threshold computation. Subsequent requests for a given threshold strategy (for other test cases) will
     hit this cache and use the previously computed population level confidence thresholds.
     """
 
-    locators_by_test_case: Dict[str, List[str]] = {}
+    locators_by_test_case: Dict[str, List[str]]
     """
     Keeps track of test sample locators for each test case (used for total # of image count in aggregated metrics).
     """
 
-    matchings_by_test_case: Dict[str, Dict[str, List[InferenceMatches]]] = defaultdict(
-        lambda: defaultdict(list),
-    )
+    matchings_by_test_case: Dict[str, Dict[str, List[InferenceMatches]]]
     """
     Caches matchings per configuration and test case for faster test case metric and plot computation.
     """
+
+    def __init__(self, configurations: Optional[List[EvaluatorConfiguration]] = None):
+        super().__init__(configurations)
+        self.threshold_cache = {}
+        self.locators_by_test_case = {}
+        self.matchings_by_test_case = defaultdict(lambda: defaultdict(list))
 
     def test_sample_metrics_ignored(
         self,


### PR DESCRIPTION
Fixes observed bug due to stateful objects being assigned as class members instead of instance members.