### PR TITLE
chore: stick with the existing kolena client dependencies for python < 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ tqdm = ">=4,<5"
 Pillow = "^10.0.1"
 retrying = "^1.3.3"
 Shapely = [
-    { version = "^1.8.5", python = ">=3.8,<3.11" },
-    { version = "^2", python = ">=3.11" }
+    { version = "^1.8.5", python = ">=3.8,<3.12" },
+    { version = "^2", python = ">=3.12" }
 ]
 termcolor = "^1.1.0"
 pyarrow = ">=8"


### PR DESCRIPTION
### Linked issue(s)

follow up of https://github.com/kolenaIO/kolena/pull/487
- even though there is no 3.11 support on the [left panel of shapely pypi page](https://pypi.org/project/shapely/1.8.5.post1/), but they mentioned that 3.11 is supported in the README.

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
