### PR TITLE
Add direnv related files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 **/coverage.xml
 **/coverage.lcov
 
+.envrc
+.direnv/
 .idea/
 .vscode/
 *.code-workspace


### PR DESCRIPTION
### What change does this PR introduce and why?
Adds [direnv](https://github.com/direnv/direnv) related files to `.gitignore`.

direnv is useful for setting project specific environment variables (eg. `KOLENA_TOKEN` set to dev tenant when in repo, otherwise production). I use a variation of the [poetry layout](https://github.com/direnv/direnv/wiki/Python#poetry) to set the `venv` location for my Python language server and add it to my path (no need to prefix commands with `poetry run ....`)

