### PR TITLE
Update `kolena.initialize` verbose default to True

### DIFF
--- a/docs/installing-kolena.md
+++ b/docs/installing-kolena.md
@@ -59,13 +59,13 @@ export KOLENA_TOKEN="********"
 ```
 
 By default, sessions are automatically initialized when a function requiring initialization is called. To configure
-your session, e.g. to enable extra logging via `verbose=True`, you can manually initialize by calling
+your session, e.g. to disable extra logging via `verbose=False`, you can manually initialize by calling
 [`kolena.initialize(...)`](./reference/initialize.md) directly:
 
 ```python
 import kolena
 
-kolena.initialize(verbose=True)
+kolena.initialize(verbose=False)
 ```
 
 By default, sessions have static scope and persist until the interpreter is exited. See the documentation on

--- a/kolena/initialize.py
+++ b/kolena/initialize.py
@@ -97,7 +97,7 @@ def initialize(
     :param verbose: Run the client in verbose mode, providing more information about execution. All logging
         events are emitted as Python standard library `logging` events from the `"kolena"` logger as well as
         to stdout/stderr directly.
-    :param proxies: Configure the client to run with `http` or `https` proxies. The `proxies` parameter
+    :param proxies: Run the client with `http` or `https` proxies. The `proxies` parameter
         is passed through to the `requests` package and can be
         [configured accordingly](https://requests.readthedocs.io/en/latest/user/advanced/#proxies).
     :raises InvalidTokenError: The provided `api_token` is not valid.

--- a/kolena/initialize.py
+++ b/kolena/initialize.py
@@ -37,7 +37,7 @@ from kolena.errors import MissingTokenError
 def initialize(
     *args: Any,
     api_token: Optional[str] = None,
-    verbose: bool = False,
+    verbose: bool = True,
     proxies: Optional[Dict[str, str]] = None,
     **kwargs: Any,
 ) -> None:
@@ -57,7 +57,7 @@ def initialize(
     ```python
     import kolena
 
-    kolena.initialize(api_token=your_token, verbose=True)
+    kolena.initialize(api_token=your_token)
     ```
 
     2. Populate the `KOLENA_TOKEN` environment variable and call `kolena.initialize()`:
@@ -92,12 +92,12 @@ def initialize(
         As of version 0.29.0: the `entity` argument is no longer needed; the signature `initialize(entity, api_token)`
         has been deprecated and replaced by `initialize(api_token)`.
 
-    :param api_token: Optionally provide an API token, otherwise attempts to find a token in `$KOLENA_TOKEN`
+    :param api_token: Directly provide an API token, otherwise attempts to find a token in `$KOLENA_TOKEN`
         or your `.netrc` file. This token is a secret and should be treated with caution.
-    :param verbose: Optionally configure client to run in verbose mode, providing more information about execution. All
-        logging events are emitted as Python standard library `logging` events from the `"kolena"` logger as well as
+    :param verbose: Run the client in verbose mode, providing more information about execution. All logging
+        events are emitted as Python standard library `logging` events from the `"kolena"` logger as well as
         to stdout/stderr directly.
-    :param proxies: Optionally configure client to run with `http` or `https` proxies. The `proxies` parameter
+    :param proxies: Configure the client to run with `http` or `https` proxies. The `proxies` parameter
         is passed through to the `requests` package and can be
         [configured accordingly](https://requests.readthedocs.io/en/latest/user/advanced/#proxies).
     :raises InvalidTokenError: The provided `api_token` is not valid.


### PR DESCRIPTION
### What change does this PR introduce and why?
Updates `kolena.initialize` verbose default value to True. The majority of calls to `kolena.initialize` in this package and docs use `verbose=True` since it enables logging to stdout/stderr providing valuable feedback to the user. This updates `kolena.initialize` to default to using `verbose=True` to match the most common invocation pattern.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
