### PR TITLE
Use projected bounding boxes in KITTI example

### DIFF
--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_dataset.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_dataset.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from argparse import ArgumentParser
 from argparse import Namespace
-from collections import Counter
 
 import pandas as pd
 from object_detection_3d.constants import BUCKET
@@ -21,13 +20,9 @@ from object_detection_3d.constants import DATASET
 from object_detection_3d.constants import DEFAULT_DATASET_NAME
 from object_detection_3d.constants import ID_FIELDS
 from object_detection_3d.constants import TASK
-from object_detection_3d.utils import create_velo_to_pixel_matrix
+from object_detection_3d.utils import load_data
 
-from kolena.annotation import LabeledBoundingBox
-from kolena.annotation import LabeledBoundingBox3D
-from kolena.asset import ImageAsset
 from kolena.dataset import upload_dataset
-from kolena.workflow.asset import PointCloudAsset
 
 # KITTI only supports evaluation of the first three classes but "Van" and "Person_sitting" GTs
 # are used to avoid penalizing inferences labeled as "Car" and "Pedestrian" respectively.
@@ -48,77 +43,6 @@ LABEL_FILE_COLUMNS = {
 }
 
 
-def load_data(df_raw: pd.DataFrame) -> pd.DataFrame:
-    records = []
-    meta_cols = [col for col in df_raw.columns if col not in LABEL_FILE_COLUMNS]
-
-    for record in df_raw.itertuples():
-        bboxes_2d = [
-            LabeledBoundingBox(
-                label=box["label"],
-                top_left=tuple(box["left_top_left"]),
-                bottom_right=tuple(box["left_bottom_right"]),
-                occluded=box["occluded"],  # type: ignore[call-arg]
-                truncated=box["truncated"],  # type: ignore[call-arg]
-                alpha=box["alpha"],  # type: ignore[call-arg]
-                difficulty=box["difficulty"],  # type: ignore[call-arg]
-            )
-            for box in record.objects
-        ]
-        bboxes_3d = [
-            LabeledBoundingBox3D(
-                label=box["label"],
-                dimensions=(box["dim_x"], box["dim_y"], box["dim_z"]),
-                center=(box["loc_x"], box["loc_y"], box["loc_z"] + (box["dim_z"] / 2.0)),
-                # translate in z (up) axis to be in center
-                rotations=(0.0, 0.0, box["rotation_y"]),  # Z yaw axis for lidar coordinates
-                occluded=box["occluded"],  # type: ignore[call-arg]
-                truncated=box["truncated"],  # type: ignore[call-arg]
-                alpha=box["alpha"],  # type: ignore[call-arg]
-                difficulty=box["difficulty"],  # type: ignore[call-arg]
-            )
-            for box in record.objects
-        ]
-        counts = Counter([r["label"] for r in record.objects])
-        metadata = {col: getattr(record, col) for col in meta_cols}
-
-        records.append(
-            {
-                "image_id": record.image_id,
-                "locator": record.left_image,
-                "image_bboxes": bboxes_2d,
-                "images": [
-                    ImageAsset(
-                        locator=record.left_image,
-                        side="left",  # type: ignore[call-arg]
-                        # type: ignore[call-arg]
-                        projection=create_velo_to_pixel_matrix(record.Tr_velo_to_cam, record.P2),
-                        velodyne_bboxes=bboxes_3d,  # type: ignore[call-arg]
-                    ),
-                    ImageAsset(
-                        locator=record.right_image,
-                        side="right",  # type: ignore[call-arg]
-                        # type: ignore[call-arg]
-                        projection=create_velo_to_pixel_matrix(record.Tr_velo_to_cam, record.P3),
-                        velodyne_bboxes=bboxes_3d,  # type: ignore[call-arg]
-                    ),
-                ],
-                "velodyne": PointCloudAsset(locator=record.velodyne),
-                "total_objects": len(bboxes_3d),
-                "n_car": counts["Car"],
-                "n_pedestrian": counts["Pedestrian"],
-                "n_cyclist": counts["Cyclist"],
-                "velodyne_bboxes": bboxes_3d,
-                "velodyne_to_camera_transformation": record.Tr_velo_to_cam,
-                "camera_rectification": record.R0_rect,
-                "projection": create_velo_to_pixel_matrix(record.Tr_velo_to_cam, record.P2),
-                **metadata,
-            },
-        )
-
-    return pd.DataFrame(records)
-
-
 def run(args: Namespace) -> int:
     df_raw = pd.read_json(
         f"s3://{BUCKET}/{DATASET}/{TASK}/raw/{DATASET}.jsonl",
@@ -128,6 +52,7 @@ def run(args: Namespace) -> int:
         storage_options={"anon": True},
     )
     df = load_data(df_raw)
+    df.drop(columns=["image_bboxes"], inplace=True)
     upload_dataset(args.dataset, df, id_fields=ID_FIELDS)
     return 0
 

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_dataset.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_dataset.py
@@ -27,20 +27,6 @@ from kolena.dataset import upload_dataset
 # KITTI only supports evaluation of the first three classes but "Van" and "Person_sitting" GTs
 # are used to avoid penalizing inferences labeled as "Car" and "Pedestrian" respectively.
 SUPPORTED_LABELS = ["Car", "Pedestrian", "Cyclist", "Van", "Person_sitting", "DontCare"]
-LABEL_FILE_COLUMNS = {
-    "image_id",
-    "left_image",
-    "right_image",
-    "velodyne",
-    "objects",
-    "P0",
-    "P1",
-    "P2",
-    "P3",
-    "R0_rect",
-    "Tr_velo_to_cam",
-    "Tr_imu_to_velo",
-}
 
 
 def run(args: Namespace) -> int:

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_dataset.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_dataset.py
@@ -52,7 +52,7 @@ def run(args: Namespace) -> int:
         storage_options={"anon": True},
     )
     df = load_data(df_raw)
-    df.drop(columns=["image_bboxes"], inplace=True)
+    df.drop(columns=["image_bboxes", "images"], inplace=True)
     upload_dataset(args.dataset, df, id_fields=ID_FIELDS)
     return 0
 

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_dataset.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_dataset.py
@@ -23,6 +23,7 @@ from object_detection_3d.constants import ID_FIELDS
 from object_detection_3d.constants import TASK
 from object_detection_3d.utils import create_velo_to_pixel_matrix
 
+from kolena.annotation import LabeledBoundingBox
 from kolena.annotation import LabeledBoundingBox3D
 from kolena.asset import ImageAsset
 from kolena.dataset import upload_dataset
@@ -52,18 +53,18 @@ def load_data(df_raw: pd.DataFrame) -> pd.DataFrame:
     meta_cols = [col for col in df_raw.columns if col not in LABEL_FILE_COLUMNS]
 
     for record in df_raw.itertuples():
-        # bboxes_2d = [
-        #     LabeledBoundingBox(
-        #         label=box["label"],
-        #         top_left=tuple(box["left_top_left"]),
-        #         bottom_right=tuple(box["left_bottom_right"]),
-        #         occluded=box["occluded"],  # type: ignore[call-arg]
-        #         truncated=box["truncated"],  # type: ignore[call-arg]
-        #         alpha=box["alpha"],  # type: ignore[call-arg]
-        #         difficulty=box["difficulty"],  # type: ignore[call-arg]
-        #     )
-        #     for box in record.objects
-        # ]
+        bboxes_2d = [
+            LabeledBoundingBox(
+                label=box["label"],
+                top_left=tuple(box["left_top_left"]),
+                bottom_right=tuple(box["left_bottom_right"]),
+                occluded=box["occluded"],  # type: ignore[call-arg]
+                truncated=box["truncated"],  # type: ignore[call-arg]
+                alpha=box["alpha"],  # type: ignore[call-arg]
+                difficulty=box["difficulty"],  # type: ignore[call-arg]
+            )
+            for box in record.objects
+        ]
         bboxes_3d = [
             LabeledBoundingBox3D(
                 label=box["label"],
@@ -85,7 +86,7 @@ def load_data(df_raw: pd.DataFrame) -> pd.DataFrame:
             {
                 "image_id": record.image_id,
                 "locator": record.left_image,
-                # "image_bboxes": bboxes_2d,
+                "image_bboxes": bboxes_2d,
                 "images": [
                     ImageAsset(
                         locator=record.left_image,

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
@@ -228,7 +228,7 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
             TP = [sum(tp) for tp in zip(result["Car"]["tp"], result["Cyclist"]["tp"], result["Pedestrian"]["tp"])]
             FP = [sum(fp) for fp in zip(result["Car"]["fp"], result["Cyclist"]["fp"], result["Pedestrian"]["fp"])]
             FN = [sum(fn) for fn in zip(result["Car"]["fn"], result["Cyclist"]["fn"], result["Pedestrian"]["fn"])]
-            # FP_2D = [inferences for inferences, fp in zip(record.raw_inferences_2d, FP) if fp]
+            FP_2D = [inferences for inferences, fp in zip(record.raw_inferences_2d, FP) if fp]
             FP_3D = [
                 dataclasses.replace(
                     record.raw_inferences_3d[j],
@@ -238,7 +238,7 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                 for j, fp in enumerate(FP)
                 if fp
             ]
-            # TP_2D = [inferences for inferences, tp in zip(record.raw_inferences_2d, TP) if tp]
+            TP_2D = [inferences for inferences, tp in zip(record.raw_inferences_2d, TP) if tp]
             TP_3D = [
                 ScoredLabeledBoundingBox3D(
                     **record.raw_inferences_3d[j]._to_dict(),
@@ -248,7 +248,7 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                 for j, tp in enumerate(TP)
                 if tp
             ]
-            # FN_2D = [image_bboxes for image_bboxes, fn in zip(record.image_bboxes, FN) if fn]
+            FN_2D = [image_bboxes for image_bboxes, fn in zip(record.image_bboxes, FN) if fn]
             FN_3D = [
                 LabeledBoundingBox3D(
                     **record.velodyne_bboxes[j]._to_dict(),
@@ -297,17 +297,20 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                     nMissedObjects=len(FN_3D),
                     nMismatchedInferences=len(FP_3D),
                     thresholds=current_optimal_thresholds,
-                    # FP_2D=FP_2D,
+                    FP_2D=FP_2D,
                     FP_3D=FP_3D,
-                    # TP_2D=TP_2D,
+                    TP_2D=TP_2D,
                     TP_3D=TP_3D,
-                    # FN_2D=FN_2D,
+                    FN_2D=FN_2D,
                     FN_3D=FN_3D,
                     images_with_inferences=[
                         ImageAsset(
                             **img._to_dict(),
+                            FP_2D=FP_2D,  # type: ignore[call-arg]
                             FP_3D=FP_3D,  # type: ignore[call-arg]
+                            TP_2D=TP_2D,  # type: ignore[call-arg]
                             TP_3D=TP_3D,  # type: ignore[call-arg]
+                            FN_2D=FN_2D,  # type: ignore[call-arg]
                             FN_3D=FN_3D,  # type: ignore[call-arg]
                         )
                         for img in record.images

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
@@ -228,7 +228,6 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
             TP = [sum(tp) for tp in zip(result["Car"]["tp"], result["Cyclist"]["tp"], result["Pedestrian"]["tp"])]
             FP = [sum(fp) for fp in zip(result["Car"]["fp"], result["Cyclist"]["fp"], result["Pedestrian"]["fp"])]
             FN = [sum(fn) for fn in zip(result["Car"]["fn"], result["Cyclist"]["fn"], result["Pedestrian"]["fn"])]
-            FP_2D = [inferences for inferences, fp in zip(record.raw_inferences_2d, FP) if fp]
             FP_3D = [
                 dataclasses.replace(
                     record.raw_inferences_3d[j],
@@ -238,7 +237,6 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                 for j, fp in enumerate(FP)
                 if fp
             ]
-            TP_2D = [inferences for inferences, tp in zip(record.raw_inferences_2d, TP) if tp]
             TP_3D = [
                 ScoredLabeledBoundingBox3D(
                     **record.raw_inferences_3d[j]._to_dict(),
@@ -248,7 +246,6 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                 for j, tp in enumerate(TP)
                 if tp
             ]
-            FN_2D = [image_bboxes for image_bboxes, fn in zip(record.image_bboxes, FN) if fn]
             FN_3D = [
                 LabeledBoundingBox3D(
                     **record.velodyne_bboxes[j]._to_dict(),
@@ -297,20 +294,14 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                     nMissedObjects=len(FN_3D),
                     nMismatchedInferences=len(FP_3D),
                     thresholds=current_optimal_thresholds,
-                    FP_2D=FP_2D,
                     FP_3D=FP_3D,
-                    TP_2D=TP_2D,
                     TP_3D=TP_3D,
-                    FN_2D=FN_2D,
                     FN_3D=FN_3D,
                     images_with_inferences=[
                         ImageAsset(
                             **img._to_dict(),
-                            FP_2D=FP_2D,  # type: ignore[call-arg]
                             FP_3D=FP_3D,  # type: ignore[call-arg]
-                            TP_2D=TP_2D,  # type: ignore[call-arg]
                             TP_3D=TP_3D,  # type: ignore[call-arg]
-                            FN_2D=FN_2D,  # type: ignore[call-arg]
                             FN_3D=FN_3D,  # type: ignore[call-arg]
                         )
                         for img in record.images

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
@@ -41,6 +41,7 @@ from kolena import dataset
 from kolena.annotation import LabeledBoundingBox3D
 from kolena.annotation import ScoredLabeledBoundingBox
 from kolena.annotation import ScoredLabeledBoundingBox3D
+from kolena.asset import ImageAsset
 from kolena.dataset import upload_results
 
 CLASS_NAME_VALUE = {"Car": 0, "Cyclist": 2, "Pedestrian": 1}
@@ -303,14 +304,14 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                     # FN_2D=FN_2D,
                     FN_3D=FN_3D,
                     images_with_inferences=[
-                        dataclasses.replace(
-                            img,
-                            FP_3D=FP_3D,
-                            TP_3D=TP_3D,
-                            FN_3D=FN_3D,
-                            matched_inference=matched_inference,
-                            unmatched_ground_truth=unmatched_ground_truth,
-                            unmatched_inference=unmatched_inference,
+                        ImageAsset(
+                            **img._to_dict(),
+                            FP_3D=FP_3D,  # type: ignore[call-arg]
+                            TP_3D=TP_3D,  # type: ignore[call-arg]
+                            FN_3D=FN_3D,  # type: ignore[call-arg]
+                            matched_inference=matched_inference,  # type: ignore[call-arg]
+                            unmatched_ground_truth=unmatched_ground_truth,  # type: ignore[call-arg]
+                            unmatched_inference=unmatched_inference,  # type: ignore[call-arg]
                         )
                         for img in record.images
                     ],

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
@@ -369,7 +369,6 @@ def load_results(model: str) -> pd.DataFrame:
 
 def run(args: Namespace) -> None:
     pred_df = load_results(args.model)
-
     raw_dataset_df = pd.read_json(
         f"s3://{BUCKET}/{DATASET}/{TASK}/raw/{DATASET}.jsonl",
         lines=True,

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
@@ -319,7 +319,7 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
             thresholds=f1_optimal_thresholds[difficulty],
         )
         metrics_df = compute_metrics_with_difficulty(difficulty)
-        results_df = df[["image_id", "raw_inferences_2d", "raw_inferences_3d", *gt_info_columns]].merge(
+        results_df = df[["image_id", "raw_inferences_3d", *gt_info_columns]].merge(
             metrics_df,
             on="image_id",
         )

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
@@ -309,9 +309,6 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                             FP_3D=FP_3D,  # type: ignore[call-arg]
                             TP_3D=TP_3D,  # type: ignore[call-arg]
                             FN_3D=FN_3D,  # type: ignore[call-arg]
-                            matched_inference=matched_inference,  # type: ignore[call-arg]
-                            unmatched_ground_truth=unmatched_ground_truth,  # type: ignore[call-arg]
-                            unmatched_inference=unmatched_inference,  # type: ignore[call-arg]
                         )
                         for img in record.images
                     ],

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
@@ -29,6 +29,7 @@ from object_detection_3d.constants import ID_FIELDS
 from object_detection_3d.constants import MODELS
 from object_detection_3d.constants import TASK
 from object_detection_3d.utils import alpha_from_bbox3D
+from object_detection_3d.utils import bbox_to_kitti_format
 from object_detection_3d.utils import center_to_kitti_format
 from object_detection_3d.utils import transform_to_camera_frame
 from object_detection_3d.vendored.kitti_eval import _prepare_data  # type: ignore[attr-defined]
@@ -53,9 +54,9 @@ def to_kitti_format(df: pd.DataFrame) -> Tuple[List[Dict[str, Any]], List[Dict[s
     dt_annos = []
     labels = set()
     for record in df.itertuples():
-        # gt_bboxes_2d = record.image_bboxes
+        gt_bboxes_2d = record.image_bboxes
         gt_bboxes_3d = record.velodyne_bboxes
-        # inf_bboxes_2d = record.raw_inferences_2d
+        inf_bboxes_2d = record.raw_inferences_2d
         inf_bboxes_3d = record.raw_inferences_3d
         velo_to_camera = record.velodyne_to_camera_transformation
         camera_rect = record.camera_rectification
@@ -86,6 +87,7 @@ def to_kitti_format(df: pd.DataFrame) -> Tuple[List[Dict[str, Any]], List[Dict[s
                 alpha=np.array(
                     [alpha_from_bbox3D(bbox, bbox_lidar) for bbox, bbox_lidar in zip(camera_bboxes, gt_bboxes_3d)],
                 ),
+                bbox=np.array([bbox_to_kitti_format(bbox) for bbox in gt_bboxes_2d]),
                 dimensions=np.array([bbox.dimensions for bbox in camera_bboxes]),
                 location=np.array([center_to_kitti_format(bbox) for bbox in camera_bboxes]),
                 rotation_y=np.array([bbox.rotations[1] for bbox in camera_bboxes]),
@@ -121,6 +123,7 @@ def to_kitti_format(df: pd.DataFrame) -> Tuple[List[Dict[str, Any]], List[Dict[s
                         for bbox, bbox_lidar in zip(pred_camera_bboxes, inf_bboxes_3d)
                     ],
                 ),
+                bbox=np.array([bbox_to_kitti_format(bbox) for bbox in inf_bboxes_2d]),
                 dimensions=np.array([bbox.dimensions for bbox in pred_camera_bboxes]),
                 location=np.array([center_to_kitti_format(bbox) for bbox in pred_camera_bboxes]),
                 rotation_y=np.array([bbox.rotations[1] for bbox in pred_camera_bboxes]),
@@ -224,7 +227,7 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
             TP = [sum(tp) for tp in zip(result["Car"]["tp"], result["Cyclist"]["tp"], result["Pedestrian"]["tp"])]
             FP = [sum(fp) for fp in zip(result["Car"]["fp"], result["Cyclist"]["fp"], result["Pedestrian"]["fp"])]
             FN = [sum(fn) for fn in zip(result["Car"]["fn"], result["Cyclist"]["fn"], result["Pedestrian"]["fn"])]
-            # FP_2D = [inferences for inferences, fp in zip(record.raw_inferences_2d, FP) if fp]
+            FP_2D = [inferences for inferences, fp in zip(record.raw_inferences_2d, FP) if fp]
             FP_3D = [
                 dataclasses.replace(
                     record.raw_inferences_3d[j],
@@ -234,7 +237,7 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                 for j, fp in enumerate(FP)
                 if fp
             ]
-            # TP_2D = [inferences for inferences, tp in zip(record.raw_inferences_2d, TP) if tp]
+            TP_2D = [inferences for inferences, tp in zip(record.raw_inferences_2d, TP) if tp]
             TP_3D = [
                 ScoredLabeledBoundingBox3D(
                     **record.raw_inferences_3d[j]._to_dict(),
@@ -244,7 +247,7 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                 for j, tp in enumerate(TP)
                 if tp
             ]
-            # FN_2D = [image_bboxes for image_bboxes, fn in zip(record.image_bboxes, FN) if fn]
+            FN_2D = [image_bboxes for image_bboxes, fn in zip(record.image_bboxes, FN) if fn]
             FN_3D = [
                 LabeledBoundingBox3D(
                     **record.velodyne_bboxes[j]._to_dict(),
@@ -293,11 +296,11 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                     nMissedObjects=len(FN_3D),
                     nMismatchedInferences=len(FP_3D),
                     thresholds=current_optimal_thresholds,
-                    # FP_2D=FP_2D,
+                    FP_2D=FP_2D,
                     FP_3D=FP_3D,
-                    # TP_2D=TP_2D,
+                    TP_2D=TP_2D,
                     TP_3D=TP_3D,
-                    # FN_2D=FN_2D,
+                    FN_2D=FN_2D,
                     FN_3D=FN_3D,
                 ),
             )

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
@@ -145,7 +145,7 @@ def compute_f1_optimal_thresholds(
     labels = {label for label in labels if label in VALID_LABELS}
     f1_optimal_thresholds = {}
 
-    _, metrics = kitti_eval(kitti_ground_truths, kitti_inferences, list(labels), eval_types=["bev", "3d"])
+    _, metrics = kitti_eval(kitti_ground_truths, kitti_inferences, list(labels), eval_types=["bbox", "bev", "3d"])
     for name, difficulty in KITTY_DIFFICULTY.items():
         thresholds = {}
         for current_class in VALID_LABELS:

--- a/examples/dataset/object_detection_3d/object_detection_3d/utils.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from typing import List
 from typing import Optional
+from typing import Tuple
 
 import numpy as np
 
@@ -97,3 +98,14 @@ def transform_to_camera_frame(
         )
         for center, dim, yaw in zip(centers, dimensions, yaws)
     ]
+
+
+def kitti_matrix_to_array(arr: List[float], shape: Tuple[int, int]) -> np.array:
+    return np.array(arr).reshape(shape)
+
+
+def create_velo_to_pixel_matrix(velo_to_cam: List[float], cam_to_pixel: List[float]) -> List[List[float]]:
+    velo_to_cam_arr = kitti_matrix_to_array(velo_to_cam, (4, 4))
+    cam_to_pixel_arr = kitti_matrix_to_array(cam_to_pixel, (4, 4))
+    composed_arr = cam_to_pixel_arr @ velo_to_cam_arr  # type: ignore[operator]
+    return composed_arr[:3, :].tolist()

--- a/examples/dataset/object_detection_3d/object_detection_3d/utils.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/utils.py
@@ -26,23 +26,20 @@ from kolena.annotation import LabeledBoundingBox3D
 from kolena.asset import ImageAsset
 from kolena.asset import PointCloudAsset
 
-LABEL_FILE_COLUMNS = [
-    "type",
-    "truncated",
-    "occluded",
-    "alpha",
-    "bbox_x0",
-    "bbox_y0",
-    "bbox_x1",
-    "bbox_y1",
-    "dim_y",
-    "dim_z",
-    "dim_x",
-    "loc_x",
-    "loc_y",
-    "loc_z",
-    "rotation_y",
-]
+LABEL_FILE_COLUMNS = {
+    "image_id",
+    "left_image",
+    "right_image",
+    "velodyne",
+    "objects",
+    "P0",
+    "P1",
+    "P2",
+    "P3",
+    "R0_rect",
+    "Tr_velo_to_cam",
+    "Tr_imu_to_velo",
+}
 
 
 def extend_matrix(mat: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
### Linked issue(s)

References KOL-6029

### What change does this PR introduce and why?

Adds world-to-pixel projection matrices to images to allow projected 3d annotations to be rendered on images in Kolena.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
