### PR TITLE
Make _check_multiclass robust to null/NaN values in the series being checked

### DIFF
--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -179,12 +179,16 @@ def _compute_metrics(
 
 def _check_multiclass(ground_truth: pd.Series, inference: pd.Series) -> bool:
     try:
-        labels = {x.label for x in itertools.chain.from_iterable(ground_truth)}.union(
-            {x.label for x in itertools.chain.from_iterable(inference)},
+        labels = {x.label for x in itertools.chain.from_iterable(_filter_null(ground_truth))}.union(
+            {x.label for x in itertools.chain.from_iterable(_filter_null(inference))},
         )
         return len(labels) >= 2
     except AttributeError:
         return False
+
+
+def _filter_null(series: pd.Series) -> pd.Series:
+    return series[series.notnull()]
 
 
 def _validate_column_present(df: pd.DataFrame, col: str) -> None:

--- a/tests/unit/_experimental/object_detection/test_dataset.py
+++ b/tests/unit/_experimental/object_detection/test_dataset.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import math
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -31,12 +32,18 @@ def test__check_multiclass() -> None:
                 [
                     [LabeledBoundingBox(label="dog", top_left=[1, 1], bottom_right=[5, 5])],
                     [LabeledBoundingBox(label="dog", top_left=[10, 10], bottom_right=[15, 15])],
+                    [],
+                    math.nan,
+                    None,
                 ],
             ),
             pd.Series(
                 [
                     [LabeledBoundingBox(label="cat", top_left=[3, 3], bottom_right=[9, 9])],
                     [LabeledBoundingBox(label="dog", top_left=[11, 10], bottom_right=[15, 15])],
+                    [],
+                    math.nan,
+                    None,
                 ],
             ),
         )
@@ -49,12 +56,18 @@ def test__check_multiclass() -> None:
                 [
                     [LabeledBoundingBox(label="dog", top_left=[1, 1], bottom_right=[5, 5])],
                     [LabeledBoundingBox(label="dog", top_left=[10, 10], bottom_right=[15, 15])],
+                    [],
+                    math.nan,
+                    None,
                 ],
             ),
             pd.Series(
                 [
                     [LabeledBoundingBox(label="dog", top_left=[3, 3], bottom_right=[9, 9])],
                     [LabeledBoundingBox(label="dog", top_left=[11, 10], bottom_right=[15, 15])],
+                    [],
+                    math.nan,
+                    None,
                 ],
             ),
         )


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?
Make `_check_multiclass` robust to null/NaN values in the series being checked

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
