### PR TITLE
feat: Attempt to initialize client if uninitialized

### DIFF
--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -27,6 +27,7 @@ import requests
 import kolena
 import kolena._api.v1.token as API
 from kolena._utils import krequests
+from kolena._utils.log import info
 from kolena._utils.serde import from_dict
 from kolena.errors import InvalidClientStateError
 from kolena.errors import InvalidTokenError
@@ -100,12 +101,9 @@ class _ClientState:
         self.additional_request_headers = additional_request_headers or self.additional_request_headers
 
     def assert_initialized(self) -> None:
-        if self.base_url is None:
-            raise InvalidClientStateError("missing base_url")
         if self.jwt_token is None:
-            raise UninitializedError("client has not been initialized via kolena.initialize(...)")
-        if self.api_token is None:
-            raise InvalidClientStateError("missing client api_token")
+            info("Attempting to initialize client...")
+            kolena.initialize(verbose=True)
 
     def reset(self) -> None:
         # note that base_url remains set

--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -129,7 +129,7 @@ def kolena_initialized(func: Callable) -> Callable:
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         if is_client_uninitialized():
-            kolena.initialize(verbose=True)
+            kolena.initialize()
         return func(*args, **kwargs)
 
     return wrapper

--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -27,7 +27,6 @@ import requests
 import kolena
 import kolena._api.v1.token as API
 from kolena._utils import krequests
-from kolena._utils.log import info
 from kolena._utils.serde import from_dict
 from kolena.errors import InvalidClientStateError
 from kolena.errors import InvalidTokenError
@@ -100,9 +99,8 @@ class _ClientState:
         self.proxies = proxies or self.proxies
         self.additional_request_headers = additional_request_headers or self.additional_request_headers
 
-    def assert_initialized(self) -> None:
+    def initialized(self) -> None:
         if self.jwt_token is None:
-            info("Attempting to initialize client...")
             kolena.initialize(verbose=True)
 
     def reset(self) -> None:
@@ -129,7 +127,7 @@ def get_client_state() -> _ClientState:
 
 def is_client_initialized() -> bool:
     try:
-        get_client_state().assert_initialized()
+        get_client_state().initialized()
     except (InvalidClientStateError, UninitializedError):
         return False
     return True
@@ -141,7 +139,7 @@ def kolena_initialized(func: Callable) -> Callable:
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         client_state = get_client_state()
-        client_state.assert_initialized()
+        client_state.initialized()
         return func(*args, **kwargs)
 
     return wrapper

--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -119,13 +119,16 @@ def get_client_state() -> _ClientState:
     return CLIENT_STATE.get(_client_state)
 
 
+def is_client_uninitialized() -> bool:
+    return get_client_state().jwt_token is None
+
+
 def kolena_initialized(func: Callable) -> Callable:
     """Attempts to initialize client if not initialized"""
 
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        client_state = get_client_state()
-        if client_state.jwt_token is None:
+        if is_client_uninitialized():
             kolena.initialize(verbose=True)
         return func(*args, **kwargs)
 

--- a/kolena/errors.py
+++ b/kolena/errors.py
@@ -42,10 +42,6 @@ class MissingTokenError(KeyError, KolenaError):
     """Exception indicating that the client could not locate an API token."""
 
 
-class UninitializedError(InvalidClientStateError):
-    """Exception indicating that the client has not been properly initialized before usage."""
-
-
 class DirectInstantiationError(RuntimeError, KolenaError):
     """
     Exception indicating that the default constructor was used for a class that does not support direct instantiation.

--- a/kolena/initialize.py
+++ b/kolena/initialize.py
@@ -98,6 +98,7 @@ def initialize(
     :raises InputValidationError: The provided combination or number of args is not valid.
     :raises MissingTokenError: An API token could not be found.
     """
+    log.info("Attempting to initialize client...")
     used_deprecated_signature = "entity" in kwargs
 
     if len(args) > 2:

--- a/kolena/workflow/evaluator_function.py
+++ b/kolena/workflow/evaluator_function.py
@@ -33,7 +33,6 @@ from pydantic.dataclasses import dataclass
 from kolena._api.v1.generic import TestRun as API
 from kolena._utils import krequests
 from kolena._utils import log
-from kolena._utils.state import is_client_initialized
 from kolena._utils.validators import ValidatorConfig
 from kolena.workflow import EvaluatorConfiguration
 from kolena.workflow import GroundTruth as BaseGroundTruth
@@ -210,9 +209,6 @@ class _TestCases(TestCases):
             self._update_progress(tc)
 
     def _update_progress(self, test_case: TestCase) -> None:
-        if not is_client_initialized():
-            return
-
         config_description = (
             f" {_configuration_description(self._wip_configuration)}" if self._wip_configuration else ""
         )

--- a/kolena/workflow/evaluator_function.py
+++ b/kolena/workflow/evaluator_function.py
@@ -33,6 +33,7 @@ from pydantic.dataclasses import dataclass
 from kolena._api.v1.generic import TestRun as API
 from kolena._utils import krequests
 from kolena._utils import log
+from kolena._utils.state import is_client_uninitialized
 from kolena._utils.validators import ValidatorConfig
 from kolena.workflow import EvaluatorConfiguration
 from kolena.workflow import GroundTruth as BaseGroundTruth
@@ -209,6 +210,9 @@ class _TestCases(TestCases):
             self._update_progress(tc)
 
     def _update_progress(self, test_case: TestCase) -> None:
+        if is_client_uninitialized():
+            return
+
         config_description = (
             f" {_configuration_description(self._wip_configuration)}" if self._wip_configuration else ""
         )

--- a/tests/unit/test_initialize.py
+++ b/tests/unit/test_initialize.py
@@ -36,9 +36,7 @@ from kolena._utils.state import API_URL_ENV_VAR
 from kolena._utils.state import get_client_state
 from kolena._utils.state import get_endpoint_with_baseurl
 from kolena._utils.state import kolena_session
-from kolena.dataset import download_dataset
 from kolena.errors import MissingTokenError
-from kolena.errors import UninitializedError
 
 
 def mock_jwt(input: str) -> str:
@@ -168,11 +166,6 @@ def test__initialize__token_missing() -> None:
     with patch("netrc.netrc", side_effect=MissingTokenError):
         with pytest.raises(MissingTokenError):
             kolena.initialize()
-
-
-def test__uninitialized_usage() -> None:
-    with pytest.raises(UninitializedError):
-        download_dataset("does not exist")
 
 
 def test__kolena_session() -> None:

--- a/tests/unit/test_initialize.py
+++ b/tests/unit/test_initialize.py
@@ -35,6 +35,7 @@ from kolena._utils.state import API_URL
 from kolena._utils.state import API_URL_ENV_VAR
 from kolena._utils.state import get_client_state
 from kolena._utils.state import get_endpoint_with_baseurl
+from kolena._utils.state import kolena_initialized
 from kolena._utils.state import kolena_session
 from kolena.errors import MissingTokenError
 
@@ -72,6 +73,22 @@ def clean_client_state() -> Iterator[None]:
         yield
     finally:
         _client_state.reset()
+
+
+@patch("kolena._utils.state.kolena.initialize")
+def test__auto_initialize(initialize_mock: Mock) -> None:
+    @kolena_initialized
+    def wrapped_func():
+        pass
+
+    initialize_mock.assert_not_called()
+    wrapped_func()
+    initialize_mock.assert_called_once()
+
+    # Should only be called once
+    with patch("kolena._utils.state.is_client_uninitialized", return_value=False):
+        wrapped_func()
+        initialize_mock.assert_called_once()
 
 
 def test__initialize__positional() -> None:


### PR DESCRIPTION
### Linked issue(s)
Fixes KOL-5272

### What change does this PR introduce and why?
Updates `kolena_initialized` wrapper to attempt to initialize the client if uninitialized instead of immediately raising an error.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
