### PR TITLE
Update references to kolena.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ---
 
-[Kolena](https://www.kolena.io) is a comprehensive machine learning testing and debugging platform to surface hidden
+[Kolena](https://www.kolena.com) is a comprehensive machine learning testing and debugging platform to surface hidden
 model behaviors and take the mystery out of model development. Kolena helps you:
 
 - Perform high-resolution model evaluation

--- a/docs/connecting-cloud-storage/amazon-s3.md
+++ b/docs/connecting-cloud-storage/amazon-s3.md
@@ -9,7 +9,7 @@ into your browser for visualization. In this tutorial, we'll learn how to establ
 Amazon S3.
 
 To get started, ensure you have administrator access within Kolena.
-Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations)
+Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization Settings](https://app.kolena.com/redirect/organization?tab=integrations)
 page and click "Add Integration", then "Amazon S3".
 
 ### Step 1: Select Integration Scope

--- a/docs/connecting-cloud-storage/azure-blob-storage.md
+++ b/docs/connecting-cloud-storage/azure-blob-storage.md
@@ -10,7 +10,7 @@ In this tutorial, we'll learn how to establish an integration between Kolena and
 Azure Blob Storage.
 
 To get started, ensure you have administrator access within Kolena.
-Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations)
+Navigate to the "Integrations" tab on the [:kolena-organization-16: Organization Settings](https://app.kolena.com/redirect/organization?tab=integrations)
 page and click "Add Integration", then "Azure Blob Storage".
 
 ### Step 1: Create Azure App Registration for Kolena

--- a/docs/connecting-cloud-storage/google-cloud-storage.md
+++ b/docs/connecting-cloud-storage/google-cloud-storage.md
@@ -10,12 +10,12 @@ between Kolena and Google Cloud Storage.
 
 To get started, ensure you have administrator access within Kolena.
 Navigate to the "Integrations" tab on the
-[:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations)
+[:kolena-organization-16: Organization Settings](https://app.kolena.com/redirect/organization?tab=integrations)
 page and click "Add Integration", then "Google Cloud Storage".
 
 ### Step 1: Save Integration to Create a Service Account
 
-From the [Integrations tab](https://app.kolena.io/redirect/organization?tab=integrations), saving a Google Cloud Storage
+From the [Integrations tab](https://app.kolena.com/redirect/organization?tab=integrations), saving a Google Cloud Storage
 integration will create a service account.
 Upon creation, the integration's `client_email` will be used to provide
 Kolena permission to load data from your Google Cloud Storage buckets.

--- a/docs/connecting-cloud-storage/http-basic.md
+++ b/docs/connecting-cloud-storage/http-basic.md
@@ -10,12 +10,12 @@ file-serving system that utilizes HTTP basic authentication.
 
 To get started, ensure you have administrator access within Kolena.
 Navigate to the "Integrations" tab on the
-[:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations)
+[:kolena-organization-16: Organization Settings](https://app.kolena.com/redirect/organization?tab=integrations)
 page and click "Add Integration", then "HTTP Basic".
 
 ### Step 1: Save Integration on Kolena
 
-On the [Integrations tab](https://app.kolena.io/redirect/organization?tab=integrations),
+On the [Integrations tab](https://app.kolena.com/redirect/organization?tab=integrations),
 fill in the fields for the integration and then click "Save".
 
 | Field | Description |

--- a/docs/connecting-cloud-storage/index.md
+++ b/docs/connecting-cloud-storage/index.md
@@ -10,7 +10,7 @@ Data such as images, videos, and documents hosted internally or with cloud stora
 creating an integration.
 
 Integrations can be managed by organization administrators by navigating to the "Integrations" tab on the
-[:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations) page.
+[:kolena-organization-16: Organization Settings](https://app.kolena.com/redirect/organization?tab=integrations) page.
 
 <div class="grid cards" markdown>
 - [:simple-amazons3: Amazon S3](./amazon-s3.md)

--- a/docs/connecting-cloud-storage/s3-compatible.md
+++ b/docs/connecting-cloud-storage/s3-compatible.md
@@ -17,7 +17,7 @@ S3-compatible API.
 
 To get started, ensure you have administrator access within Kolena.
 Navigate to the "Integrations" tab on the
-[:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=integrations)
+[:kolena-organization-16: Organization Settings](https://app.kolena.com/redirect/organization?tab=integrations)
 page and click "Add Integration", then "MinIO".
 
 Steps performed outside of Kolena are shown for a subset of possible S3-compatible systems.
@@ -71,7 +71,7 @@ Next, create the policy and attach the policy to the service user created in [st
 
 ### Step 3: Save Integration on Kolena
 
-Return to the Kolena platform [Integrations tab](https://app.kolena.io/redirect/organization?tab=integrations).
+Return to the Kolena platform [Integrations tab](https://app.kolena.com/redirect/organization?tab=integrations).
 
 By default, any locators beginning with `s3://` will be loaded using this integration.
 

--- a/docs/dataset/advanced-usage/set-up-natural-language-search.md
+++ b/docs/dataset/advanced-usage/set-up-natural-language-search.md
@@ -31,7 +31,7 @@ Let's take a look at each step with example code snippets.
 ### Step 1: Install `kolena-embeddings` Package
 
 The package can be installed via `pip` or `poetry` and requires use of your kolena token which can be created
-on the [:kolena-developer-16: Developer](https://app.kolena.io/redirect/developer) page.
+on the [:kolena-developer-16: Developer](https://app.kolena.com/redirect/developer) page.
 
 We first [retrieve and set](../../installing-kolena.md#initialization) our `KOLENA_TOKEN` environment variable.
 This is used by the uploader for authentication against your Kolena instance.
@@ -130,7 +130,7 @@ df_embeddings = pd.DataFrame(locator_and_embeddings, columns=["locator", "embedd
 upload_dataset_embeddings(dataset_name, model_key, df_embeddings)
 ```
 
-Once the upload completes, we can now visit [:kolena-dataset-20: Datasets](https://app.kolena.io/redirect/datasets),
+Once the upload completes, we can now visit [:kolena-dataset-20: Datasets](https://app.kolena.com/redirect/datasets),
 open the dataset and navigate to the <nobr>:kolena-studio-16: Studio</nobr> tab to search
 by natural language or similar images over the corresponding image data.
 

--- a/docs/dataset/formatting-your-datasets.md
+++ b/docs/dataset/formatting-your-datasets.md
@@ -28,7 +28,7 @@ accomplished by configuring an `id_field` - a unique identifier for a datapoint.
 unique across your data, or generate one if no unique identifiers exist for your dataset.
 
 Kolena will attempt to infer common `id_field`s (eg. `locator`, `text`) based on what is present in the dataset during import.
-This can be overriden by explicitly declaring id fields when importing via the Web App from the [:kolena-dataset-16: Datasets](https://app.kolena.io/redirect/datasets)
+This can be overriden by explicitly declaring id fields when importing via the Web App from the [:kolena-dataset-16: Datasets](https://app.kolena.com/redirect/datasets)
 page, or the SDK by using the [`upload_dataset`](../reference/dataset/index.md#kolena.dataset.dataset.upload_dataset)
 function.
 
@@ -187,7 +187,7 @@ df_merged = df_metadata.merge(df_boxes, on="locator")
 dataframe_to_csv(df_merged, "processed.csv")
 ```
 
-The file `processed.csv` can be uploaded through the [:kolena-dataset-16: Datasets](https://app.kolena.io/redirect/datasets)
+The file `processed.csv` can be uploaded through the [:kolena-dataset-16: Datasets](https://app.kolena.com/redirect/datasets)
 page.
 
 ### Formatting results for Object Detection
@@ -205,7 +205,7 @@ These columns are used to determine `True Postitives`, `False Positives`, and `F
 These results can be formatted for upload with a similar process as above. This is done by adding the relevant list of
 bounding boxes to the `matched_inference`, `unmatched_inference`, and `unmatched_ground_truth` columns for each image.
 The `results.csv` created can be uploaded by opening the corresponding dataset from the
-[:kolena-dataset-16: Datasets](https://app.kolena.io/redirect/datasets) page and navigating to the Studio section.
+[:kolena-dataset-16: Datasets](https://app.kolena.com/redirect/datasets) page and navigating to the Studio section.
 
 We have provided an [:kolena-widget-16: Object Detection (2D) ↗](https://github.com/kolenaIO/kolena/tree/trunk/examples/dataset/object_detection_2d)
 example that shows how to take raw results and perform bounding box matching to produce the values mentioned above.

--- a/docs/dataset/quickstart.md
+++ b/docs/dataset/quickstart.md
@@ -80,7 +80,7 @@ creating test cases.
     and register it as a dataset in Kolena using the `register_dataset` function.
 
     First, let's first configure our environment by populating the `KOLENA_TOKEN`
-    environment variable. Visit the [:kolena-developer-16: Developer](https://app.kolena.io/redirect/developer) page to
+    environment variable. Visit the [:kolena-developer-16: Developer](https://app.kolena.com/redirect/developer) page to
     generate an API token and copy and paste the code snippet into your environment:
 
     ```shell
@@ -94,7 +94,7 @@ creating test cases.
     ```
 
     After this script has completed, a new dataset named `300-W` will be created, which you can
-    see in [:kolena-dataset-20: Datasets](https://app.kolena.io/redirect/datasets).
+    see in [:kolena-dataset-20: Datasets](https://app.kolena.com/redirect/datasets).
 
 ## Step 2: Upload Model Results
 

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -36,7 +36,7 @@ If you don't see your question here, please reach out to us on Slack or at
     Kolena to only users on your corporate VPN.
 
     We support a variety of integration patterns depending on your organization's requirements and security stance.
-    [Get in touch with us to discuss details](https://www.kolena.io/schedule-a-demo)!
+    [Get in touch with us to discuss details](https://www.kolena.com/schedule-a-demo)!
 
 ??? faq "Do I have to upload my models to Kolena?"
 
@@ -53,14 +53,14 @@ If you don't see your question here, please reach out to us on Slack or at
 
 ??? faq "How do I generate an API token?"
 
-    Generate an API token by visiting the [:kolena-developer-16: Developer](https://app.kolena.io/redirect/developer)
+    Generate an API token by visiting the [:kolena-developer-16: Developer](https://app.kolena.com/redirect/developer)
     page, located at the bottom of the lefthand sidebar, then copy/paste the shell snippet to set this token as
     `KOLENA_TOKEN` in your environment.
 
 ??? faq "How many API tokens can I generate?"
 
     API tokens are scoped to your username. Each user is limited to one valid token at a time — generating a new token
-    on the [:kolena-developer-16: Developer](https://app.kolena.io/redirect/developer) page invalidates any previous
+    on the [:kolena-developer-16: Developer](https://app.kolena.com/redirect/developer) page invalidates any previous
     token generated for your user.
 
     To retrieve a service user API token that is not scoped to a specific username, please reach out to us on Slack or
@@ -85,7 +85,7 @@ If you don't see your question here, please reach out to us on Slack or at
 ??? faq "How can I add new users to my organization?"
 
     Administrators for your organization can add new users and grant users administrator privileges by visiting the
-    [:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization) page and adding
+    [:kolena-organization-16: Organization Settings](https://app.kolena.com/redirect/organization) page and adding
     entries to the **Authorized Users** table.
 
     Note that this page is only visible for organization administrators.
@@ -97,7 +97,7 @@ If you don't see your question here, please reach out to us on Slack or at
     as well as configure Integrations.
 
     You may become an administrator by having an existing administrator grant you privileges
-    using the [:kolena-organization-16: Organization Settings](https://app.kolena.io/redirect/organization?tab=users) page.
+    using the [:kolena-organization-16: Organization Settings](https://app.kolena.com/redirect/organization?tab=users) page.
 
 ??? faq "I'm new to Kolena — how can I learn more about the platform and how to use it?"
 
@@ -106,7 +106,7 @@ If you don't see your question here, please reach out to us on Slack or at
 
 ??? faq "How can I report a bug?"
 
-    If you encounter a bug when using the `kolena` Python client or when using [app.kolena.io](https://app.kolena.io),
+    If you encounter a bug when using the `kolena` Python client or when using [app.kolena.com](https://app.kolena.com),
     message us on Slack, email your support representative or [contact@kolena.com](mailto:contact@kolena.com), or
     [open an issue on the `kolena` repository](https://github.com/kolenaIO/kolena/issues) for Python-client-related
     issues.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ hide:
 
 ---
 
-[Kolena](https://www.kolena.io) is a comprehensive machine learning testing and debugging platform to surface hidden
+[Kolena](https://www.kolena.com) is a comprehensive machine learning testing and debugging platform to surface hidden
 model behaviors and take the mystery out of model development. Kolena helps you:
 
 - Perform high-resolution model evaluation
@@ -43,7 +43,7 @@ model behaviors and take the mystery out of model development. Kolena helps you:
 - Automate model testing and deployment workflows
 
 Kolena organizes your test data, stores and visualizes your model evaluations, and provides tooling to craft better
-tests. You interface with it through the web at [app.kolena.io](https://app.kolena.io) and programmatically via the
+tests. You interface with it through the web at [app.kolena.com](https://app.kolena.com) and programmatically via the
 [`kolena`](installing-kolena.md) Python client.
 
 ## Why Kolena?
@@ -92,7 +92,7 @@ We built Kolena to solve these two problems.
 
 ## Read More
 
-- Best Practices for ML Model Testing ([Kolena Blog](https://www.kolena.io/blog/best-practices-for-ml-model-testing))
+- Best Practices for ML Model Testing ([Kolena Blog](https://www.kolena.com/blog/best-practices-for-ml-model-testing))
 - Hidden Stratification Causes Clinically Meaningful Failures in Machine Learning for Medical Imaging ([arXiv:1909.12475](https://arxiv.org/abs/1909.12475))
 - No Subclass Left Behind: Fine-Grained Robustness in Coarse-Grained Classification Problems ([arXiv:2011.12945](https://arxiv.org/abs/2011.12945))
 

--- a/docs/installing-kolena.md
+++ b/docs/installing-kolena.md
@@ -50,7 +50,7 @@ Certain metrics computation functionality depends on additional packages like
 
 Once you have `kolena` installed, initialize a session with `kolena.initialize(api_token=token)`.
 
-From the [:kolena-developer-16: Developer](https://app.kolena.io/redirect/developer) page, generate an API token and set
+From the [:kolena-developer-16: Developer](https://app.kolena.com/redirect/developer) page, generate an API token and set
 the `KOLENA_TOKEN` environment variable:
 
 ```bash

--- a/docs/workflow/advanced-usage/index.md
+++ b/docs/workflow/advanced-usage/index.md
@@ -28,7 +28,7 @@ This section contains tutorial documentation for advanced features for Kolena Wo
     ---
 
     Upload and visualize your activation map for each [`TestSample`][kolena.workflow.TestSample] along with your model
-    results on the [<nobr>:kolena-studio-16: Studio</nobr>](https://app.kolena.io/redirect/studio).
+    results on the [<nobr>:kolena-studio-16: Studio</nobr>](https://app.kolena.com/redirect/studio).
 
 - [:kolena-comparison-16: Setting Up Natural Language Search](set-up-natural-language-search.md)
 
@@ -36,6 +36,6 @@ This section contains tutorial documentation for advanced features for Kolena Wo
 
     Extract and upload embeddings on each [`Image`][kolena.workflow.Image]
     to set up natural language and similarity search across image data and
-    results in the [<nobr>:kolena-studio-16: Studio</nobr>](https://app.kolena.io/redirect/studio).
+    results in the [<nobr>:kolena-studio-16: Studio</nobr>](https://app.kolena.com/redirect/studio).
 
 </div>

--- a/docs/workflow/advanced-usage/nesting-test-case-metrics.md
+++ b/docs/workflow/advanced-usage/nesting-test-case-metrics.md
@@ -106,7 +106,7 @@ describes performance for each of the given classes within the test case.
 
 When defining nested metrics, e.g. `PerClassMetrics` in the example above, it's important to identify each row by
 including at least one `str`-type column. This column, e.g. `Class` above, is pinned to the left when displaying nested
-metrics on the [:kolena-results-16: Results](https://app.kolena.io/redirect/results) page.
+metrics on the [:kolena-results-16: Results](https://app.kolena.com/redirect/results) page.
 
 ## Statistical Significance
 

--- a/docs/workflow/advanced-usage/packaging-for-automated-evaluation.md
+++ b/docs/workflow/advanced-usage/packaging-for-automated-evaluation.md
@@ -210,7 +210,7 @@ option.
 At this point, we are all set to leverage Kolena's automatic metrics evaluation capability. To see it in
 action, let's first use Kolena's Studio to curate a new test case.
 
-Head over to the [:kolena-studio-16: Studio](https://app.kolena.io/redirect/studio) and use the "Explore" tab to learn
+Head over to the [:kolena-studio-16: Studio](https://app.kolena.com/redirect/studio) and use the "Explore" tab to learn
 more about the test samples from a given test case.
 Select multiple test samples of interest and then go to the "Create" tab to create a new test case with the
 "Create Test Case" button. You will notice there's an option to compute metrics on this new test case for applicable
@@ -245,7 +245,7 @@ docker run --rm \
   <evaluator-docker-image>
 ```
 
-You can find a test suite's version on the [:kolena-test-suite-16: Test Suites](https://app.kolena.io/redirect/testing)
+You can find a test suite's version on the [:kolena-test-suite-16: Test Suites](https://app.kolena.com/redirect/testing)
 page. By default, the latest version is displayed.
 
 ### Using docker.kolena.io
@@ -254,7 +254,7 @@ In this tutorial, we published an evaluator container image to `docker.kolena.io
 section, we'll explain how to use the Docker CLI to interact with `docker.kolena.io`.
 
 The first step is to use `docker login` to log into `docker.kolena.io`. Using your organization's name (e.g.
-`my-organization`, the part after `app.kolena.io` when you visit the app) as a username and
+`my-organization`, the part after `app.kolena.com` when you visit the app) as a username and
 your API token as a password, log in with the following command:
 
 ```shell

--- a/docs/workflow/advanced-usage/set-up-natural-language-search.md
+++ b/docs/workflow/advanced-usage/set-up-natural-language-search.md
@@ -30,7 +30,7 @@ Let's take a look at each step with example code snippets.
 ### Step 1: Install `kolena_embeddings` Package
 
 The package can be installed via `pip` or `poetry` and requires use of your kolena token which can be created
-on the [:kolena-developer-16: Developer](https://app.kolena.io/redirect/developer) page.
+on the [:kolena-developer-16: Developer](https://app.kolena.com/redirect/developer) page.
 
 === "`pip`"
 
@@ -134,7 +134,7 @@ locators = [
 extract_and_upload_embeddings(iter_image_locators(locators))
 ```
 
-Once the upload completes, we can now visit [<nobr>:kolena-studio-16: Studio</nobr>](https://app.kolena.io/redirect/studio)
+Once the upload completes, we can now visit [<nobr>:kolena-studio-16: Studio</nobr>](https://app.kolena.com/redirect/studio)
 to search by natural language over the corresponding [`Image`][kolena.workflow.Image] data.
 
 ## Conclusion

--- a/docs/workflow/advanced-usage/uploading-activation-maps.md
+++ b/docs/workflow/advanced-usage/uploading-activation-maps.md
@@ -29,7 +29,7 @@ are interested in learning more about them, here is a list of some of the popula
 ## Can I Visualize Activation Maps on Kolena?
 
 Yes! Activation maps can be visualized as an overlay on the corresponding image in
-[<nobr>:kolena-studio-16: Studio</nobr>](https://app.kolena.io/redirect/studio) using the
+[<nobr>:kolena-studio-16: Studio</nobr>](https://app.kolena.com/redirect/studio) using the
 [`BitmapMask`][kolena.workflow.annotation.BitmapMask]
 annotation type which can help us understand the model’s decision — what
 the model “sees” when it makes its prediction.
@@ -144,7 +144,7 @@ class Inference(Inf):
 
 Before you run tests, make sure to update your `infer` function to return an `Inference` with the corresponding
 `BitmapMask` as its `activation_map` field. You are now ready to run tests! Once the tests complete, we can now visit
-[<nobr>:kolena-studio-16: Studio</nobr>](https://app.kolena.io/redirect/studio)
+[<nobr>:kolena-studio-16: Studio</nobr>](https://app.kolena.com/redirect/studio)
 to visualize activation maps overlaid on your [`Image`][kolena.workflow.Image] data.
 
 ## Conclusion

--- a/docs/workflow/building-a-workflow.md
+++ b/docs/workflow/building-a-workflow.md
@@ -179,7 +179,7 @@ class TestCaseMetrics(MetricsTestCase):
 !!! tip "Tip: Plots"
 
     Evaluators can also compute test-case-level plots using the [`Plot`][kolena.workflow.Plot] API. These plots are
-    visualized on the [:kolena-results-16: Results](https://app.kolena.io/redirect/results) dashboard alongside the
+    visualized on the [:kolena-results-16: Results](https://app.kolena.com/redirect/results) dashboard alongside the
     metrics reported for each test case.
 
 !!! tip "Tip: Test Suite Metrics"
@@ -214,7 +214,7 @@ test_case = TestCase(f"{DATASET} :: basic", test_samples=ts_with_gt)
 
     In this tutorial we created only a single simple test case, but more advanced test cases can be generated in a
     variety of fast and scalable ways, either programmatically with the `kolena` Python client or visually in the
-    [:kolena-studio-16: Studio](https://app.kolena.io/redirect/studio).
+    [:kolena-studio-16: Studio](https://app.kolena.com/redirect/studio).
 
 Now that we have a basic test case for our entire dataset let's create a test suite for it:
 
@@ -320,7 +320,7 @@ test(
 )
 ```
 
-That wraps up the testing process! We can now visit [:kolena-results-16: Results](https://app.kolena.io/redirect/results)
+That wraps up the testing process! We can now visit [:kolena-results-16: Results](https://app.kolena.com/redirect/results)
 to analyze and debug our model's performance on this test suite.
 
 ### Conclusion

--- a/docs/workflow/core-concepts/model.md
+++ b/docs/workflow/core-concepts/model.md
@@ -9,7 +9,7 @@ search:
 In Kolena, a model is a deterministic transformation from [test samples](workflow.md#test-sample) to
 [inferences](workflow.md#inference).
 
-Kolena only stores metadata associated with your model in its [:kolena-model-16: Models](https://app.kolena.io/redirect/models)
+Kolena only stores metadata associated with your model in its [:kolena-model-16: Models](https://app.kolena.com/redirect/models)
 registry. Models themselves — their code or their weights — are never uploaded to Kolena, only the inferences from models.
 
 Models are considered black boxes, which makes Kolena agnostic to the underlying framework
@@ -114,7 +114,7 @@ associate with the model. This metadata can be useful to track relevant informat
 - Hyperparameters applied during training
 
 Metadata can be specified on the command line or edited on the web on the
-[:kolena-model-16: Models](https://app.kolena.io/redirect/models) page.
+[:kolena-model-16: Models](https://app.kolena.com/redirect/models) page.
 
 ## FAQ & Best Practices
 
@@ -139,4 +139,4 @@ Metadata can be specified on the command line or edited on the web on the
     helpful-meadow-5 (YOLOR-D6, 1280x1280, pytorch-1.7)
     ```
 
-    Model names can be edited on the web on the [:kolena-model-16: Models](https://app.kolena.io/redirect/models) page.
+    Model names can be edited on the web on the [:kolena-model-16: Models](https://app.kolena.com/redirect/models) page.

--- a/docs/workflow/core-concepts/test-suite.md
+++ b/docs/workflow/core-concepts/test-suite.md
@@ -14,7 +14,7 @@ a benchmark dataset.
 
 A **test suite** is a collection of test cases. Models are tested on test suites.
 
-Test cases and test suites are found on the [:kolena-test-suite-16: Test Suites](https://app.kolena.io/redirect/testing)
+Test cases and test suites are found on the [:kolena-test-suite-16: Test Suites](https://app.kolena.com/redirect/testing)
 page on Kolena.
 
 ## Managing Test Cases & Test Suites
@@ -132,7 +132,7 @@ All test data on Kolena is versioned and immutable[^1]. Previous versions of tes
 available and can be visualized on the web and loaded programmatically by specifying a version.
 
 [^1]: Immutability caveat: test suites, along with any test cases and test samples they hold, can be deleted on the
-    [:kolena-test-suite-16: Test Suites](https://app.kolena.io/redirect/testing) page.
+    [:kolena-test-suite-16: Test Suites](https://app.kolena.com/redirect/testing) page.
 
 ```python
 # load a specific version of a test suite

--- a/docs/workflow/core-concepts/workflow.md
+++ b/docs/workflow/core-concepts/workflow.md
@@ -123,7 +123,7 @@ class QuadImage(Composite):
 The ground truth represents the expected output from a model when provided with a test sample. Ground truths are often
 manually annotated and are used to determine the correctness of model predictions.
 
-In the [:kolena-studio-16: Studio](https://app.kolena.io/redirect/studio), ground truths are always displayed alongside
+In the [:kolena-studio-16: Studio](https://app.kolena.com/redirect/studio), ground truths are always displayed alongside
 their paired test samples. Any [annotations][kolena.workflow.annotation.Annotation], such as bounding boxes or polygons,
 are visualized on top of the test sample.
 

--- a/docs/workflow/quickstart.md
+++ b/docs/workflow/quickstart.md
@@ -176,7 +176,7 @@ Each of the example integrations comes with scripts for two flows:
 
 Before running [`seed_test_suite.py`](https://github.com/kolenaIO/kolena/blob/trunk/examples/workflow/object_detection_2d/object_detection_2d/seed_test_suite.py),
 let's first configure our environment by populating the `KOLENA_TOKEN`
-environment variable. Visit the [:kolena-developer-16: Developer](https://app.kolena.io/redirect/developer) page to
+environment variable. Visit the [:kolena-developer-16: Developer](https://app.kolena.com/redirect/developer) page to
 generate an API token and copy and paste the code snippet into your environment:
 
 ```shell
@@ -189,7 +189,7 @@ We can now create test suites using the provided seeding script:
 poetry run python3 object_detection_2d/seed_test_suite.py
 ```
 
-After this script has completed, we can visit the [:kolena-test-suite-16: Test Suites](https://app.kolena.io/redirect/testing)
+After this script has completed, we can visit the [:kolena-test-suite-16: Test Suites](https://app.kolena.com/redirect/testing)
 page to view our newly created test suites.
 
 In this `object_detection_2d` example,
@@ -213,7 +213,7 @@ poetry run python3 object_detection_2d/seed_test_run.py "yolo_v4s"
     plug it into the `infer` method in [`seed_test_run.py`](https://github.com/kolenaIO/kolena/blob/trunk/examples/workflow/object_detection_2d/object_detection_2d/seed_test_run.py).
 
 Once this script has completed, click the results link in your console or visit
-[:kolena-results-16: Results](https://app.kolena.io/redirect/results) to view the test results for this newly tested model.
+[:kolena-results-16: Results](https://app.kolena.com/redirect/results) to view the test results for this newly tested model.
 
 ## Conclusion
 

--- a/examples/dataset/automatic_speech_recognition/README.md
+++ b/examples/dataset/automatic_speech_recognition/README.md
@@ -59,7 +59,7 @@ optional arguments:
 
 ## Quality Standards Guide
 
-Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.io/redirect/) to
+Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.com/redirect/) to
 test the automatic speech recognition models. See our [QuickStart](https://docs.kolena.com/dataset/quickstart/) guide
 for details.
 

--- a/examples/dataset/classification/README.md
+++ b/examples/dataset/classification/README.md
@@ -92,7 +92,7 @@ optional arguments:
 
 ## Quality Standards Guide
 
-Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.io/redirect/) to
+Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.com/redirect/) to
 [explore the data and results](https://docs.kolena.com/dataset/quickstart/#step-3-explore-data-and-results).
 
 Here are our [Quality Standards](https://docs.kolena.com/dataset/core-concepts/quality-standard/) recommendations for

--- a/examples/dataset/keypoint_detection/README.md
+++ b/examples/dataset/keypoint_detection/README.md
@@ -51,7 +51,7 @@ optional arguments:
 
 ## Quality Standards Guide
 
-Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.io/redirect/) to
+Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.com/redirect/) to
 [explore the data and results](https://docs.kolena.com/dataset/quickstart/#step-3-explore-data-and-results).
 
 Here are our [Quality Standards](https://docs.kolena.com/dataset/core-concepts/quality-standard/) recommendations for

--- a/examples/dataset/object_detection_2d/README.md
+++ b/examples/dataset/object_detection_2d/README.md
@@ -55,7 +55,7 @@ optional arguments:
 
 ## Quality Standards Guide
 
-Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.io/redirect/) to
+Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.com/redirect/) to
 [explore the data and results](https://docs.kolena.com/dataset/quickstart/#step-3-explore-data-and-results).
 
 Here are our [Quality Standards](https://docs.kolena.com/dataset/core-concepts/quality-standard/) recommendations

--- a/examples/dataset/question_answering/README.md
+++ b/examples/dataset/question_answering/README.md
@@ -72,7 +72,7 @@ optional arguments:
 
 ## Quality Standards Guide
 
-Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.io/redirect/) to
+Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.com/redirect/) to
 [explore the data and results](https://docs.kolena.com/dataset/quickstart/#step-3-explore-data-and-results).
 
 Here are our [Quality Standards](https://docs.kolena.com/dataset/core-concepts/quality-standard/) recommendations for

--- a/examples/dataset/rain_forecast/README.md
+++ b/examples/dataset/rain_forecast/README.md
@@ -43,7 +43,7 @@ optional arguments:
 
 ## Quality Standards Guide
 
-Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.io/redirect/) to
+Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.com/redirect/) to
 test the rain forecast models. See our [QuickStart](https://docs.kolena.com/dataset/quickstart/) guide
 for details.
 

--- a/examples/dataset/rain_forecast/pyproject.toml
+++ b/examples/dataset/rain_forecast/pyproject.toml
@@ -2,7 +2,7 @@
 name = "rain_forecast"
 version = "0.1.0"
 description = "Kolena Datasets Example integration for rain forecast"
-authors = ["Kolena Engineering <eng@kolena.io>"]
+authors = ["Kolena Engineering <eng@kolena.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]

--- a/examples/dataset/search_embeddings/README.md
+++ b/examples/dataset/search_embeddings/README.md
@@ -50,4 +50,4 @@ options:
 ```
 
 Once the embeddings have been extracted, you will be able to search the relevant
-age estimation test suite in the [Kolena Studio](https://app.kolena.io/redirect/studio) using natural language.
+age estimation test suite in the [Kolena Studio](https://app.kolena.com/redirect/studio) using natural language.

--- a/examples/dataset/semantic_segmentation/README.md
+++ b/examples/dataset/semantic_segmentation/README.md
@@ -64,7 +64,7 @@ optional arguments:
 
 ## Quality Standards Guide
 
-Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.io/redirect/) to
+Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.com/redirect/) to
 test the semantic segmentation models. See our [QuickStart](https://docs.kolena.com/dataset/quickstart/) guide
 for details.
 

--- a/examples/dataset/speaker_diarization/README.md
+++ b/examples/dataset/speaker_diarization/README.md
@@ -69,7 +69,7 @@ optional arguments:
 
 ## Quality Standards Guide
 
-Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.io/redirect/) to
+Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.com/redirect/) to
 [explore the data and results](https://docs.kolena.com/dataset/quickstart/#step-3-explore-data-and-results).
 
 Here are our [Quality Standards](https://docs.kolena.com/dataset/core-concepts/quality-standard/) recommendations for

--- a/examples/dataset/speaker_diarization/pyproject.toml
+++ b/examples/dataset/speaker_diarization/pyproject.toml
@@ -2,7 +2,7 @@
 name = "speaker-diarization"
 version = "0.1.0"
 description = "Example Kolena integration for speaker diarization"
-authors = ["Kolena Engineering <eng@kolena.io>"]
+authors = ["Kolena Engineering <eng@kolena.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]

--- a/examples/dataset/text_summarization/README.md
+++ b/examples/dataset/text_summarization/README.md
@@ -56,7 +56,7 @@ optional arguments:
 
 ## Quality Standards Guide
 
-Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.io/redirect/) to
+Once the dataset and results have been uploaded to Kolena, visit [Kolena](https://app.kolena.com/redirect/) to
 [explore the data and results](https://docs.kolena.com/dataset/quickstart/#step-3-explore-data-and-results).
 
 Here are our [Quality Standards](https://docs.kolena.com/dataset/core-concepts/quality-standard/) recommendations for

--- a/examples/workflow/object_detection_3d/README.md
+++ b/examples/workflow/object_detection_3d/README.md
@@ -48,7 +48,7 @@ The script generates a file containing structured test samples and ground truths
 velodyne binary file under `$datadir/velodyne_pcd`. Upload the camera images and pointcloud files to the cloud storage
 location specified in the argument `remote_prefix`, mirroring the directory structure as described in
 [Data preparation](#data-preparation) section, you can then view the images and visualize pointcloud data in
-[Kolena studio](https://app.kolena.io/redirect/studio) after a test suite is created in
+[Kolena studio](https://app.kolena.com/redirect/studio) after a test suite is created in
 [Kolena Integration](#kolena-integration).
 
 ### Test the model

--- a/examples/workflow/search_embeddings/README.md
+++ b/examples/workflow/search_embeddings/README.md
@@ -45,4 +45,4 @@ optional arguments:
 ```
 
 Once the embeddings have been extracted, you will be able to search the relevant
-age estimation test suite in the [Kolena Studio](https://app.kolena.io/redirect/studio) using natural language.
+age estimation test suite in the [Kolena Studio](https://app.kolena.com/redirect/studio) using natural language.

--- a/kolena/_utils/endpoints.py
+++ b/kolena/_utils/endpoints.py
@@ -47,7 +47,7 @@ def _get_platform_origin(client_state: _ClientState) -> str:
     hostname = base_url.hostname or ""
     gateway_subdomain, *_ = hostname.split(".")
     subdomain = "trunk" if "trunk" in gateway_subdomain else "app"
-    return f"https://{subdomain}.kolena.io"
+    return f"https://{subdomain}.kolena.com"
 
 
 def get_results_url(workflow: str, model_id: int, test_suite_id: int) -> str:

--- a/kolena/initialize.py
+++ b/kolena/initialize.py
@@ -46,7 +46,7 @@ def initialize(
 
     A session has a global scope and remains active until interpreter shutdown.
 
-    Retrieve an API token from the [:kolena-developer-16: Developer](https://app.kolena.io/redirect/developer) page and
+    Retrieve an API token from the [:kolena-developer-16: Developer](https://app.kolena.com/redirect/developer) page and
     make it available through one of the following options before initializing:
 
 

--- a/kolena/workflow/plot.py
+++ b/kolena/workflow/plot.py
@@ -14,7 +14,7 @@
 """
 This module surfaces plot definitions to visualize test-case-level data. [Evaluator](evaluator.md) implementations can
 optionally compute plots using these definitions for visualization on the
-[:kolena-results-16: Results](https://app.kolena.io/redirect/results) page.
+[:kolena-results-16: Results](https://app.kolena.com/redirect/results) page.
 
 The following plot types are available:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,7 +111,7 @@ nav:
       - metrics/statistical-significance.md
   - Help & FAQ:
     - Help & FAQ: faq/index.md
-  - Sign in ↗: https://app.kolena.io
+  - Sign in ↗: https://app.kolena.com
 
 theme:
   name: material
@@ -232,7 +232,7 @@ extra:
       link: https://github.com/kolenaIO/kolena
       name: Kolena on GitHub
     - icon: kolena/logo
-      link: https://app.kolena.io
+      link: https://app.kolena.com
       name: Kolena Platform
   dd_rum:
     client_token: !ENV [ DD_RUM_CLIENT_TOKEN, blank ]

--- a/tests/unit/utils/test_endpoints.py
+++ b/tests/unit/utils/test_endpoints.py
@@ -42,8 +42,8 @@ def assert_url_equals(a: str, b: str) -> None:
 @pytest.mark.parametrize(
     "client_state,expected",
     [
-        (_ClientState(tenant="test-tenant"), "https://app.kolena.io/test-tenant"),
-        (_ClientState(tenant="test-tenant", base_url=BASE_URL_TRUNK), "https://trunk.kolena.io/test-tenant"),
+        (_ClientState(tenant="test-tenant"), "https://app.kolena.com/test-tenant"),
+        (_ClientState(tenant="test-tenant", base_url=BASE_URL_TRUNK), "https://trunk.kolena.com/test-tenant"),
         (_ClientState(tenant="test-tenant", base_url=BASE_URL_LOCALHOST), "http://localhost:3000/test-tenant"),
     ],
 )
@@ -57,12 +57,12 @@ def test__get_platform_url(client_state: _ClientState, expected: str) -> None:
         (
             _ClientState(tenant="test-tenant"),
             WorkflowType.FR.value,
-            "https://app.kolena.io/test-tenant/results/fr?modelIds=1&testSuiteId=2",
+            "https://app.kolena.com/test-tenant/results/fr?modelIds=1&testSuiteId=2",
         ),
         (
             _ClientState(tenant="test-tenant", base_url=BASE_URL_TRUNK),
             WorkflowType.FR.value,
-            "https://trunk.kolena.io/test-tenant/results/fr?modelIds=1&testSuiteId=2",
+            "https://trunk.kolena.com/test-tenant/results/fr?modelIds=1&testSuiteId=2",
         ),
         (
             _ClientState(tenant="test-tenant", base_url=BASE_URL_LOCALHOST),
@@ -72,22 +72,22 @@ def test__get_platform_url(client_state: _ClientState, expected: str) -> None:
         (
             _ClientState(tenant="test-tenant"),
             WorkflowType.DETECTION.value,
-            "https://app.kolena.io/test-tenant/results/object-detection?modelIds=1&testSuiteId=2",
+            "https://app.kolena.com/test-tenant/results/object-detection?modelIds=1&testSuiteId=2",
         ),
         (
             _ClientState(tenant="test-tenant"),
             WorkflowType.CLASSIFICATION.value,
-            "https://app.kolena.io/test-tenant/results/classification?modelIds=1&testSuiteId=2",
+            "https://app.kolena.com/test-tenant/results/classification?modelIds=1&testSuiteId=2",
         ),
         (
             _ClientState(tenant="test-tenant"),
             "example-workflow",
-            "https://app.kolena.io/test-tenant/results?modelIds=1&testSuiteId=2&workflow=example-workflow",
+            "https://app.kolena.com/test-tenant/results?modelIds=1&testSuiteId=2&workflow=example-workflow",
         ),
         (
             _ClientState(tenant="test-tenant"),
             "Example Workflow",
-            "https://app.kolena.io/test-tenant/results?modelIds=1&testSuiteId=2&workflow=Example+Workflow",
+            "https://app.kolena.com/test-tenant/results?modelIds=1&testSuiteId=2&workflow=Example+Workflow",
         ),
     ],
 )
@@ -98,8 +98,8 @@ def test__get_results_url(client_state: _ClientState, workflow: Union[Workflow, 
 @pytest.mark.parametrize(
     "client_state,expected",
     [
-        (_ClientState(tenant="a"), "https://app.kolena.io/a/testing?testSuiteId=1"),
-        (_ClientState(tenant="b", base_url=BASE_URL_TRUNK), "https://trunk.kolena.io/b/testing?testSuiteId=1"),
+        (_ClientState(tenant="a"), "https://app.kolena.com/a/testing?testSuiteId=1"),
+        (_ClientState(tenant="b", base_url=BASE_URL_TRUNK), "https://trunk.kolena.com/b/testing?testSuiteId=1"),
         (_ClientState(tenant="c", base_url=BASE_URL_LOCALHOST), "http://localhost:3000/c/testing?testSuiteId=1"),
     ],
 )
@@ -110,8 +110,8 @@ def test__get_test_suite_url(client_state: _ClientState, expected: str) -> None:
 @pytest.mark.parametrize(
     "client_state,expected",
     [
-        (_ClientState(tenant="a"), "https://app.kolena.io/a/models?modelIds=1"),
-        (_ClientState(tenant="b", base_url=BASE_URL_TRUNK), "https://trunk.kolena.io/b/models?modelIds=1"),
+        (_ClientState(tenant="a"), "https://app.kolena.com/a/models?modelIds=1"),
+        (_ClientState(tenant="b", base_url=BASE_URL_TRUNK), "https://trunk.kolena.com/b/models?modelIds=1"),
         (_ClientState(tenant="c", base_url=BASE_URL_LOCALHOST), "http://localhost:3000/c/models?modelIds=1"),
     ],
 )


### PR DESCRIPTION
### Linked issue(s)
https://linear.app/kolena/issue/KOL-3715/migrate-to-appkolenacom

### What change does this PR introduce and why?
Resolves KOL-3715
Update all references from `kolena.io` to `kolena.com`


### Verification
Running `git grep kolena.io` - the remaining references fall into the following categories:
- Syncing the `.io` doc buckets
- CNAME: can be ignored given cloudfront distribution
- CORS doc: intentionally left for customers to add both `.io` and `.com`
- `kolena.io` python module
- `docker.kolena.io` and `api.kolena.io`: no plan to migrate to `.com`

```
.github/workflows/docs.yml:          aws s3 sync ./site "s3://trunk-docs.kolena.io" --delete
.github/workflows/docs.yml:          aws s3 sync ./site "s3://docs.kolena.io" --delete
.github/workflows/release.yml:          aws s3 sync ./site "s3://docs.kolena.io" --delete
docs/CNAME:docs.kolena.io
docs/connecting-cloud-storage/amazon-s3.md:      "https://app.kolena.io"
docs/connecting-cloud-storage/azure-blob-storage.md:1. Add `https://app.kolena.com` and `https://app.kolena.io` as allowed origins with `GET` as an allowed method
docs/connecting-cloud-storage/google-cloud-storage.md:      "https://app.kolena.io"
docs/dataset/formatting-your-datasets.md:[`dataframe_to_csv()`](../reference/io.md#kolena.io.dataframe_to_csv) function provided by Kolena to save a `.csv` file
docs/dataset/formatting-your-datasets.md:from kolena.io import dataframe_to_csv
docs/faq/index.md:    [`dataframe_to_csv`](../reference/io.md#kolena.io.dataframe_to_csv) for a drop-in replacement.
docs/reference/index.md:- [`kolena.io`](./io.md)
docs/reference/io.md:::: kolena.io
docs/workflow/advanced-usage/packaging-for-automated-evaluation.md:DOCKER_REGISTRY="docker.kolena.io"
docs/workflow/advanced-usage/packaging-for-automated-evaluation.md:### Using docker.kolena.io
docs/workflow/advanced-usage/packaging-for-automated-evaluation.md:In this tutorial, we published an evaluator container image to `docker.kolena.io`, Kolena's Docker Registry. In this
docs/workflow/advanced-usage/packaging-for-automated-evaluation.md:section, we'll explain how to use the Docker CLI to interact with `docker.kolena.io`.
docs/workflow/advanced-usage/packaging-for-automated-evaluation.md:The first step is to use `docker login` to log into `docker.kolena.io`. Using your organization's name (e.g.
docs/workflow/advanced-usage/packaging-for-automated-evaluation.md:echo $KOLENA_TOKEN | docker login --username my-organization --password-stdin docker.kolena.io
docs/workflow/advanced-usage/packaging-for-automated-evaluation.md:docker pull docker.kolena.io/my-organization/<docker-image-tag>
docs/workflow/advanced-usage/packaging-for-automated-evaluation.md:`docker.kolena.io` first. As mentioned in [Register Evaluator for Workflow](#register-evaluator-for-workflow), the
docs/workflow/advanced-usage/packaging-for-automated-evaluation.md:After the repository is created, we can use the Docker CLI to publish a newly built Docker image to `docker.kolena.io`:
docs/workflow/advanced-usage/packaging-for-automated-evaluation.md:docker push docker.kolena.io/my-organization/new-evaluator:v1
docs/workflow/advanced-usage/packaging-for-automated-evaluation.md:  "image": "docker.kolena.io/my-organization/keypoint_detection_evaluator:v1",
examples/dataset/keypoint_detection/keypoint_detection/upload_results.py:from kolena.io import dataframe_from_csv
examples/dataset/text_summarization/text_summarization/upload_dataset.py:from kolena.io import dataframe_from_csv
kolena/_utils/state.py:API_URL = "https://api.kolena.io"
kolena/dataset/dataset.py:from kolena.io import _dataframe_object_serde
kolena/initialize.py:    machine api.kolena.io password ********
kolena/io.py:`kolena.io` provides helper functions for converting `pandas.DataFrame`s containing
kolena/workflow/io.py:from kolena.io import dataframe_from_csv
kolena/workflow/io.py:from kolena.io import dataframe_from_json
kolena/workflow/io.py:from kolena.io import dataframe_to_csv
mkdocs.yml:    - <code>kolena.io</code>: reference/io.md
tests/unit/dataset/test_dataset.py:        ("https://kolena.io/demo.mp4", DatapointType.VIDEO),
tests/unit/test_initialize.py:    base_url = "https://internal-api.kolena.io"
tests/unit/test_io.py:from kolena.io import dataframe_from_csv
```

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
