### PR TITLE
chore: upgrade docker version

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -386,7 +386,7 @@ jobs:
       - checkout:
           path: ~/project
       - setup_remote_docker:
-          version: 20.10.14
+          version: default
       - run:
           name: Build evaluator
           command: examples/workflow/text_summarization/docker/build.sh


### PR DESCRIPTION
### Linked issue(s)

to fix 

> This job was rejected because the image is [unavailable](https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/)

based on [this thread](https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176)

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
