### PR TITLE
fix: Prepopulate `_DATA_TYPE_MAP`

### DIFF
--- a/kolena/_experimental/workflow/thresholded.py
+++ b/kolena/_experimental/workflow/thresholded.py
@@ -17,6 +17,7 @@ from dataclasses import fields
 from typing import Any
 
 from kolena._utils.datatypes import _register_data_type
+from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
 
@@ -34,8 +35,8 @@ class _MetricsType(DataType):
     THRESHOLDED = "THRESHOLDED"
 
     @staticmethod
-    def _data_category() -> str:
-        return "METRICS"
+    def _data_category() -> DataCategory:
+        return DataCategory.METRICS
 
 
 @dataclass(frozen=True)

--- a/kolena/_utils/datatypes.py
+++ b/kolena/_utils/datatypes.py
@@ -36,6 +36,7 @@ import pandera as pa
 from pydantic.dataclasses import dataclass
 from pydantic.dataclasses import is_pydantic_dataclass
 
+from kolena._utils import log
 from kolena._utils.dataframes.validators import validate_df_schema
 from kolena._utils.validators import ValidatorConfig
 
@@ -111,6 +112,8 @@ def _get_data_type(name: str) -> Optional[Type["TypedDataObject"]]:
             data_category, _ = name.split("/")
             module = DataCategory(data_category).data_category_to_module_name()
             importlib.import_module(module)
+        except (ValueError, ModuleNotFoundError) as e:
+            log.error(f"Failed to import module for data type '{name}'", e)
         finally:
             return _DATA_TYPE_MAP.get(name, None)
     return class_type

--- a/kolena/annotation.py
+++ b/kolena/annotation.py
@@ -41,6 +41,7 @@ from typing import Tuple
 from pydantic.dataclasses import dataclass
 
 from kolena._utils.datatypes import _register_data_type
+from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
 from kolena._utils.validators import ValidatorConfig
@@ -58,8 +59,8 @@ class _AnnotationType(DataType):
     TIME_SEGMENT = "TIME_SEGMENT"
 
     @staticmethod
-    def _data_category() -> str:
-        return "ANNOTATION"
+    def _data_category() -> DataCategory:
+        return DataCategory.ANNOTATION
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/asset.py
+++ b/kolena/asset.py
@@ -32,6 +32,7 @@ from typing import Optional
 from pydantic.dataclasses import dataclass
 
 from kolena._utils.datatypes import _register_data_type
+from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
 from kolena._utils.validators import ValidatorConfig
@@ -46,8 +47,8 @@ class _AssetType(DataType):
     AUDIO = "AUDIO"
 
     @staticmethod
-    def _data_category() -> str:
-        return "ASSET"
+    def _data_category() -> DataCategory:
+        return DataCategory.ASSET
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/io.py
+++ b/kolena/io.py
@@ -26,7 +26,7 @@ from typing import Union
 import pandas as pd
 
 from kolena._utils.dataframes.transformers import df_apply
-from kolena._utils.datatypes import _DATA_TYPE_MAP
+from kolena._utils.datatypes import _get_data_type
 from kolena._utils.datatypes import DATA_TYPE_FIELD
 from kolena._utils.datatypes import DataObject
 
@@ -44,7 +44,7 @@ def _deserialize_dataobject(x: Any) -> Any:
 
     if isinstance(x, dict):
         if data_type := x.pop(DATA_TYPE_FIELD, None):
-            if typed_dataobject := _DATA_TYPE_MAP.get(data_type):
+            if typed_dataobject := _get_data_type(data_type):
                 return typed_dataobject._from_dict(x)
         else:
             return {k: _deserialize_dataobject(v) for k, v in x.items()}

--- a/kolena/workflow/plot.py
+++ b/kolena/workflow/plot.py
@@ -34,6 +34,7 @@ from typing import Union
 import numpy as np
 from pydantic.dataclasses import dataclass
 
+from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataObject
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
@@ -53,8 +54,8 @@ class _PlotType(DataType):
     BAR = "BAR"
 
     @staticmethod
-    def _data_category() -> str:
-        return "PLOT"
+    def _data_category() -> DataCategory:
+        return DataCategory.PLOT
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/test_sample.py
+++ b/kolena/workflow/test_sample.py
@@ -58,6 +58,7 @@ from pydantic import StrictStr
 from pydantic.dataclasses import dataclass
 
 from kolena._utils.datatypes import _register_data_type
+from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
 from kolena._utils.validators import ValidatorConfig
@@ -127,8 +128,8 @@ class _TestSampleType(DataType):
     CUSTOM = "CUSTOM"
 
     @staticmethod
-    def _data_category() -> str:
-        return "TEST_SAMPLE"
+    def _data_category() -> DataCategory:
+        return DataCategory.TEST_SAMPLE
 
 
 @dataclass(frozen=True, config=ValidatorConfig)


### PR DESCRIPTION
### Linked issue(s)
Fixes KOL-5860

### What change does this PR introduce and why?
Fixes a bug where `_DATA_TYPE_MAP` is missing Annotation, Asset, TestSample, Thresholded if the corresponding `TypedDataObject` has not been subclassed in the current Python process.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
