### PR TITLE
Reduce warnings, improve log message

### DIFF
--- a/kolena/_utils/batched_load.py
+++ b/kolena/_utils/batched_load.py
@@ -49,7 +49,7 @@ def init_upload() -> API.InitiateUploadResponse:
 
 def upload_data_frame(df: pd.DataFrame, batch_size: int, load_uuid: str) -> None:
     num_chunks = math.ceil(len(df) / batch_size)
-    chunk_iter = np.array_split(df, num_chunks) if num_chunks > 0 else []
+    chunk_iter = np.array_split(df, num_chunks) if num_chunks > 1 else [df] if num_chunks > 0 else []
 
     # only display progress bar if there are multiple chunks to upload
     chunk_iter_logged = log.progress_bar(chunk_iter) if num_chunks > 1 else chunk_iter

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -185,7 +185,8 @@ def _prepare_upload_results_request(
     _validate_configs([cfg for cfg, _ in results])
     total_rows = 0
     for config, df_result_input in results:
-        log.info(f"uploading test results with configuration {config}" if config else "uploading test results")
+        log_slug = f"uploading results with configuration {config}" if config else "uploading results"
+        log.info(f"{log_slug} for model '{model}' on dataset '{dataset}'")
         if isinstance(df_result_input, pd.DataFrame):
             total_rows += df_result_input.shape[0]
             validate_dataframe_ids(df_result_input, id_fields)
@@ -216,8 +217,8 @@ def _upload_results(
 
     response = _send_upload_results_request(model, load_uuid, dataset_id, sources=sources)
     log.info(
-        f"uploaded test results for model '{model}' on dataset '{dataset}': "
-        f"{total_rows} uploaded, {response.n_inserted} inserted, {response.n_updated} updated",
+        f"uploaded {total_rows} results for model '{model}' on dataset '{dataset}' "
+        f"({response.n_inserted} inserted, {response.n_updated} updated)",
     )
     return response
 


### PR DESCRIPTION
- Reduce warnings from `np.array_split` not being well supported for Pandas DataFrames (https://github.com/numpy/numpy/issues/24889#issuecomment-1895503977)
- More explicit `upload_results` log message