### PR TITLE
Accommodate Pandas<3 for Python<3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ numpy = [
     { version = ">=1.26", python = ">=3.12" },
 ]
 pandas = [
-    { version = ">=1.1,<1.6", python = ">=3.8,<3.11" },
-    { version = ">=1.5,<1.6", python = ">=3.11,<3.12" },
+    { version = ">=1.1,<3", python = ">=3.8,<3.11" },
+    { version = ">=1.5,<3", python = ">=3.11,<3.12" },
     { version = ">=2.1.1,<3", python = ">=3.12" },
 ]
 pandera = ">=0.9.0,<0.16"


### PR DESCRIPTION
Relax upper bound for `pandas` dependency for Python versions between 3.8 and 3.11.

Fixes KOL-5824