### PR TITLE
fix: Update `data_type` retrieval to not modify underlying dict

### DIFF
--- a/kolena/io.py
+++ b/kolena/io.py
@@ -42,7 +42,7 @@ def _deserialize_dataobject(x: Any) -> Any:
         return [_deserialize_dataobject(item) for item in x]
 
     if isinstance(x, dict):
-        if data_type := x.pop(DATA_TYPE_FIELD, None):
+        if data_type := x.get(DATA_TYPE_FIELD):
             if typed_dataobject := _DATA_TYPE_MAP.get(data_type):
                 return typed_dataobject._from_dict(x)
         else:

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -40,7 +40,7 @@ DF_TEST = pd.DataFrame.from_dict(
         "id": list(range(10)),
         "bad actor": [
             "{",
-            dict(value="box"),
+            dict(value="box", data_type="MY/DATATYPE"),
             15,
             None,
             "foo",
@@ -69,7 +69,7 @@ def test__dataframe_json() -> None:
             "id": list(range(10)),
             "bad actor": [
                 "{",
-                dict(value="box"),
+                dict(value="box", data_type="MY/DATATYPE"),
                 15,
                 None,
                 "foo",
@@ -102,7 +102,7 @@ def test__dataframe_csv() -> None:
             "id": list(range(10)),
             "bad actor": [
                 "{",
-                dict(value="box"),
+                dict(value="box", data_type="MY/DATATYPE"),
                 15,
                 NAN,
                 "foo",


### PR DESCRIPTION
### What change does this PR introduce and why?
Updates `data_type` retrieval in `_deserialize_dataobject` to use `get` instead of `pop`, so that the underlying dictionary is unmodified. This fixes a bug where `data_type` was removed from all dicts during deserialization.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
