### PR TITLE
feat: Support unlabeled object annotations via `upload_object_detection_results`

### DIFF
--- a/kolena/_experimental/instance_segmentation/__init__.py
+++ b/kolena/_experimental/instance_segmentation/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from .dataset import upload_instance_segmentation_results
 from .evaluator import InstanceSegmentationEvaluator
 from .workflow import EvaluatorConfiguration
 from .workflow import GroundTruth
@@ -29,4 +30,5 @@ __all__ = [
     "TestCase",
     "TestSuite",
     "InstanceSegmentationEvaluator",
+    "upload_instance_segmentation_results",
 ]

--- a/kolena/_experimental/instance_segmentation/dataset.py
+++ b/kolena/_experimental/instance_segmentation/dataset.py
@@ -1,0 +1,36 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from kolena._experimental.object_detection.dataset import upload_object_detection_results
+
+
+upload_instance_segmentation_results = upload_object_detection_results
+"""
+Compute metrics and upload results of the model for the dataset.
+
+Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
+:inference in the Dataframe `df` should be a list of scored [`Polygons`][kolena.annotation.Polygon].
+
+:param dataset_name: Dataset name.
+:param model_name: Model name.
+:param df: Dataframe for model results.
+:param ground_truths_field: Field name in datapoint with ground truth polygons, defaulting to `"ground_truths"`.
+:param raw_inferences_field: Column in model result DataFrame with raw inference polygons,
+defaulting to `"raw_inferences"`.
+:param iou_threshold: The [IoU ↗](../../metrics/iou.md) threshold, defaulting to `0.5`.
+:param threshold_strategy: The confidence threshold strategy. It can either be a fixed confidence threshold such
+    as `0.5` or `0.75`, or `"F1-Optimal"` to find the threshold maximizing F1 score..
+:param min_confidence_score: The minimum confidence score to consider for the evaluation. This is usually set to
+    reduce noise by excluding inferences with low confidence score.
+:return:
+"""

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -26,9 +26,7 @@ from kolena import dataset
 from kolena._experimental.object_detection.utils import compute_optimal_f1_threshold
 from kolena._experimental.object_detection.utils import compute_optimal_f1_threshold_multiclass
 from kolena._experimental.object_detection.utils import filter_inferences
-from kolena.annotation import LabeledBoundingBox
 from kolena.annotation import ScoredLabel
-from kolena.annotation import ScoredLabeledBoundingBox
 from kolena.errors import IncorrectUsageError
 from kolena.metrics import InferenceMatches
 from kolena.metrics import match_inferences
@@ -36,18 +34,18 @@ from kolena.workflow.metrics import match_inferences_multiclass
 from kolena.workflow.metrics import MulticlassInferenceMatches
 
 
-def single_class_datapoint_metrics(bbox_matches: InferenceMatches, thresholds: float) -> Dict[str, Any]:
-    tp = [inf for _, inf in bbox_matches.matched if inf.score >= thresholds]
-    fp = [inf for inf in bbox_matches.unmatched_inf if inf.score >= thresholds]
-    fn = bbox_matches.unmatched_gt + [gt for gt, inf in bbox_matches.matched if inf.score < thresholds]
+def single_class_datapoint_metrics(object_matches: InferenceMatches, thresholds: float) -> Dict[str, Any]:
+    tp = [inf for _, inf in object_matches.matched if inf.score >= thresholds]
+    fp = [inf for inf in object_matches.unmatched_inf if inf.score >= thresholds]
+    fn = object_matches.unmatched_gt + [gt for gt, inf in object_matches.matched if inf.score < thresholds]
     scores = [inf.score for inf in tp + fp]
     return dict(
         TP=tp,
         FP=fp,
         FN=fn,
-        matched_inference=[inf for _, inf in bbox_matches.matched],
-        unmatched_ground_truth=bbox_matches.unmatched_gt,
-        unmatched_inference=bbox_matches.unmatched_inf,
+        matched_inference=[inf for _, inf in object_matches.matched],
+        unmatched_ground_truth=object_matches.unmatched_gt,
+        unmatched_inference=object_matches.unmatched_inf,
         count_TP=len(tp),
         count_FP=len(fp),
         count_FN=len(fn),
@@ -61,40 +59,26 @@ def single_class_datapoint_metrics(bbox_matches: InferenceMatches, thresholds: f
 
 
 def multiclass_datapoint_metrics(
-    bbox_matches: MulticlassInferenceMatches,
+    object_matches: MulticlassInferenceMatches,
     thresholds: Dict[str, float],
 ) -> Dict[str, Any]:
-    tp = [inf for _, inf in bbox_matches.matched if inf.score >= thresholds[inf.label]]
-    fp = [inf for inf in bbox_matches.unmatched_inf if inf.score >= thresholds[inf.label]]
-    fn = [gt for gt, _ in bbox_matches.unmatched_gt] + [
-        gt for gt, inf in bbox_matches.matched if inf.score < thresholds[inf.label]
+    tp = [inf for _, inf in object_matches.matched if inf.score >= thresholds[inf.label]]
+    fp = [inf for inf in object_matches.unmatched_inf if inf.score >= thresholds[inf.label]]
+    fn = [gt for gt, _ in object_matches.unmatched_gt] + [
+        gt for gt, inf in object_matches.matched if inf.score < thresholds[inf.label]
     ]
     unmatched_ground_truth = [
-        LabeledBoundingBox(
-            label=gt.label,
-            top_left=gt.top_left,
-            bottom_right=gt.bottom_right,
-            predicted_label=inf.label,  # type: ignore[call-arg]
-            predicted_score=inf.score,  # type: ignore[call-arg]
-        )
-        if inf
-        else gt
-        for gt, inf in bbox_matches.unmatched_gt
+        dict(gt._to_dict(), predicted_label=inf.label, predicted_score=inf.score) if inf else gt
+        for gt, inf in object_matches.unmatched_gt
     ]
     confused = [
-        ScoredLabeledBoundingBox(
-            label=inf.label,
-            score=inf.score,
-            top_left=inf.top_left,
-            bottom_right=inf.bottom_right,
-            actual_label=gt.label,  # type: ignore[call-arg]
-        )
-        for gt, inf in bbox_matches.unmatched_gt
+        dict(inf._to_dict(), actual_label=gt.label)
+        for gt, inf in object_matches.unmatched_gt
         if inf is not None and inf.score >= thresholds[inf.label]
     ]
     scores = [inf.score for inf in tp + fp]
-    inference_labels = {inf.label for _, inf in bbox_matches.matched}.union(
-        {inf.label for inf in bbox_matches.unmatched_inf},
+    inference_labels = {inf.label for _, inf in object_matches.matched}.union(
+        {inf.label for inf in object_matches.unmatched_inf},
     )
     fields = [
         ScoredLabel(label=label, score=thresholds[label])
@@ -105,14 +89,14 @@ def multiclass_datapoint_metrics(
         TP=tp,
         FP=fp,
         FN=fn,
-        matched_inference=[inf for _, inf in bbox_matches.matched],
+        matched_inference=[inf for _, inf in object_matches.matched],
         unmatched_ground_truth=unmatched_ground_truth,
-        unmatched_inference=bbox_matches.unmatched_inf,
+        unmatched_inference=object_matches.unmatched_inf,
         Confused=confused,
         count_TP=len(tp),
         count_FP=len(fp),
         count_FN=len(fn),
-        count_Confused=len(confused),
+        count_Confusedo=len(confused),
         has_TP=len(tp) > 0,
         has_FP=len(fp) > 0,
         has_FN=len(fn) > 0,
@@ -136,8 +120,8 @@ def _compute_metrics(
     Compute metrics for object detection.
 
     :param df: Dataframe for model results.
-    :param ground_truth: Column name for ground_truth bounding boxes
-    :param inference: Column name for inference bounding boxes
+    :param ground_truth: Column name for ground truth object annotations
+    :param inference: Column name for inference object annotations
     :param iou_threshold: The [IoU ↗](../../metrics/iou.md) threshold, defaulting to `0.5`.
     :param threshold_strategy: The confidence threshold strategy. It can either be a fixed confidence threshold such
         as `0.5` or `0.75`, or the F1-optimal threshold.
@@ -149,13 +133,11 @@ def _compute_metrics(
 
     idx = {name: i for i, name in enumerate(list(pred_df), start=1)}
 
-    all_bbox_matches: Union[List[MulticlassInferenceMatches], List[InferenceMatches]] = []
+    all_object_matches: Union[List[MulticlassInferenceMatches], List[InferenceMatches]] = []
     for record in pred_df.itertuples():
-        ground_truths = [
-            LabeledBoundingBox(box.top_left, box.bottom_right, box.label) for box in record[idx[ground_truth]]
-        ]
+        ground_truths = record[idx[ground_truth]]
         inferences = record[idx[inference]]
-        all_bbox_matches.append(
+        all_object_matches.append(
             match_fn(  # type: ignore[arg-type]
                 ground_truths,
                 filter_inferences(inferences, min_confidence_score),
@@ -173,11 +155,11 @@ def _compute_metrics(
             thresholds = defaultdict(lambda: threshold_strategy)
         else:
             thresholds = compute_optimal_f1_threshold_multiclass(
-                cast(List[MulticlassInferenceMatches], all_bbox_matches),
+                cast(List[MulticlassInferenceMatches], all_object_matches),
             )
         results = [
             multiclass_datapoint_metrics(cast(MulticlassInferenceMatches, matches), thresholds)
-            for matches in all_bbox_matches
+            for matches in all_object_matches
         ]
     else:
         if isinstance(threshold_strategy, dict) and threshold_strategy:
@@ -185,19 +167,22 @@ def _compute_metrics(
         elif isinstance(threshold_strategy, float):
             threshold = threshold_strategy
         else:
-            threshold = compute_optimal_f1_threshold(cast(List[InferenceMatches], all_bbox_matches))
+            threshold = compute_optimal_f1_threshold(cast(List[InferenceMatches], all_object_matches))
         results = [
-            single_class_datapoint_metrics(cast(InferenceMatches, matches), threshold) for matches in all_bbox_matches
+            single_class_datapoint_metrics(cast(InferenceMatches, matches), threshold) for matches in all_object_matches
         ]
 
     return pd.concat([pd.DataFrame(results), pred_df], axis=1)
 
 
 def _check_multiclass(ground_truth: pd.Series, inference: pd.Series) -> bool:
-    labels = {x.label for x in itertools.chain.from_iterable(ground_truth)}.union(
-        {x.label for x in itertools.chain.from_iterable(inference)},
-    )
-    return len(labels) >= 2
+    try:
+        labels = {x.label for x in itertools.chain.from_iterable(ground_truth)}.union(
+            {x.label for x in itertools.chain.from_iterable(inference)},
+        )
+        return len(labels) >= 2
+    except AttributeError:
+        return False
 
 
 def _validate_column_present(df: pd.DataFrame, col: str) -> None:
@@ -220,16 +205,16 @@ def upload_object_detection_results(
     Compute metrics and upload results of the model for the dataset.
 
     Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
-    :inference in the Dataframe `df` should be a list of
-    [`ScoredLabeledBoundingBox`][kolena.workflow.annotation.ScoredLabeledBoundingBox]es.
+    :inference in the Dataframe `df` should be a list of scored
+    [`BoundingBoxes`][kolena.annotation.BoundingBox] or [`Polygons`][kolena.annotation.Polygon].
 
     :param dataset_name: Dataset name.
     :param model_name: Model name.
     :param df: Dataframe for model results.
-    :param ground_truths_field: Field name in datapoint with ground truth bounding boxes, defaulting to
-        `"ground_truths"`.
-    :param raw_inferences_field: Column in model result DataFrame with raw inference bounding boxes, defaulting to
-        `"raw_inferences"`.
+    :param ground_truths_field: Field name in datapoint with ground truth object annotations,
+    defaulting to `"ground_truths"`.
+    :param raw_inferences_field: Column in model result DataFrame with raw inference object annotations,
+    defaulting to `"raw_inferences"`.
     :param iou_threshold: The [IoU ↗](../../metrics/iou.md) threshold, defaulting to `0.5`.
     :param threshold_strategy: The confidence threshold strategy. It can either be a fixed confidence threshold such
         as `0.5` or `0.75`, or `"F1-Optimal"` to find the threshold maximizing F1 score..

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -205,15 +205,14 @@ def upload_object_detection_results(
     Compute metrics and upload results of the model for the dataset.
 
     Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
-    :inference in the Dataframe `df` should be a list of scored
-    [`BoundingBoxes`][kolena.annotation.BoundingBox] or [`Polygons`][kolena.annotation.Polygon].
+    :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
 
     :param dataset_name: Dataset name.
     :param model_name: Model name.
     :param df: Dataframe for model results.
-    :param ground_truths_field: Field name in datapoint with ground truth object annotations,
+    :param ground_truths_field: Field name in datapoint with ground truth bounding boxes,
     defaulting to `"ground_truths"`.
-    :param raw_inferences_field: Column in model result DataFrame with raw inference object annotations,
+    :param raw_inferences_field: Column in model result DataFrame with raw inference bounding boxes,
     defaulting to `"raw_inferences"`.
     :param iou_threshold: The [IoU ↗](../../metrics/iou.md) threshold, defaulting to `0.5`.
     :param threshold_strategy: The confidence threshold strategy. It can either be a fixed confidence threshold such

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -96,7 +96,7 @@ def multiclass_datapoint_metrics(
         count_TP=len(tp),
         count_FP=len(fp),
         count_FN=len(fn),
-        count_Confusedo=len(confused),
+        count_Confused=len(confused),
         has_TP=len(tp) > 0,
         has_FP=len(fp) > 0,
         has_FN=len(fn) > 0,

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -70,11 +70,11 @@ def multiclass_datapoint_metrics(
         gt for gt, inf in object_matches.matched if inf.score < thresholds[inf.label]
     ]
     unmatched_ground_truth = [
-        dict(gt._to_dict(), predicted_label=inf.label, predicted_score=inf.score) if inf else gt
+        dict(**gt._to_dict(), predicted_label=inf.label, predicted_score=inf.score) if inf else gt
         for gt, inf in object_matches.unmatched_gt
     ]
     confused = [
-        dict(inf._to_dict(), actual_label=gt.label)
+        dict(**inf._to_dict(), actual_label=gt.label)
         for gt, inf in object_matches.unmatched_gt
         if inf is not None and inf.score >= thresholds[inf.label]
     ]

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -30,8 +30,8 @@ from kolena.annotation import ScoredLabel
 from kolena.errors import IncorrectUsageError
 from kolena.metrics import InferenceMatches
 from kolena.metrics import match_inferences
-from kolena.workflow.metrics import match_inferences_multiclass
-from kolena.workflow.metrics import MulticlassInferenceMatches
+from kolena.metrics import match_inferences_multiclass
+from kolena.metrics import MulticlassInferenceMatches
 
 
 def single_class_datapoint_metrics(object_matches: InferenceMatches, thresholds: float) -> Dict[str, Any]:

--- a/kolena/metrics/__init__.py
+++ b/kolena/metrics/__init__.py
@@ -33,7 +33,6 @@ __all__ = [
     "iou",
     "InferenceMatches",
     "match_inferences",
-    "MulticlassInferenceMatches",
     "match_inferences_multiclass",
     "MulticlassInferenceMatches",
 ]

--- a/kolena/metrics/_geometry.py
+++ b/kolena/metrics/_geometry.py
@@ -303,16 +303,19 @@ def match_inferences_multiclass(
 
     # collect all unique labels, store gts and infs of the same label together
     for gt in ground_truths:
-        gts_by_class[gt.label].append(gt)  # type: ignore[union-attr]
-        all_labels.add(gt.label)  # type: ignore[union-attr]
+        assert hasattr(gt, "label")
+        gts_by_class[gt.label].append(gt)
+        all_labels.add(gt.label)
 
     for inf in inferences:
-        infs_by_class[inf.label].append(inf)  # type: ignore[union-attr]
-        all_labels.add(inf.label)  # type: ignore[union-attr]
+        assert hasattr(inf, "label")
+        infs_by_class[inf.label].append(inf)
+        all_labels.add(inf.label)
 
     if ignored_ground_truths:
         for ignored_gt in ignored_ground_truths:
-            ignored_gts_by_class[ignored_gt.label].append(ignored_gt)  # type: ignore[union-attr]
+            assert hasattr(ignored_gt, "label")
+            ignored_gts_by_class[ignored_gt.label].append(ignored_gt)
 
     for label in sorted(all_labels):
         ground_truths_single = gts_by_class[label]
@@ -339,7 +342,8 @@ def match_inferences_multiclass(
 
     confused = []
     for gt, inf in confused_matches.matched:
-        if gt.label != inf.label:  # type: ignore[union-attr]
+        assert hasattr(gt, "label") and hasattr(inf, "label")
+        if gt.label != inf.label:
             confused.append((gt, inf))
             unmatched_gt.remove(gt)
 

--- a/tests/integration/_experimental/object_detection/test_dataset.py
+++ b/tests/integration/_experimental/object_detection/test_dataset.py
@@ -275,6 +275,6 @@ def test__upload_results__multiclass(annotation, gts, infs) -> None:
     assert len(df_results_two) == 10
 
     # check data format
-    confused = next(x for x in df_results_one["unmatched_ground_truth"] if len(x))
-    assert confused[0].predicted_label
-    assert confused[0].predicted_score
+    if confused := next(x for x in df_results_one["unmatched_ground_truth"] if len(x)):
+        assert confused[0].predicted_label
+        assert confused[0].predicted_score

--- a/tests/integration/_experimental/object_detection/test_dataset.py
+++ b/tests/integration/_experimental/object_detection/test_dataset.py
@@ -16,8 +16,14 @@ import random
 import pandas as pd
 import pytest
 
+from kolena.annotation import BoundingBox
 from kolena.annotation import LabeledBoundingBox
+from kolena.annotation import LabeledPolygon
+from kolena.annotation import Polygon
+from kolena.annotation import ScoredBoundingBox
 from kolena.annotation import ScoredLabeledBoundingBox
+from kolena.annotation import ScoredLabeledPolygon
+from kolena.annotation import ScoredPolygon
 from kolena.dataset import download_results
 from kolena.dataset import upload_dataset
 from tests.integration.helper import fake_locator
@@ -26,47 +32,112 @@ from tests.integration.helper import with_test_prefix
 object_detection = pytest.importorskip("kolena._experimental.object_detection", reason="requires kolena[metrics] extra")
 upload_object_detection_results = object_detection.upload_object_detection_results
 
+N_DATAPOINTS = 10
+
+gt_labeled_bbox_single = [
+    [
+        LabeledBoundingBox(label="cat", top_left=[i, i], bottom_right=[i + 10, i + 10]),
+        LabeledBoundingBox(label="cat", top_left=[i + 5, i + 5], bottom_right=[i + 20, i + 20]),
+    ]
+    for i in range(N_DATAPOINTS)
+]
+inf_labeled_bbox_single = [
+    [
+        ScoredLabeledBoundingBox(
+            label="cat",
+            top_left=[box.top_left[0] + 1, box.top_left[1] + 1],
+            bottom_right=[box.bottom_right[0] + 3, box.bottom_right[1] + 3],
+            score=random.random(),
+        )
+        for box in boxes
+    ]
+    for boxes in gt_labeled_bbox_single
+]
+
+gt_unlabeled_bbox_single = [
+    [
+        BoundingBox(top_left=[i, i], bottom_right=[i + 10, i + 10]),
+        BoundingBox(top_left=[i + 5, i + 5], bottom_right=[i + 20, i + 20]),
+    ]
+    for i in range(N_DATAPOINTS)
+]
+inf_unlabeled_bbox_single = [
+    [
+        ScoredBoundingBox(
+            top_left=[box.top_left[0] + 1, box.top_left[1] + 1],
+            bottom_right=[box.bottom_right[0] + 3, box.bottom_right[1] + 3],
+            score=random.random(),
+        )
+        for box in boxes
+    ]
+    for boxes in gt_labeled_bbox_single
+]
+
+
+gt_labeled_polygon_single = [
+    [
+        LabeledPolygon(label="cat", points=[(i, i), (i + 10, i), (i, i + 10), (i + 10, i + 10)]),
+        LabeledPolygon(label="cat", points=[(i + 5, i + 5), (i + 20, i + 5), (i + 5, i + 20), (i + 20, i + 20)]),
+    ]
+    for i in range(N_DATAPOINTS)
+]
+inf_labeled_polygon_single = [
+    [
+        ScoredLabeledPolygon(label="cat", points=[(x + 1, y + 1) for x, y in polygon.points], score=random.random())
+        for polygon in polygons
+    ]
+    for polygons in gt_labeled_polygon_single
+]
+
+gt_unlabeled_polygon_single = [
+    [
+        Polygon(points=[(i, i), (i + 10, i), (i, i + 10), (i + 10, i + 10)]),
+        Polygon(points=[(i + 5, i + 5), (i + 20, i + 5), (i + 5, i + 20), (i + 20, i + 20)]),
+    ]
+    for i in range(N_DATAPOINTS)
+]
+inf_unlabeled_polygon_single = [
+    [ScoredPolygon(points=[(x + 1, y + 1) for x, y in polygon.points], score=random.random()) for polygon in polygons]
+    for polygons in gt_unlabeled_polygon_single
+]
+
 
 @pytest.mark.metrics
-def test__upload_results__single_class() -> None:
-    name = with_test_prefix(f"{__file__}::test__upload_results__single_class")
+@pytest.mark.parametrize(
+    "annotation,gts,infs",
+    [
+        ("labeled_bboxes", gt_labeled_bbox_single, inf_labeled_bbox_single),
+        ("unlabeled_bboxes", gt_unlabeled_bbox_single, inf_unlabeled_bbox_single),
+        ("labeled_polygons", gt_labeled_polygon_single, inf_labeled_polygon_single),
+        ("unlabeled_polygons", gt_unlabeled_polygon_single, inf_unlabeled_polygon_single),
+    ],
+)
+def test__upload_results__single_class(annotation, gts, infs) -> None:
+    name = with_test_prefix(f"{__file__}::test__upload_results__{annotation}__single_class")
     datapoints = [
         dict(
             locator=fake_locator(i, name),
             width=i + 500,
             height=i + 400,
-            bboxes=[
-                LabeledBoundingBox(label="cat", top_left=[i, i], bottom_right=[i + 10, i + 10]),
-                LabeledBoundingBox(label="cat", top_left=[i + 5, i + 5], bottom_right=[i + 20, i + 20]),
-            ],
+            ground_truths=gt,
         )
-        for i in range(10)
+        for i, gt in enumerate(gts)
     ]
     upload_dataset(name, pd.DataFrame(datapoints))
 
     inferences = [
         dict(
             locator=dp["locator"],
-            raw_inferences=[
-                ScoredLabeledBoundingBox(
-                    label="cat",
-                    top_left=[box.top_left[0] + 1, box.top_left[1] + 1],
-                    bottom_right=[box.bottom_right[0] + 3, box.bottom_right[1] + 3],
-                    score=random.random(),
-                )
-                for box in dp["bboxes"]
-            ],
+            raw_inferences=inf,
             theme=random.choice(["animal", "sports", "technology"]),
         )
-        for dp in datapoints
+        for dp, inf in zip(datapoints, infs)
     ]
     eval_config = dict(iou_threshold=0.3, threshold_strategy=0.7, min_confidence_score=0.2)
     upload_object_detection_results(
         name,
         name,
         pd.DataFrame(inferences),
-        ground_truths_field="bboxes",
-        raw_inferences_field="raw_inferences",
         iou_threshold=0.3,
         threshold_strategy=0.7,
         min_confidence_score=0.2,
@@ -87,43 +158,80 @@ def test__upload_results__single_class() -> None:
         "theme",
     }
     assert expected_columns.issubset(set(df_results.columns))
-    assert "bboxes" not in df_results.columns
+    assert "ground_truths" not in df_results.columns
     assert len(df_results) == 10
 
 
+gt_labeled_bbox_multi = [
+    [
+        LabeledBoundingBox(label="cat", top_left=[i, i], bottom_right=[i + 30, i + 30]),
+        LabeledBoundingBox(label="dog", top_left=[i + 5, i + 5], bottom_right=[i + 50, i + 50]),
+        LabeledBoundingBox(label="horse", top_left=[i + 15, i + 15], bottom_right=[i + 60, i + 75]),
+    ]
+    for i in range(N_DATAPOINTS)
+]
+inf_labeled_bbox_multi = [
+    [
+        ScoredLabeledBoundingBox(
+            label=box.label if i % 4 else "dog",
+            top_left=[box.top_left[0] + 1, box.top_left[1] + 1],
+            bottom_right=[box.bottom_right[0] + 3, box.bottom_right[1] + 3],
+            score=random.random(),
+        )
+        for box in boxes
+    ]
+    for i, boxes in enumerate(gt_labeled_bbox_multi)
+]
+
+gt_labeled_polygon_multi = [
+    [
+        LabeledPolygon(label="cat", points=[(i, i), (i + 30, i), (i, i + 30), (i + 30, i + 30)]),
+        LabeledPolygon(label="dog", points=[(i + 5, i + 5), (i + 50, i + 5), (i + 5, i + 50), (i + 50, i + 50)]),
+        LabeledPolygon(label="horse", points=[(i + 15, i + 15), (i + 60, i + 15), (i + 15, i + 75), (i + 60, i + 75)]),
+    ]
+    for i in range(N_DATAPOINTS)
+]
+inf_labeled_polygon_multi = [
+    [
+        ScoredLabeledPolygon(
+            label=polygon.label if i % 4 else "dog",
+            points=[(x, y) for x, y in polygon.points],
+            score=random.random(),
+        )
+        for polygon in polygons
+    ]
+    for i, polygons in enumerate(gt_labeled_polygon_multi)
+]
+
+
 @pytest.mark.metrics
-def test__upload_results__multiclass() -> None:
-    name = with_test_prefix(f"{__file__}::test__upload_results__multiclass")
+@pytest.mark.parametrize(
+    "annotation,gts,infs",
+    [
+        ("labeled_bboxes", gt_labeled_bbox_multi, inf_labeled_bbox_multi),
+        ("labeled_polygons", gt_labeled_polygon_multi, inf_labeled_polygon_multi),
+    ],
+)
+def test__upload_results__multiclass(annotation, gts, infs) -> None:
+    name = with_test_prefix(f"{__file__}::test__upload_results__{annotation}__multiclass")
     datapoints = [
         dict(
             locator=fake_locator(i, name),
             width=i + 500,
             height=i + 400,
-            bounding_boxes=[
-                LabeledBoundingBox(label="cat", top_left=[i, i], bottom_right=[i + 30, i + 30]),
-                LabeledBoundingBox(label="dog", top_left=[i + 5, i + 5], bottom_right=[i + 50, i + 50]),
-                LabeledBoundingBox(label="horse", top_left=[i + 15, i + 25], bottom_right=[i + 60, i + 75]),
-            ],
+            ground_truths=gt,
         )
-        for i in range(10)
+        for i, gt in enumerate(gts)
     ]
     upload_dataset(name, pd.DataFrame(datapoints))
 
     inferences = [
         dict(
             locator=dp["locator"],
-            inferences=[
-                ScoredLabeledBoundingBox(
-                    label=box.label if i % 4 else "dog",
-                    top_left=[box.top_left[0] + 1, box.top_left[1] + 1],
-                    bottom_right=[box.bottom_right[0] + 3, box.bottom_right[1] + 3],
-                    score=0.7,
-                )
-                for box in dp["bounding_boxes"]
-            ],
+            raw_inferences=inf,
             theme=random.choice(["animal", "sports", "technology"]),
         )
-        for i, dp in enumerate(datapoints)
+        for dp, inf in zip(datapoints, infs)
     ]
     eval_config_one = dict(
         iou_threshold=0.3,
@@ -135,16 +243,12 @@ def test__upload_results__multiclass() -> None:
         name,
         name,
         pd.DataFrame(inferences),
-        ground_truths_field="bounding_boxes",
-        raw_inferences_field="inferences",
         **eval_config_one,
     )
     upload_object_detection_results(
         name,
         name,
         pd.DataFrame(inferences),
-        ground_truths_field="bounding_boxes",
-        raw_inferences_field="inferences",
         **eval_config_two,
     )
 
@@ -158,7 +262,7 @@ def test__upload_results__multiclass() -> None:
     expected_columns = {
         "TP",
         "FP",
-        "inferences",
+        "raw_inferences",
         "matched_inference",
         "unmatched_inference",
         "unmatched_ground_truth",
@@ -166,7 +270,7 @@ def test__upload_results__multiclass() -> None:
         "Confused",
     }
     assert expected_columns.issubset(set(df_results_one.columns))
-    assert "bounding_boxes" not in df_results_one.columns
+    assert "ground_truths" not in df_results_one.columns
     assert len(df_results_one) == 10
     assert len(df_results_two) == 10
 

--- a/tests/integration/_experimental/object_detection/test_dataset.py
+++ b/tests/integration/_experimental/object_detection/test_dataset.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import random
 from typing import List
+from typing import Union
 
 import pandas as pd
 import pytest
@@ -32,6 +33,8 @@ from tests.integration.helper import with_test_prefix
 
 object_detection = pytest.importorskip("kolena._experimental.object_detection", reason="requires kolena[metrics] extra")
 upload_object_detection_results = object_detection.upload_object_detection_results
+
+ObjectAnnotations = Union[List[BoundingBox], List[Polygon]]
 
 N_DATAPOINTS = 10
 
@@ -128,7 +131,7 @@ def _assert_result_bbox_contains_fields(df_results: pd.DataFrame, columns: List[
         ("unlabeled_polygons", gt_unlabeled_polygon_single, inf_unlabeled_polygon_single),
     ],
 )
-def test__upload_results__single_class(annotation, gts, infs) -> None:
+def test__upload_results__single_class(annotation: str, gts: ObjectAnnotations, infs: ObjectAnnotations) -> None:
     name = with_test_prefix(f"{__file__}::test__upload_results__{annotation}__single_class")
     datapoints = [
         dict(
@@ -242,7 +245,7 @@ inf_labeled_polygon_multi = [
         ("labeled_polygons", gt_labeled_polygon_multi, inf_labeled_polygon_multi),
     ],
 )
-def test__upload_results__multiclass(annotation, gts, infs) -> None:
+def test__upload_results__multiclass(annotation: str, gts: ObjectAnnotations, infs: ObjectAnnotations) -> None:
     name = with_test_prefix(f"{__file__}::test__upload_results__{annotation}__multiclass")
     datapoints = [
         dict(


### PR DESCRIPTION
### Linked issue(s)
Fixes KOL-5294 and KOL-5142

### What change does this PR introduce and why?
Supports unlabeled object annotations via `upload_object_detection_results`.
Also adds an alias function `upload_instance_segmentation_results` -> `upload_object_detection_results`

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
