### PR TITLE
fix: `dataframe_to_csv` only serialize list/dict to JSON

### DIFF
--- a/kolena/io.py
+++ b/kolena/io.py
@@ -42,7 +42,7 @@ def _deserialize_dataobject(x: Any) -> Any:
         return [_deserialize_dataobject(item) for item in x]
 
     if isinstance(x, dict):
-        if data_type := x.get(DATA_TYPE_FIELD):
+        if data_type := x.pop(DATA_TYPE_FIELD, None):
             if typed_dataobject := _DATA_TYPE_MAP.get(data_type):
                 return typed_dataobject._from_dict(x)
         else:
@@ -52,7 +52,7 @@ def _deserialize_dataobject(x: Any) -> Any:
 
 
 def _serialize_dataobject_str(x: Any) -> Any:
-    if isinstance(x, list) or isinstance(x, dict):
+    if isinstance(x, list) or isinstance(x, dict) or isinstance(x, DataObject):
         return json.dumps(x, cls=DataObjectJSONEncoder)
     return x
 

--- a/kolena/io.py
+++ b/kolena/io.py
@@ -52,7 +52,7 @@ def _deserialize_dataobject(x: Any) -> Any:
 
 
 def _serialize_dataobject_str(x: Any) -> Any:
-    if isinstance(x, list) or isinstance(x, dict) or isinstance(x, DataObject):
+    if isinstance(x, (list, dict, DataObject)):
         return json.dumps(x, cls=DataObjectJSONEncoder)
     return x
 

--- a/kolena/io.py
+++ b/kolena/io.py
@@ -52,7 +52,9 @@ def _deserialize_dataobject(x: Any) -> Any:
 
 
 def _serialize_dataobject_str(x: Any) -> Any:
-    return json.dumps(x, cls=DataObjectJSONEncoder)
+    if isinstance(x, list) or isinstance(x, dict):
+        return json.dumps(x, cls=DataObjectJSONEncoder)
+    return x
 
 
 def _deserialize_dataobject_str(x: Any) -> Any:

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -11,13 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from io import StringIO
+from math import isnan
 
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
 from kolena.annotation import BoundingBox
 from kolena.annotation import LabeledBoundingBox
+from kolena.io import _serialize_dataobject_str
 from kolena.io import dataframe_from_csv
 from kolena.io import dataframe_from_json
 from kolena.io import dataframe_to_csv
@@ -48,36 +51,37 @@ DF_TEST = pd.DataFrame.from_dict(
         + ["car"] * 2,
     },
 )
-DF_EXPECTED = pd.DataFrame.from_dict(
-    {
-        "z": [dict(value=i + 0.3) for i in range(10)],
-        "partial": [None, ""] + ["fan"] * 8,
-        "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
-        "deep_data": [
-            dict(asset=[BoundingBox(label=f"bar-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10])])
-            for i in range(10)
-        ],
-        "id": list(range(10)),
-        "bad actor": [
-            "{",
-            dict(value="box"),
-            15,
-            None,
-            "foo",
-            [1, "3", "5"],
-            BoundingBox(label="cat", top_left=[3, 5], bottom_right=[10, 15]),
-            "",
-        ]
-        + ["car"] * 2,
-    },
-)
 
 
 def test__dataframe_json() -> None:
     json_str = DF_TEST.to_json()
     df_deserialized = dataframe_from_json(json_str)
 
-    assert_frame_equal(df_deserialized, DF_EXPECTED)
+    json_df_expected = pd.DataFrame.from_dict(
+        {
+            "z": [dict(value=i + 0.3) for i in range(10)],
+            "partial": [None, ""] + ["fan"] * 8,
+            "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
+            "deep_data": [
+                dict(asset=[BoundingBox(label=f"bar-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10])])
+                for i in range(10)
+            ],
+            "id": list(range(10)),
+            "bad actor": [
+                "{",
+                dict(value="box"),
+                15,
+                None,
+                "foo",
+                [1, "3", "5"],
+                BoundingBox(label="cat", top_left=[3, 5], bottom_right=[10, 15]),
+                "",
+            ]
+            + ["car"] * 2,
+        },
+    )
+
+    assert_frame_equal(df_deserialized, json_df_expected)
     assert df_deserialized.iloc[0]["id"] == 0
     assert df_deserialized.iloc[0]["data"].label == "foo-0"
 
@@ -86,9 +90,50 @@ def test__dataframe_csv() -> None:
     csv_str = dataframe_to_csv(DF_TEST, index=False)
     df_deserialized = dataframe_from_csv(StringIO(csv_str))
 
-    assert_frame_equal(df_deserialized, DF_EXPECTED)
+    csv_df_expected = pd.DataFrame.from_dict(
+        {
+            "z": [dict(value=i + 0.3) for i in range(10)],
+            "partial": [NAN, NAN] + ["fan"] * 8,
+            "data": [BoundingBox(label=f"foo-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10]) for i in range(10)],
+            "deep_data": [
+                dict(asset=[BoundingBox(label=f"bar-{i}", top_left=[i, i], bottom_right=[i + 10, i + 10])])
+                for i in range(10)
+            ],
+            "id": list(range(10)),
+            "bad actor": [
+                "{",
+                dict(value="box"),
+                15,
+                NAN,
+                "foo",
+                [1, "3", "5"],
+                BoundingBox(label="cat", top_left=[3, 5], bottom_right=[10, 15]),
+                NAN,
+            ]
+            + ["car"] * 2,
+        },
+    )
+
+    assert_frame_equal(df_deserialized, csv_df_expected)
     assert df_deserialized.iloc[0]["id"] == 0
     assert df_deserialized.iloc[0]["data"].label == "foo-0"
+
+
+def test___serialize_dataobject_str() -> None:
+    # does not serialize
+    assert 1 == _serialize_dataobject_str(1)
+    assert "locator" == _serialize_dataobject_str("locator")
+    assert isnan(_serialize_dataobject_str(NAN))
+
+    labeled_bbox = LabeledBoundingBox(label="foo", top_left=[0, 0], bottom_right=[10, 10])
+    bbox = BoundingBox(label="foo", top_left=[0, 0], bottom_right=[10, 10])
+
+    # serializes
+    assert json.dumps(bbox._to_dict()) == _serialize_dataobject_str(labeled_bbox)
+    assert json.dumps(["locator"]) == _serialize_dataobject_str(["locator"])
+    assert json.dumps(dict(field1=True, field2="locator", field3=bbox._to_dict())) == _serialize_dataobject_str(
+        dict(field1=True, field2="locator", field3=labeled_bbox),
+    )
 
 
 def test__dataframe_csv__malformed_input() -> None:


### PR DESCRIPTION
### Linked issue(s)
KOL-5841

### What change does this PR introduce and why?
Fixes a bug in `dataframe_to_csv` where primitives where being dumped to JSON. Add guard to only dump lists/dicts

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
