### PR TITLE
Update quickstart url to dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ model behaviors and take the mystery out of model development. Kolena helps you:
 
 This `kolena` package contains the Python client library for programmatic interaction with the Kolena ML testing
 platform. [Install](https://docs.kolena.io/installing-kolena) with your favorite Python package manager and
-[get started in minutes](https://docs.kolena.io/quickstart):
+[get started in minutes](https://docs.kolena.io/dataset/quickstart):
 
 ```
 pip install kolena
@@ -47,6 +47,6 @@ pip install kolena
 
 ## Quick Links
 
-| [Developer Guide](https://docs.kolena.io) | [Quickstart](https://docs.kolena.io/quickstart) | [API Reference](https://docs.kolena.io/reference) | [Examples](./examples) |
+| [Developer Guide](https://docs.kolena.io) | [Quickstart](https://docs.kolena.io/dataset/quickstart) | [API Reference](https://docs.kolena.io/reference) | [Examples](./examples) |
 | --- | --- | --- | --- |
 | Tutorial and usage documentation | Set up rigorous and repeatable model testing in minutes | Detailed `kolena` typing and function documentation | Reference integrations for different machine learning workflows |

--- a/docs/workflow/advanced-usage/set-up-natural-language-search.md
+++ b/docs/workflow/advanced-usage/set-up-natural-language-search.md
@@ -113,7 +113,7 @@ def iter_image_locators(locators: List[str]) -> Iterator[Tuple[str, Image.Image]
 
 ### Step 3: Extract and Upload Embeddings
 
-We first [retrieve and set](https://docs.kolena.io/installing-kolena/#initialization) our `KOLENA_TOKEN` environment variable.
+We first [retrieve and set](../../installing-kolena.md#initialization) our `KOLENA_TOKEN` environment variable.
 This is used by the uploader for authentication against your Kolena instance.
 
 ```shell

--- a/docs/workflow/advanced-usage/uploading-activation-maps.md
+++ b/docs/workflow/advanced-usage/uploading-activation-maps.md
@@ -121,10 +121,10 @@ def create_and_upload_bitmap(
 
 !!! info inline end
     If you are not familiar with the workflow concept, please read the
-    [:kolena-cube-20: Building a Workflow](https://docs.kolena.io/building-a-workflow) guide.
+    [:kolena-cube-20: Building a Workflow](https://docs.kolena.io/workflow/building-a-workflow) guide.
 
 For the purposes of this tutorial, let's assume we already have a workflow built, and we are going to upload
-the activation maps as one of the fields in [`Inference`](https://docs.kolena.io/building-a-workflow/#inference-type).
+the activation maps as one of the fields in [`Inference`](https://docs.kolena.io/workflow/building-a-workflow/#inference-type).
 All we need to do is to update the `Inference` definition to include a new field for the activation map:
 
 ```python
@@ -139,8 +139,8 @@ class Inference(Inf):
 
 !!! info inline end
     If you are not familiar with how to run tests, please read the
-    [Step 4: Running Tests](https://docs.kolena.io/building-a-workflow/#step-4-running-tests)
-    from [:kolena-cube-20: Building a Workflow](https://docs.kolena.io/building-a-workflow) guide.
+    [Step 4: Running Tests](https://docs.kolena.io/workflow/building-a-workflow/#step-4-running-tests)
+    from [:kolena-cube-20: Building a Workflow](https://docs.kolena.io/workflow/building-a-workflow) guide.
 
 Before you run tests, make sure to update your `infer` function to return an `Inference` with the corresponding
 `BitmapMask` as its `activation_map` field. You are now ready to run tests! Once the tests complete, we can now visit

--- a/docs/workflow/advanced-usage/uploading-activation-maps.md
+++ b/docs/workflow/advanced-usage/uploading-activation-maps.md
@@ -121,10 +121,10 @@ def create_and_upload_bitmap(
 
 !!! info inline end
     If you are not familiar with the workflow concept, please read the
-    [:kolena-cube-20: Building a Workflow](https://docs.kolena.io/workflow/building-a-workflow) guide.
+    [:kolena-cube-20: Building a Workflow](../building-a-workflow.md) guide.
 
 For the purposes of this tutorial, let's assume we already have a workflow built, and we are going to upload
-the activation maps as one of the fields in [`Inference`](https://docs.kolena.io/workflow/building-a-workflow/#inference-type).
+the activation maps as one of the fields in [`Inference`](../building-a-workflow.md#inference-type).
 All we need to do is to update the `Inference` definition to include a new field for the activation map:
 
 ```python
@@ -139,8 +139,8 @@ class Inference(Inf):
 
 !!! info inline end
     If you are not familiar with how to run tests, please read the
-    [Step 4: Running Tests](https://docs.kolena.io/workflow/building-a-workflow/#step-4-running-tests)
-    from [:kolena-cube-20: Building a Workflow](https://docs.kolena.io/workflow/building-a-workflow) guide.
+    [Step 4: Running Tests](../building-a-workflow.md#step-4-running-tests)
+    from [:kolena-cube-20: Building a Workflow](../building-a-workflow.md) guide.
 
 Before you run tests, make sure to update your `infer` function to return an `Inference` with the corresponding
 `BitmapMask` as its `activation_map` field. You are now ready to run tests! Once the tests complete, we can now visit

--- a/examples/dataset/semantic_segmentation/README.md
+++ b/examples/dataset/semantic_segmentation/README.md
@@ -32,7 +32,7 @@ e.g. `pspnet_r101`, `pspnet_r50`, on the dataset.
     As part of the evaluation, result masks (i.e. TP/FP/FN masks) are computed and uploaded to a cloud storage for
     better visualization experience on our webapp. Please use `--write-bucket` argument to provide your AWS S3 bucket
     with write access where these result masks are going to be uploaded to. Also, follow the
-    [instructions](https://docs.kolena.io/advanced-usage/connecting-cloud-storage/amazon-s3/) to connect
+    [instructions](https://docs.kolena.io/connecting-cloud-storage/amazon-s3/) to connect
     your bucket to Kolena.
 
     The result masks will be stored under `s3://{args.write_bucket}/coco-stuff-10k/results/{args.model}/masks` directory

--- a/examples/workflow/README.md
+++ b/examples/workflow/README.md
@@ -1,8 +1,8 @@
 # Example Workflows
 
 This directory contains example Kolena integrations for different machine learning workflows. See the
-[Building a Workflow](https://docs.kolena.io/building-a-workflow/) guide to learn how to build a workflow to test any
-arbitrary ML problem.
+[Building a Workflow](https://docs.kolena.io/workflow/building-a-workflow/) guide to learn how to build a workflow to
+test any arbitrary ML problem.
 
 - [Age Estimation](./age_estimation): regression model tested using the
   [Labeled Faces in the Wild (LFW)](http://vis-www.cs.umass.edu/lfw/) dataset

--- a/examples/workflow/semantic_segmentation/README.md
+++ b/examples/workflow/semantic_segmentation/README.md
@@ -36,7 +36,7 @@ test suite.
     As part of the evaluation, result masks (i.e. TP/FP/FN masks) are computed and uploaded to a cloud storage for
     better visualization experience on our webapp. Please use `--out-bucket` argument to provide your AWS S3 bucket
     with write access where these result masks are going to be uploaded to. Also, follow the
-    [instructions](https://docs.kolena.io/advanced-usage/connecting-cloud-storage/amazon-s3/) to connect
+    [instructions](https://docs.kolena.io/connecting-cloud-storage/amazon-s3/) to connect
     your bucket to Kolena.
 
     The result masks will be stored under `s3://{args.out_bucket}/coco-stuff-10k/results/{args.model}` directory in


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?
[Quickstart page is removed](https://docs.kolena.io/quickstart/) after https://github.com/kolenaIO/kolena/pull/482. Moving references to `dataset/quickstart`

Also:
- `building-a-workflow` is moved down under `/workflow`
- `connecting-cloud-storage` has been bumped up from `/advanced-usage`

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
