### PR TITLE
chore: expose sources for uploading

### DIFF
--- a/kolena/_api/v2/dataset.py
+++ b/kolena/_api/v2/dataset.py
@@ -33,6 +33,7 @@ class RegisterRequest:
     name: str
     id_fields: List[str]
     uuid: str
+    sources: Optional[List[str]] = None
 
 
 @dataclass(frozen=True)

--- a/kolena/_api/v2/dataset.py
+++ b/kolena/_api/v2/dataset.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from enum import Enum
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -33,7 +34,7 @@ class RegisterRequest:
     name: str
     id_fields: List[str]
     uuid: str
-    sources: Optional[List[str]] = None
+    sources: Optional[List[Dict[str, str]]] = None
 
 
 @dataclass(frozen=True)

--- a/kolena/_api/v2/dataset.py
+++ b/kolena/_api/v2/dataset.py
@@ -34,7 +34,7 @@ class RegisterRequest:
     name: str
     id_fields: List[str]
     uuid: str
-    sources: Optional[List[Dict[str, str]]] = None
+    sources: Optional[List[Dict[str, str]]]
 
 
 @dataclass(frozen=True)

--- a/kolena/_api/v2/model.py
+++ b/kolena/_api/v2/model.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from enum import Enum
+from typing import List
+from typing import Optional
 
 from pydantic.dataclasses import dataclass
 
@@ -44,6 +46,7 @@ class UploadResultsRequest:
     model: str
     uuid: str
     dataset_id: int
+    sources: Optional[List[str]] = None
 
 
 @dataclass(frozen=True)

--- a/kolena/_api/v2/model.py
+++ b/kolena/_api/v2/model.py
@@ -47,7 +47,7 @@ class UploadResultsRequest:
     model: str
     uuid: str
     dataset_id: int
-    sources: Optional[List[Dict[str, str]]] = None
+    sources: Optional[List[Dict[str, str]]]
 
 
 @dataclass(frozen=True)

--- a/kolena/_api/v2/model.py
+++ b/kolena/_api/v2/model.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from enum import Enum
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -46,7 +47,7 @@ class UploadResultsRequest:
     model: str
     uuid: str
     dataset_id: int
-    sources: Optional[List[str]] = None
+    sources: Optional[List[Dict[str, str]]] = None
 
 
 @dataclass(frozen=True)

--- a/kolena/dataset/_common.py
+++ b/kolena/dataset/_common.py
@@ -25,6 +25,8 @@ COL_DATAPOINT_ID_OBJECT = "datapoint_id_object"
 COL_EVAL_CONFIG = "eval_config"
 COL_RESULT = "result"
 
+DEFAULT_SOURCES = [dict(type="sdk")]
+
 
 def validate_batch_size(batch_size: int) -> None:
     if batch_size <= 0:

--- a/kolena/dataset/dataset.py
+++ b/kolena/dataset/dataset.py
@@ -17,6 +17,7 @@ import sys
 from dataclasses import asdict
 from enum import Enum
 from typing import Any
+from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Optional
@@ -272,7 +273,7 @@ def _send_upload_dataset_request(
     name: str,
     id_fields: List[str],
     load_uuid: str,
-    sources: Optional[List[str]] = None,
+    sources: Optional[List[Dict[str, str]]] = None,
 ) -> EntityData:
     request = RegisterRequest(name=name, id_fields=id_fields, uuid=load_uuid, sources=sources)
     response = krequests.post(Path.REGISTER, json=asdict(request))

--- a/kolena/dataset/dataset.py
+++ b/kolena/dataset/dataset.py
@@ -243,6 +243,56 @@ def _resolve_id_fields(
     return id_fields
 
 
+def _prepare_upload_dataset_request(
+    name: str,
+    df: Union[pd.DataFrame, Iterator[pd.DataFrame]],
+    *,
+    id_fields: Optional[List[str]] = None,
+) -> Tuple[List[str], str]:
+    load_uuid = init_upload().uuid
+    existing_dataset = _load_dataset_metadata(name)
+    if isinstance(df, pd.DataFrame):
+        id_fields = _resolve_id_fields(df, id_fields, existing_dataset)
+        validate_dataframe_ids(df, id_fields)
+        _upload_dataset_chunk(df, load_uuid, id_fields)
+    else:
+        validated = False
+        for chunk in df:
+            if not validated:
+                id_fields = _resolve_id_fields(chunk, id_fields, existing_dataset)
+                validate_dataframe_ids(chunk, id_fields)
+                validated = True
+            assert id_fields is not None
+            _upload_dataset_chunk(chunk, load_uuid, id_fields)
+    assert id_fields is not None
+    return id_fields, load_uuid
+
+
+def _send_upload_dataset_request(
+    name: str,
+    id_fields: List[str],
+    load_uuid: str,
+    sources: Optional[List[str]] = None,
+) -> EntityData:
+    request = RegisterRequest(name=name, id_fields=id_fields, uuid=load_uuid, sources=sources)
+    response = krequests.post(Path.REGISTER, json=asdict(request))
+    krequests.raise_for_status(response)
+    data = from_dict(EntityData, response.json())
+    return data
+
+
+def _upload_dataset(
+    name: str,
+    df: Union[pd.DataFrame, Iterator[pd.DataFrame]],
+    *,
+    id_fields: Optional[List[str]] = None,
+) -> None:
+    prepared_id_fields, load_uuid = _prepare_upload_dataset_request(name, df, id_fields=id_fields)
+
+    data = _send_upload_dataset_request(name, prepared_id_fields, load_uuid)
+    log.info(f"uploaded dataset '{name}' ({get_dataset_url(dataset_id=data.id)})")
+
+
 @with_event(event_name=EventAPI.Event.REGISTER_DATASET)
 def upload_dataset(
     name: str,
@@ -264,27 +314,7 @@ def upload_dataset(
         within a dataset. When unspecified, a suitable value is inferred from the columns of the provided `df`. Note
         that `id_fields` must be hashable.
     """
-    load_uuid = init_upload().uuid
-    existing_dataset = _load_dataset_metadata(name)
-    if isinstance(df, pd.DataFrame):
-        id_fields = _resolve_id_fields(df, id_fields, existing_dataset)
-        validate_dataframe_ids(df, id_fields)
-        _upload_dataset_chunk(df, load_uuid, id_fields)
-    else:
-        validated = False
-        for chunk in df:
-            if not validated:
-                id_fields = _resolve_id_fields(chunk, id_fields, existing_dataset)
-                validate_dataframe_ids(chunk, id_fields)
-                validated = True
-            assert id_fields is not None
-            _upload_dataset_chunk(chunk, load_uuid, id_fields)
-    assert id_fields is not None
-    request = RegisterRequest(name=name, id_fields=id_fields, uuid=load_uuid)
-    response = krequests.post(Path.REGISTER, json=asdict(request))
-    krequests.raise_for_status(response)
-    data = from_dict(EntityData, response.json())
-    log.info(f"uploaded dataset '{name}' ({get_dataset_url(dataset_id=data.id)})")
+    _upload_dataset(name, df, id_fields=id_fields)
 
 
 def _iter_dataset_raw(

--- a/kolena/dataset/dataset.py
+++ b/kolena/dataset/dataset.py
@@ -53,6 +53,7 @@ from kolena._utils.serde import from_dict
 from kolena._utils.state import API_V2
 from kolena.dataset._common import COL_DATAPOINT
 from kolena.dataset._common import COL_DATAPOINT_ID_OBJECT
+from kolena.dataset._common import DEFAULT_SOURCES
 from kolena.dataset._common import validate_batch_size
 from kolena.dataset._common import validate_dataframe_ids
 from kolena.errors import InputValidationError
@@ -273,7 +274,7 @@ def _send_upload_dataset_request(
     name: str,
     id_fields: List[str],
     load_uuid: str,
-    sources: Optional[List[Dict[str, str]]] = None,
+    sources: Optional[List[Dict[str, str]]],
 ) -> EntityData:
     request = RegisterRequest(name=name, id_fields=id_fields, uuid=load_uuid, sources=sources)
     response = krequests.post(Path.REGISTER, json=asdict(request))
@@ -287,10 +288,11 @@ def _upload_dataset(
     df: Union[pd.DataFrame, Iterator[pd.DataFrame]],
     *,
     id_fields: Optional[List[str]] = None,
+    sources: Optional[List[Dict[str, str]]] = DEFAULT_SOURCES,
 ) -> None:
     prepared_id_fields, load_uuid = _prepare_upload_dataset_request(name, df, id_fields=id_fields)
 
-    data = _send_upload_dataset_request(name, prepared_id_fields, load_uuid)
+    data = _send_upload_dataset_request(name, prepared_id_fields, load_uuid, sources=sources)
     log.info(f"uploaded dataset '{name}' ({get_dataset_url(dataset_id=data.id)})")
 
 

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -102,7 +102,7 @@ def _send_upload_results_request(
     model: str,
     load_uuid: str,
     dataset_id: int,
-    sources: Optional[List[str]] = None,
+    sources: Optional[List[Dict[str, str]]] = None,
 ) -> UploadResultsResponse:
     request = UploadResultsRequest(
         model=model,

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -41,6 +41,7 @@ from kolena.dataset._common import COL_DATAPOINT
 from kolena.dataset._common import COL_DATAPOINT_ID_OBJECT
 from kolena.dataset._common import COL_EVAL_CONFIG
 from kolena.dataset._common import COL_RESULT
+from kolena.dataset._common import DEFAULT_SOURCES
 from kolena.dataset._common import validate_batch_size
 from kolena.dataset._common import validate_dataframe_have_other_columns_besides_ids
 from kolena.dataset._common import validate_dataframe_ids
@@ -102,7 +103,7 @@ def _send_upload_results_request(
     model: str,
     load_uuid: str,
     dataset_id: int,
-    sources: Optional[List[Dict[str, str]]] = None,
+    sources: Optional[List[Dict[str, str]]],
 ) -> UploadResultsResponse:
     request = UploadResultsRequest(
         model=model,
@@ -209,10 +210,11 @@ def _upload_results(
     dataset: str,
     model: str,
     results: Union[DataFrame, List[Tuple[EvalConfig, DataFrame]]],
+    sources: Optional[List[Dict[str, str]]] = DEFAULT_SOURCES,
 ) -> UploadResultsResponse:
     load_uuid, dataset_id, total_rows = _prepare_upload_results_request(dataset, model, results)
 
-    response = _send_upload_results_request(model, load_uuid, dataset_id)
+    response = _send_upload_results_request(model, load_uuid, dataset_id, sources=sources)
     log.info(
         f"uploaded test results for model '{model}' on dataset '{dataset}': "
         f"{total_rows} uploaded, {response.n_inserted} inserted, {response.n_updated} updated",


### PR DESCRIPTION
### Linked issue(s)

counterpart of: https://github.com/kolenaIO/shipyard/pull/1854

### What change does this PR introduce and why?

- expose the sources for uploading endpoints
- refactor to have these wrapper mapping: `upload_x` => `_upload_x` => `_prepare_upload_x_request` + `_send_upload_x_request`

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
