### PR TITLE
Update docs to add cors policy for both .io and .com

### DIFF
--- a/docs/connecting-cloud-storage/amazon-s3.md
+++ b/docs/connecting-cloud-storage/amazon-s3.md
@@ -96,7 +96,10 @@ To configure CORS access, navigate to your S3 bucket inside your AWS console and
   {
     "AllowedHeaders": ["*"],
     "AllowedMethods": ["GET"],
-    "AllowedOrigins": ["https://app.kolena.io"],
+    "AllowedOrigins": [
+      "https://app.kolena.com",
+      "https://app.kolena.io"
+    ],
     "ExposeHeaders": []
   }
 ]

--- a/docs/connecting-cloud-storage/azure-blob-storage.md
+++ b/docs/connecting-cloud-storage/azure-blob-storage.md
@@ -82,4 +82,4 @@ In some scenarios, CORS permissions are required for Kolena to render content fr
 To configure CORS access, navigate to your storage account in the Azure portal and follow these steps:
 
 1. Click "Resource Sharing (CORS)" under "Settings"
-1. Add `https://app.kolena.io` as an allowed origin with `GET` as an allowed method
+1. Add `https://app.kolena.com` and `https://app.kolena.io` as allowed origins with `GET` as an allowed method

--- a/docs/connecting-cloud-storage/google-cloud-storage.md
+++ b/docs/connecting-cloud-storage/google-cloud-storage.md
@@ -38,7 +38,10 @@ Create a json file `cors.json` with the following content:
 ```json
 [
   {
-    "origin": ["https://app.kolena.io"],
+    "origin": [
+      "https://app.kolena.com",
+      "https://app.kolena.io"
+    ],
     "method": ["GET"],
     "responseHeader": ["Content-Type"],
     "maxAgeSeconds": 3600


### PR DESCRIPTION
### Linked issue(s)
Part of KOL-3715

### What change does this PR introduce and why?
Update cloud storage docs to add CORS policy for both `.com` and `.io` domains of Kolena.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
