### PR TITLE
Update kolena version in OD example

### DIFF
--- a/examples/dataset/object_detection_2d/object_detection_2d/upload_dataset.py
+++ b/examples/dataset/object_detection_2d/object_detection_2d/upload_dataset.py
@@ -34,7 +34,11 @@ def load_data(df_metadata_csv: pd.DataFrame) -> pd.DataFrame:
 
     for record in df_metadata_csv.itertuples():
         coords = (float(record.min_x), float(record.min_y)), (float(record.max_x), float(record.max_y))
-        bounding_box = LabeledBoundingBox(*coords, record.label)
+        bounding_box = LabeledBoundingBox(
+            *coords,
+            record.label,
+            supercategory=record.supercategory,  # type: ignore[call-arg]
+        )
         image_to_boxes[record.locator].append(bounding_box)
         metadata = {
             "locator": str(record.locator),

--- a/examples/dataset/object_detection_2d/pyproject.toml
+++ b/examples/dataset/object_detection_2d/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = {extras = ["metrics"], version = "^1.4.0"}
+kolena = {extras = ["metrics"], version = "^1.7.0"}
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"


### PR DESCRIPTION
### Linked issue(s)
https://linear.app/kolena/issue/KOL-5283/update-sdk-client-to-persist-bouding-box-metadata-when-uploading

### What change does this PR introduce and why?
- Ping the Kolena version to 1.7.0 or higher after https://github.com/kolenaIO/kolena/pull/522 was merged.
- Persist `supercategory` of bounding boxes as an example of bounding box metadata

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
