### PR TITLE
remove deprecated docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,14 +57,14 @@ jobs:
         if: inputs.environment != 'production'
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
-          aws s3 sync ./site "s3://trunk-docs.kolena.io"
+          aws s3 sync ./site "s3://trunk-docs.kolena.io" --delete
           aws cloudfront create-invalidation --no-cli-pager --distribution-id ${{ secrets.TRUNK_DOC_DISTRIBUTION_ID }} --paths "/*"
 
       - name: Publish 'kolena' documentation to production (S3)
         if: inputs.environment == 'production'
         run: |
           poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
-          aws s3 sync ./site "s3://docs.kolena.io"
+          aws s3 sync ./site "s3://docs.kolena.io" --delete
           aws cloudfront create-invalidation --no-cli-pager --distribution-id ${{ secrets.DOC_DISTRIBUTION_ID }} --paths "/*"
         env:
           DD_RUM_CLIENT_TOKEN: ${{ vars.DD_RUM_CLIENT_TOKEN }}


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?
Deprecated docs are still lying around in our S3 bucket. Example: https://trunk-docs.kolena.io/quickstart/
<img width="924" alt="image" src="https://github.com/kolenaIO/kolena/assets/145366880/2b6e0271-13cb-42f9-86d4-44828f93eebd">
<img width="955" alt="image" src="https://github.com/kolenaIO/kolena/assets/145366880/79bb9bf4-3d73-4b05-acbf-b0ee7e60f1c0">


Adding `--delete` arg. Based on [official doc](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html):
>--delete (boolean) Files that exist in the destination but not in the source are deleted during sync. Note that files excluded by filters are excluded from deletion.


### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
