### PR TITLE
Remove explicit `kolena.initialize` call from dataset examples

### DIFF
--- a/examples/dataset/age_estimation/age_estimation/upload_dataset.py
+++ b/examples/dataset/age_estimation/age_estimation/upload_dataset.py
@@ -19,14 +19,11 @@ from age_estimation.constants import DATA_FILEPATH
 from age_estimation.constants import DATASET
 from age_estimation.constants import TASK
 
-import kolena
 from kolena.dataset import upload_dataset
 
 
 def run(args: Namespace) -> None:
     df = pd.read_csv(DATA_FILEPATH)
-
-    kolena.initialize(verbose=True)
     upload_dataset(args.dataset, df)
 
 

--- a/examples/dataset/age_estimation/age_estimation/upload_results.py
+++ b/examples/dataset/age_estimation/age_estimation/upload_results.py
@@ -22,7 +22,6 @@ from age_estimation.constants import DATASET
 from age_estimation.constants import TASK
 from tqdm import tqdm
 
-import kolena
 from kolena.dataset import download_dataset
 from kolena.dataset import upload_results
 
@@ -40,7 +39,6 @@ def compute_metrics(gt_age: float, inf_age: float) -> Dict[str, Union[bool, floa
 def run(args: Namespace) -> None:
     model = args.model
 
-    kolena.initialize(verbose=True)
     dataset_df = download_dataset(args.dataset)
     gt_age_by_locator = {record["locator"]: record["age"] for record in dataset_df.to_dict(orient="records")}
 

--- a/examples/dataset/age_estimation/pyproject.toml
+++ b/examples/dataset/age_estimation/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = "^1.8.0"
+kolena = "^1.9.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/age_estimation/pyproject.toml
+++ b/examples/dataset/age_estimation/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = ">=1.0.0"
+kolena = "^1.8.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/age_estimation/tests/test_age_estimation.py
+++ b/examples/dataset/age_estimation/tests/test_age_estimation.py
@@ -11,29 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import random
 import string
 from argparse import Namespace
-from collections.abc import Iterator
 
 import pytest
 from age_estimation.upload_dataset import run as upload_dataset_main
 from age_estimation.upload_results import run as upload_results_main
-
-from kolena._utils.state import kolena_session
 
 
 BUCKET = "kolena-public-examples"
 DATASET = "labeled-faces-in-the-wild"
 
 TEST_PREFIX = "".join(random.choices(string.ascii_uppercase + string.digits, k=12))
-
-
-@pytest.fixture(scope="session", autouse=True)
-def with_init() -> Iterator[None]:
-    with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
-        yield
 
 
 @pytest.fixture(scope="module")

--- a/examples/dataset/automatic_speech_recognition/automatic_speech_recognition/upload_dataset.py
+++ b/examples/dataset/automatic_speech_recognition/automatic_speech_recognition/upload_dataset.py
@@ -19,13 +19,11 @@ from automatic_speech_recognition.constants import BUCKET
 from automatic_speech_recognition.constants import DATASET
 from automatic_speech_recognition.utils import preprocess_transcription
 
-import kolena
 from kolena.asset import AudioAsset
 from kolena.dataset import upload_dataset
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     df_dataset = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
     df_dataset["audio"] = df_dataset["audio"].apply(AudioAsset)
     df_dataset["transcript"] = df_dataset["transcript"].str.lower().apply(preprocess_transcription)

--- a/examples/dataset/automatic_speech_recognition/automatic_speech_recognition/upload_results.py
+++ b/examples/dataset/automatic_speech_recognition/automatic_speech_recognition/upload_results.py
@@ -28,7 +28,6 @@ from jiwer import cer
 from jiwer import process_words
 from tqdm import tqdm
 
-import kolena
 from kolena.dataset import download_dataset
 from kolena.dataset import upload_results
 
@@ -60,7 +59,6 @@ def compute_metrics(ground_truth: str, inference: str) -> Dict[str, Any]:
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     df_dataset = download_dataset(args.dataset)
     df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/results/raw/{args.model}.csv", storage_options={"anon": True})
     df["transcript"] = df["transcript"].str.lower().apply(preprocess_transcription)

--- a/examples/dataset/automatic_speech_recognition/pyproject.toml
+++ b/examples/dataset/automatic_speech_recognition/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = "^1.8.0"
+kolena = "^1.9.0"
 s3fs = "^2023.5.0"
 jiwer = "^3.0.3"
 langid = "^1.1.6"

--- a/examples/dataset/automatic_speech_recognition/pyproject.toml
+++ b/examples/dataset/automatic_speech_recognition/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = ">=1.0.0"
+kolena = "^1.8.0"
 s3fs = "^2023.5.0"
 jiwer = "^3.0.3"
 langid = "^1.1.6"

--- a/examples/dataset/automatic_speech_recognition/tests/test_automatic_speech_recognition.py
+++ b/examples/dataset/automatic_speech_recognition/tests/test_automatic_speech_recognition.py
@@ -11,25 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import random
 import string
 from argparse import Namespace
-from collections.abc import Iterator
 
 import pytest
 from automatic_speech_recognition.constants import BUCKET
 from automatic_speech_recognition.constants import DATASET
 from automatic_speech_recognition.upload_dataset import run as upload_dataset_run
 from automatic_speech_recognition.upload_results import run as upload_results_run
-
-from kolena._utils.state import kolena_session
-
-
-@pytest.fixture(scope="session", autouse=True)
-def with_init() -> Iterator[None]:
-    with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
-        yield
 
 
 @pytest.fixture(scope="module")

--- a/examples/dataset/classification/classification/binary/upload_dataset.py
+++ b/examples/dataset/classification/classification/binary/upload_dataset.py
@@ -19,7 +19,6 @@ from classification.binary.constants import BUCKET
 from classification.binary.constants import DATASET
 from classification.binary.constants import ID_FIELDS
 
-import kolena
 from kolena.annotation import ClassificationLabel
 from kolena.dataset import upload_dataset
 
@@ -27,7 +26,6 @@ from kolena.dataset import upload_dataset
 def run(args: Namespace) -> None:
     df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/raw/{DATASET}.csv", storage_options={"anon": True})
     df["label"] = df["label"].apply(lambda label: ClassificationLabel(label))
-    kolena.initialize(verbose=True)
     upload_dataset(args.dataset, df, id_fields=ID_FIELDS)
 
 

--- a/examples/dataset/classification/classification/binary/upload_results.py
+++ b/examples/dataset/classification/classification/binary/upload_results.py
@@ -21,7 +21,6 @@ from classification.binary.constants import BUCKET
 from classification.binary.constants import DATASET
 from classification.binary.constants import ID_FIELDS
 
-import kolena
 from kolena.annotation import ScoredClassificationLabel
 from kolena.dataset import download_dataset
 from kolena.dataset import upload_results
@@ -57,7 +56,6 @@ def create_classification(score: float) -> ScoredClassificationLabel:
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     dataset_df = download_dataset(args.dataset)
     df_results = pd.read_csv(
         f"s3://{BUCKET}/{DATASET}/results/raw/{args.model}.csv",

--- a/examples/dataset/classification/classification/multiclass/upload_dataset.py
+++ b/examples/dataset/classification/classification/multiclass/upload_dataset.py
@@ -19,7 +19,6 @@ from classification.multiclass.constants import BUCKET
 from classification.multiclass.constants import DATASET
 from classification.multiclass.constants import ID_FIELDS
 
-import kolena
 from kolena.annotation import ClassificationLabel
 from kolena.dataset import upload_dataset
 
@@ -28,7 +27,6 @@ def run(args: Namespace) -> None:
     df = pd.read_csv(f"s3://{BUCKET}/{DATASET}/raw/{DATASET}.csv", storage_options={"anon": True})
     df["ground_truth"] = df["ground_truth"].apply(lambda label: ClassificationLabel(label))
 
-    kolena.initialize(verbose=True)
     upload_dataset(args.dataset, df, id_fields=ID_FIELDS)
 
 

--- a/examples/dataset/classification/classification/multiclass/upload_results.py
+++ b/examples/dataset/classification/classification/multiclass/upload_results.py
@@ -22,7 +22,6 @@ from classification.multiclass.constants import BUCKET
 from classification.multiclass.constants import DATASET
 from classification.multiclass.constants import ID_FIELDS
 
-import kolena
 from kolena.dataset import download_dataset
 from kolena.dataset import upload_results
 from kolena.workflow.annotation import ScoredClassificationLabel
@@ -49,7 +48,6 @@ def list_inferences(scores: List[float]) -> List[ScoredClassificationLabel]:
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     dataset_df = download_dataset(args.dataset)
     df_results = pd.read_csv(
         f"s3://{BUCKET}/{DATASET}/results/raw/{args.model}.csv",

--- a/examples/dataset/classification/pyproject.toml
+++ b/examples/dataset/classification/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = "^1.8.0"
+kolena = "^1.9.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/classification/pyproject.toml
+++ b/examples/dataset/classification/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = ">=1.0.0"
+kolena = "^1.8.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/classification/tests/test_classification.py
+++ b/examples/dataset/classification/tests/test_classification.py
@@ -11,11 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import random
 import string
 from argparse import Namespace
-from collections.abc import Iterator
 
 import pytest
 from classification.binary.upload_dataset import run as upload_binary_dataset
@@ -23,17 +21,9 @@ from classification.binary.upload_results import run as upload_binary_results
 from classification.multiclass.upload_dataset import run as upload_multiclass_dataset
 from classification.multiclass.upload_results import run as upload_multiclass_results
 
-from kolena._utils.state import kolena_session
-
 BUCKET = "kolena-public-examples"
 BINARY_DATASET = "dogs-vs-cats"
 MULTICLASS_DATASET = "cifar10"
-
-
-@pytest.fixture(scope="session", autouse=True)
-def with_init() -> Iterator[None]:
-    with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
-        yield
 
 
 @pytest.fixture(scope="module")

--- a/examples/dataset/image_retrieval_by_text/image_retrieval_by_text/upload_dataset.py
+++ b/examples/dataset/image_retrieval_by_text/image_retrieval_by_text/upload_dataset.py
@@ -19,7 +19,6 @@ from image_retrieval_by_text.constants import BUCKET
 from image_retrieval_by_text.constants import DATASET
 from image_retrieval_by_text.constants import ID_FIELDS
 
-import kolena
 from kolena.asset import ImageAsset
 from kolena.dataset import upload_dataset
 
@@ -32,7 +31,6 @@ def transform_data(df_csv: pd.DataFrame) -> pd.DataFrame:
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     df_csv = pd.read_csv(
         f"s3://{BUCKET}/coco-2014-val/image-retrieval-by-text/dataset/raw/image-retrieval-by-text-raw.csv",
         storage_options={"anon": True},

--- a/examples/dataset/image_retrieval_by_text/image_retrieval_by_text/upload_results.py
+++ b/examples/dataset/image_retrieval_by_text/image_retrieval_by_text/upload_results.py
@@ -38,7 +38,6 @@ from transformers import AutoProcessor
 from transformers import CLIPModel
 from transformers import CLIPProcessor
 
-import kolena
 from kolena.asset import ImageAsset
 from kolena.dataset import download_dataset
 from kolena.dataset import upload_results
@@ -213,7 +212,6 @@ def retrieve_images_by_text(dataset: pd.DataFrame, df_img_emb: pd.DataFrame, df_
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     args.model = args.model.replace("/", "_")
     if not args.run_inference:
         pred_df_csv = pd.read_csv(

--- a/examples/dataset/image_retrieval_by_text/pyproject.toml
+++ b/examples/dataset/image_retrieval_by_text/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
-kolena = {extras = ["metrics"], version = "^1.4.0"}
+kolena = {extras = ["metrics"], version = "^1.9.0"}
 s3fs = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"
 numpy = "^1.26.4"

--- a/examples/dataset/image_retrieval_by_text/tests/test_image_retrieval_by_text.py
+++ b/examples/dataset/image_retrieval_by_text/tests/test_image_retrieval_by_text.py
@@ -11,27 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import random
 import string
 from argparse import Namespace
-from collections.abc import Iterator
 
 import pytest
 from image_retrieval_by_text.constants import MODELS
 from image_retrieval_by_text.upload_dataset import run as upload_dataset_main
 from image_retrieval_by_text.upload_results import run as upload_results_main
 
-from kolena._utils.state import kolena_session
-
 
 DATASET = "image-retrieval-by-text"
-
-
-@pytest.fixture(scope="session", autouse=True)
-def with_init() -> Iterator[None]:
-    with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
-        yield
 
 
 @pytest.fixture(scope="module")

--- a/examples/dataset/keypoint_detection/keypoint_detection/upload_dataset.py
+++ b/examples/dataset/keypoint_detection/keypoint_detection/upload_dataset.py
@@ -19,7 +19,6 @@ import pandas as pd
 from keypoint_detection.constants import BUCKET
 from keypoint_detection.constants import DATASET
 
-import kolena
 from kolena.annotation import Keypoints
 from kolena.dataset import upload_dataset
 
@@ -29,7 +28,6 @@ def run(args: Namespace) -> None:
     df["face"] = df["points"].apply(lambda points: Keypoints(points=json.loads(points)))
     df["condition"] = df["locator"].apply(lambda locator: "indoor" if "indoor" in locator else "outdoor")
 
-    kolena.initialize(verbose=True)
     upload_dataset(args.dataset, df[["locator", "face", "normalization_factor", "condition"]])
 
 

--- a/examples/dataset/keypoint_detection/keypoint_detection/upload_results.py
+++ b/examples/dataset/keypoint_detection/keypoint_detection/upload_results.py
@@ -25,7 +25,6 @@ from keypoint_detection.model import infer_from_df
 from keypoint_detection.model import infer_random
 from tqdm import tqdm
 
-import kolena
 from kolena.annotation import Keypoints
 from kolena.annotation import ScoredLabeledBoundingBox
 from kolena.dataset import download_dataset
@@ -37,7 +36,6 @@ MODELS = ["retinaface", "random"]
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     infer = infer_random
     if args.model == "retinaface":
         retinaface_raw_inferences_df = dataframe_from_csv(

--- a/examples/dataset/keypoint_detection/pyproject.toml
+++ b/examples/dataset/keypoint_detection/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = "^1.8.0"
+kolena = "^1.9.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/keypoint_detection/pyproject.toml
+++ b/examples/dataset/keypoint_detection/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = ">=1.0.0"
+kolena = "^1.8.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/keypoint_detection/tests/test_keypoint_detection.py
+++ b/examples/dataset/keypoint_detection/tests/test_keypoint_detection.py
@@ -11,27 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import random
 import string
 from argparse import Namespace
-from collections.abc import Iterator
 
 import pytest
 from keypoint_detection.upload_dataset import run as upload_dataset_main
 from keypoint_detection.upload_results import run as upload_results_main
 
-from kolena._utils.state import kolena_session
-
 
 BUCKET = "kolena-public-examples"
 DATASET = "300-W"
-
-
-@pytest.fixture(scope="session", autouse=True)
-def with_init() -> Iterator[None]:
-    with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
-        yield
 
 
 @pytest.fixture(scope="module")

--- a/examples/dataset/object_detection_2d/object_detection_2d/upload_dataset.py
+++ b/examples/dataset/object_detection_2d/object_detection_2d/upload_dataset.py
@@ -23,7 +23,6 @@ from object_detection_2d.constants import BUCKET
 from object_detection_2d.constants import DATASET
 from object_detection_2d.constants import ID_FIELDS
 
-import kolena
 from kolena.annotation import LabeledBoundingBox
 from kolena.dataset import upload_dataset
 
@@ -55,7 +54,6 @@ def load_data(df_metadata_csv: pd.DataFrame) -> pd.DataFrame:
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     df_metadata_csv = pd.read_csv(
         f"s3://{BUCKET}/{DATASET}/raw/{DATASET}.csv",
         storage_options={"anon": True},

--- a/examples/dataset/object_detection_2d/object_detection_2d/upload_results.py
+++ b/examples/dataset/object_detection_2d/object_detection_2d/upload_results.py
@@ -20,7 +20,6 @@ from object_detection_2d.constants import BUCKET
 from object_detection_2d.constants import DATASET
 from object_detection_2d.constants import MODELS
 
-import kolena
 from kolena._experimental.object_detection import upload_object_detection_results
 from kolena.annotation import ScoredLabeledBoundingBox
 
@@ -37,8 +36,6 @@ def load_data(df_pred_csv: pd.DataFrame) -> pd.DataFrame:
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
-
     pred_df_csv = pd.read_csv(
         f"s3://{BUCKET}/{DATASET}/results/raw/{args.model}.csv",
         storage_options={"anon": True},

--- a/examples/dataset/object_detection_2d/pyproject.toml
+++ b/examples/dataset/object_detection_2d/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = {extras = ["metrics"], version = "^1.7.0"}
+kolena = {extras = ["metrics"], version = "^1.8.0"}
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/object_detection_2d/pyproject.toml
+++ b/examples/dataset/object_detection_2d/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = {extras = ["metrics"], version = "^1.8.0"}
+kolena = {extras = ["metrics"], version = "^1.9.0"}
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/object_detection_2d/tests/test_object_detection_2d.py
+++ b/examples/dataset/object_detection_2d/tests/test_object_detection_2d.py
@@ -11,26 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import random
 import string
 from argparse import Namespace
-from collections.abc import Iterator
 
 import pytest
 from object_detection_2d.upload_dataset import run as upload_dataset_main
 from object_detection_2d.upload_results import run as upload_results_main
 
-from kolena._utils.state import kolena_session
-
 
 DATASET = "coco-2014-val"
-
-
-@pytest.fixture(scope="session", autouse=True)
-def with_init() -> Iterator[None]:
-    with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
-        yield
 
 
 @pytest.fixture(scope="module")

--- a/examples/dataset/person_detection/person_detection/upload_dataset.py
+++ b/examples/dataset/person_detection/person_detection/upload_dataset.py
@@ -24,7 +24,6 @@ from kolena.dataset import upload_dataset
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     df_metadata = kolena.io.dataframe_from_csv(
         f"s3://{BUCKET}/{DATASET_DIR}/{DATASET_NAME}.csv",
         storage_options={"anon": True},

--- a/examples/dataset/person_detection/person_detection/upload_results.py
+++ b/examples/dataset/person_detection/person_detection/upload_results.py
@@ -24,7 +24,6 @@ from person_detection.constants import DATASET_NAME
 from person_detection.constants import MODELS
 from person_detection.constants import TASK_DIR
 
-import kolena.io
 from kolena._experimental.object_detection import upload_object_detection_results
 from kolena.annotation import ScoredLabeledBoundingBox
 
@@ -54,8 +53,6 @@ def map_results(images: list[dict], annotations: list[dict], categories: list[di
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
-
     s3 = s3fs.S3FileSystem()
     with s3.open(f"s3://{BUCKET}/{DATASET_DIR}/{TASK_DIR}/results/raw/{args.model}.json") as f:
         coco_results = json.loads(f.read())

--- a/examples/dataset/person_detection/pyproject.toml
+++ b/examples/dataset/person_detection/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = {extras = ["metrics"], version = "^1.8.0"}
+kolena = {extras = ["metrics"], version = "^1.9.0"}
 s3fs = "^2023.5.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/dataset/person_detection/pyproject.toml
+++ b/examples/dataset/person_detection/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = {extras = ["metrics"], version = "^1.5.0"}
+kolena = {extras = ["metrics"], version = "^1.8.0"}
 s3fs = "^2023.5.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/dataset/person_detection/tests/test_person_detection.py
+++ b/examples/dataset/person_detection/tests/test_person_detection.py
@@ -11,27 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import random
 import string
 from argparse import Namespace
-from collections.abc import Iterator
 
 import pytest
 from person_detection.constants import DATASET_NAME
 from person_detection.upload_dataset import run as upload_dataset_main
 from person_detection.upload_results import run as upload_results_main
 
-from kolena._utils.state import kolena_session
-
 
 DATASET = "coco-person-detection"
-
-
-@pytest.fixture(scope="session", autouse=True)
-def with_init() -> Iterator[None]:
-    with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
-        yield
 
 
 @pytest.fixture(scope="module")

--- a/examples/dataset/question_answering/pyproject.toml
+++ b/examples/dataset/question_answering/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.11"
-kolena = ">=1.0.0"
+kolena = "^1.8.0"
 s3fs = "^2022.7.1"
 torch = [
   {markers = "sys_platform == 'darwin' and platform_machine == 'arm64'", url = "https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_11_0_arm64.whl"},

--- a/examples/dataset/question_answering/pyproject.toml
+++ b/examples/dataset/question_answering/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.11"
-kolena = "^1.8.0"
+kolena = "^1.9.0"
 s3fs = "^2022.7.1"
 torch = [
   {markers = "sys_platform == 'darwin' and platform_machine == 'arm64'", url = "https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_11_0_arm64.whl"},

--- a/examples/dataset/question_answering/question_answering/upload_dataset.py
+++ b/examples/dataset/question_answering/question_answering/upload_dataset.py
@@ -16,13 +16,11 @@ from argparse import Namespace
 
 from question_answering.constants import DATASET_TO_LOCATOR
 
-import kolena
 from kolena.dataset import upload_dataset
 from kolena.workflow.io import dataframe_from_csv
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     for dataset in args.datasets:
         print(f"loading {dataset}...")
         df_datapoint = dataframe_from_csv(DATASET_TO_LOCATOR[dataset])

--- a/examples/dataset/question_answering/question_answering/upload_results.py
+++ b/examples/dataset/question_answering/question_answering/upload_results.py
@@ -17,13 +17,11 @@ from argparse import Namespace
 from question_answering.constants import DATASET_TO_RESULTS
 from question_answering.constants import MODELS
 
-import kolena
 from kolena.dataset import upload_results
 from kolena.workflow.io import dataframe_from_csv
 
 
 def main(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     for dataset in args.datasets:
         print(f"loading {dataset}...")
         for model in args.models:

--- a/examples/dataset/question_answering/tests/test_question_answering.py
+++ b/examples/dataset/question_answering/tests/test_question_answering.py
@@ -11,20 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from argparse import Namespace
-from collections.abc import Iterator
 
-import pytest
 from question_answering.upload_dataset import run as upload_dataset_main
-
-from kolena._utils.state import kolena_session
-
-
-@pytest.fixture(scope="session", autouse=True)
-def with_init() -> Iterator[None]:
-    with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
-        yield
 
 
 def test__upload_datasets() -> None:

--- a/examples/dataset/rain_forecast/pyproject.toml
+++ b/examples/dataset/rain_forecast/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-kolena = "^1.8.0"
+kolena = "^1.9.0"
 s3fs = "^2022.7.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/dataset/rain_forecast/pyproject.toml
+++ b/examples/dataset/rain_forecast/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-kolena = ">=1.0.0"
+kolena = "^1.8.0"
 s3fs = "^2022.7.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/dataset/rain_forecast/rain_forecast/upload_dataset.py
+++ b/examples/dataset/rain_forecast/rain_forecast/upload_dataset.py
@@ -18,12 +18,10 @@ import pandas as pd
 from rain_forecast.constants import BUCKET
 from rain_forecast.constants import DATASET
 
-import kolena
 from kolena.dataset import upload_dataset
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     df_dataset = pd.read_csv(args.dataset_csv, storage_options={"anon": True})
     upload_dataset(args.dataset_name, df_dataset, id_fields=["Date", "Location"])
 

--- a/examples/dataset/rain_forecast/rain_forecast/upload_results.py
+++ b/examples/dataset/rain_forecast/rain_forecast/upload_results.py
@@ -23,7 +23,6 @@ from rain_forecast.constants import EVAL_CONFIG
 from rain_forecast.constants import MODEL_NAME
 from tqdm import tqdm
 
-import kolena
 from kolena.dataset import upload_results
 
 
@@ -70,8 +69,6 @@ def run(args: Namespace) -> None:
         )
 
     df_results = pd.DataFrame.from_records(results)
-
-    kolena.initialize(verbose=True)
     upload_results(args.dataset, MODEL_NAME[args.model], [(EVAL_CONFIG, df_results)])
 
 

--- a/examples/dataset/search_embeddings/pyproject.toml
+++ b/examples/dataset/search_embeddings/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.13"
-kolena = "^1.8.0"
+kolena = "^1.9.0"
 s3fs = "^2023.5.0"
 kolena-embeddings = {version = "^0.6.0", source = "kolena-embeddings"}
 

--- a/examples/dataset/search_embeddings/pyproject.toml
+++ b/examples/dataset/search_embeddings/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.13"
-kolena = ">=1.3.0"
+kolena = "^1.8.0"
 s3fs = "^2023.5.0"
 kolena-embeddings = {version = "^0.6.0", source = "kolena-embeddings"}
 

--- a/examples/dataset/search_embeddings/search_embeddings/upload_embeddings.py
+++ b/examples/dataset/search_embeddings/search_embeddings/upload_embeddings.py
@@ -27,7 +27,6 @@ from kembed.util import load_embedding_model
 from PIL import Image
 from tqdm import tqdm
 
-import kolena
 from kolena._experimental.search import upload_dataset_embeddings
 from kolena.dataset import download_dataset
 
@@ -121,7 +120,6 @@ def load_precomputed_embedding() -> pd.DataFrame:
 
 
 def run(run_extraction: bool, dataset_name: str, local_path: str) -> None:
-    kolena.initialize(verbose=True)
     df_dataset = download_dataset(dataset_name)
 
     model, model_key = load_embedding_model()

--- a/examples/dataset/semantic_segmentation/pyproject.toml
+++ b/examples/dataset/semantic_segmentation/pyproject.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 opencv-python-headless = ">=4.6.0.66,<4.7"
-kolena = ">=1.2.0"
+kolena = "^1.8.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/semantic_segmentation/pyproject.toml
+++ b/examples/dataset/semantic_segmentation/pyproject.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 opencv-python-headless = ">=4.6.0.66,<4.7"
-kolena = "^1.8.0"
+kolena = "^1.9.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/semantic_segmentation/semantic_segmentation/upload_activation_map.py
+++ b/examples/dataset/semantic_segmentation/semantic_segmentation/upload_activation_map.py
@@ -22,7 +22,6 @@ from semantic_segmentation.constants import MODEL_NAME
 from semantic_segmentation.utils import activation_map_locator_path
 from semantic_segmentation.utils import inference_locator_path
 
-import kolena
 from kolena.dataset import download_dataset
 
 
@@ -35,7 +34,6 @@ def upload_activation_map(model_name: str, write_bucket: str) -> None:
 
 
 def main(args: Namespace) -> int:
-    kolena.initialize(verbose=True)
     upload_activation_map(args.model, args.write_bucket)
     return 0
 

--- a/examples/dataset/semantic_segmentation/semantic_segmentation/upload_dataset.py
+++ b/examples/dataset/semantic_segmentation/semantic_segmentation/upload_dataset.py
@@ -18,13 +18,11 @@ import pandas as pd
 from semantic_segmentation.constants import BUCKET
 from semantic_segmentation.constants import DATASET
 
-import kolena
 from kolena.annotation import SegmentationMask
 from kolena.dataset import upload_dataset
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     df_dataset = pd.read_csv(args.dataset_csv, storage_options={"anon": True}, converters={"captions": pd.eval})
     df_dataset["mask"] = df_dataset["mask"].apply(lambda mask: SegmentationMask(locator=mask, labels={1: "PERSON"}))
     upload_dataset(args.dataset_name, df_dataset)

--- a/examples/dataset/semantic_segmentation/semantic_segmentation/upload_results.py
+++ b/examples/dataset/semantic_segmentation/semantic_segmentation/upload_results.py
@@ -33,7 +33,6 @@ from semantic_segmentation.utils import result_masks_locator_path
 from semantic_segmentation.utils import upload_result_masks
 from tqdm import tqdm
 
-import kolena
 from kolena.annotation import BitmapMask
 from kolena.annotation import SegmentationMask
 from kolena.asset import BinaryAsset
@@ -88,8 +87,6 @@ def compute_metrics(record: RecordType) -> Dict[str, Any]:
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
-
     threshold = EVAL_CONFIG["threshold"]
 
     df_dataset = download_dataset(args.dataset)

--- a/examples/dataset/semantic_segmentation/tests/test_semantic_segmentation.py
+++ b/examples/dataset/semantic_segmentation/tests/test_semantic_segmentation.py
@@ -11,25 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import random
 import string
 from argparse import Namespace
-from collections.abc import Iterator
 
 import pytest
 from semantic_segmentation.constants import BUCKET
 from semantic_segmentation.constants import DATASET
 from semantic_segmentation.upload_dataset import run as upload_dataset_run
 from semantic_segmentation.upload_results import run as upload_results_run
-
-from kolena._utils.state import kolena_session
-
-
-@pytest.fixture(scope="session", autouse=True)
-def with_init() -> Iterator[None]:
-    with kolena_session(api_token=os.environ["KOLENA_TOKEN"]):
-        yield
 
 
 @pytest.fixture(scope="module")

--- a/examples/dataset/semantic_textual_similarity/pyproject.toml
+++ b/examples/dataset/semantic_textual_similarity/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = ">=1.5.0"
+kolena = "^1.8.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/semantic_textual_similarity/pyproject.toml
+++ b/examples/dataset/semantic_textual_similarity/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = "^1.8.0"
+kolena = "^1.9.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/semantic_textual_similarity/semantic_textual_similarity/upload_dataset.py
+++ b/examples/dataset/semantic_textual_similarity/semantic_textual_similarity/upload_dataset.py
@@ -18,13 +18,11 @@ from semantic_textual_similarity.constants import BUCKET
 from semantic_textual_similarity.constants import DATASET
 from semantic_textual_similarity.constants import ID_FIELD
 
-import kolena
 from kolena.dataset import upload_dataset
 from kolena.io import dataframe_from_csv
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     df_dataset = dataframe_from_csv(args.dataset_csv, storage_options={"anon": True})
     upload_dataset(args.dataset, df_dataset, id_fields=[ID_FIELD])
 

--- a/examples/dataset/semantic_textual_similarity/semantic_textual_similarity/upload_results.py
+++ b/examples/dataset/semantic_textual_similarity/semantic_textual_similarity/upload_results.py
@@ -22,14 +22,11 @@ from semantic_textual_similarity.constants import MODELS
 from semantic_textual_similarity.metrics import compute_metrics
 from tqdm import tqdm
 
-import kolena
 from kolena.dataset import download_dataset
 from kolena.dataset import upload_results
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
-
     model = MODELS[args.model]
     df_dataset = download_dataset(args.dataset)
     df_inferences = pd.read_csv(f"s3://{BUCKET}/{DATASET}/results/raw/{model}.csv", storage_options={"anon": True})

--- a/examples/dataset/speaker_diarization/pyproject.toml
+++ b/examples/dataset/speaker_diarization/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = "^1.8.0"
+kolena = "^1.9.0"
 pyannote-metrics = "^3.2.1"
 s3fs = "^2023.10.0"
 pyannote-core = "^5.0.0"

--- a/examples/dataset/speaker_diarization/pyproject.toml
+++ b/examples/dataset/speaker_diarization/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = ">=1.0.0"
+kolena = "^1.8.0"
 pyannote-metrics = "^3.2.1"
 s3fs = "^2023.10.0"
 pyannote-core = "^5.0.0"

--- a/examples/dataset/speaker_diarization/speaker_diarization/upload_dataset.py
+++ b/examples/dataset/speaker_diarization/speaker_diarization/upload_dataset.py
@@ -17,12 +17,10 @@ from argparse import Namespace
 from speaker_diarization.data_loader import DATASET
 from speaker_diarization.data_loader import load_data
 
-import kolena
 from kolena.dataset import upload_dataset
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     df = load_data()
     sample_count = args.sample_count
     if sample_count:

--- a/examples/dataset/speaker_diarization/speaker_diarization/upload_results.py
+++ b/examples/dataset/speaker_diarization/speaker_diarization/upload_results.py
@@ -21,7 +21,6 @@ from speaker_diarization.data_loader import load_results
 from speaker_diarization.utils import compute_metrics
 from speaker_diarization.utils import realign_labels
 
-import kolena
 from kolena.dataset import upload_results
 
 
@@ -30,8 +29,6 @@ def align_df_speakers(ref: pd.Series, inf: pd.Series) -> pd.Series:
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
-
     model = "gcp-stt-video"
     align_speakers = args.align_speakers
     sample_count = args.sample_count

--- a/examples/dataset/text_summarization/pyproject.toml
+++ b/examples/dataset/text_summarization/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-kolena = "^1.8.0"
+kolena = "^1.9.0"
 s3fs = "^2022.7.1"
 scikit-learn = "^1.1.2"
 numba = "^0.56.0"

--- a/examples/dataset/text_summarization/pyproject.toml
+++ b/examples/dataset/text_summarization/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-kolena = ">=1.0.0"
+kolena = "^1.8.0"
 s3fs = "^2022.7.1"
 scikit-learn = "^1.1.2"
 numba = "^0.56.0"

--- a/examples/dataset/text_summarization/text_summarization/upload_dataset.py
+++ b/examples/dataset/text_summarization/text_summarization/upload_dataset.py
@@ -18,13 +18,11 @@ from text_summarization.constants import BUCKET
 from text_summarization.constants import DATASET
 from text_summarization.constants import ID_FIELD
 
-import kolena
 from kolena.dataset import upload_dataset
 from kolena.io import dataframe_from_csv
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
     df_dataset = dataframe_from_csv(args.dataset_csv, storage_options={"anon": True})
     upload_dataset(args.dataset, df_dataset, id_fields=[ID_FIELD])
 

--- a/examples/dataset/text_summarization/text_summarization/upload_results.py
+++ b/examples/dataset/text_summarization/text_summarization/upload_results.py
@@ -22,14 +22,11 @@ from text_summarization.constants import MODELS
 from text_summarization.metrics import compute_metrics
 from tqdm import tqdm
 
-import kolena
 from kolena.dataset import download_dataset
 from kolena.dataset import upload_results
 
 
 def run(args: Namespace) -> None:
-    kolena.initialize(verbose=True)
-
     model = MODELS[args.model]
     df_dataset = download_dataset(args.dataset)
     df_inferences = pd.read_csv(f"s3://{BUCKET}/{DATASET}/results/raw/{model}.csv", storage_options={"anon": True})


### PR DESCRIPTION
### Linked issue(s)
Fixes KOL-5451

### What change does this PR introduce and why?
Kolena version 1.8.0 shipped auto-initialization removing the need to explicitly call `kolena.initialize`.
Uses Kolena version 1.9.0 since `kolena.initialize` verbose was changed to default to `True`

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated