### PR TITLE
Remove annotations attached to ImageAssets in KITTI

### DIFF
--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_dataset.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_dataset.py
@@ -38,7 +38,7 @@ def run(args: Namespace) -> int:
         storage_options={"anon": True},
     )
     df = load_data(df_raw)
-    df.drop(columns=["image_bboxes", "images"], inplace=True)
+    df.drop(columns=["image_bboxes"], inplace=True)
     upload_dataset(args.dataset, df, id_fields=ID_FIELDS)
     return 0
 

--- a/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/upload_results.py
@@ -41,7 +41,6 @@ from object_detection_3d.vendored.kitti_eval import kitti_eval  # type: ignore[a
 from kolena.annotation import LabeledBoundingBox3D
 from kolena.annotation import ScoredLabeledBoundingBox
 from kolena.annotation import ScoredLabeledBoundingBox3D
-from kolena.asset import ImageAsset
 from kolena.dataset import upload_results
 
 CLASS_NAME_VALUE = {"Car": 0, "Cyclist": 2, "Pedestrian": 1}
@@ -297,15 +296,6 @@ def compute_metrics_by_difficulty(df: pd.DataFrame) -> List[Tuple[Dict[str, Any]
                     FP_3D=FP_3D,
                     TP_3D=TP_3D,
                     FN_3D=FN_3D,
-                    images_with_inferences=[
-                        ImageAsset(
-                            **img._to_dict(),
-                            FP_3D=FP_3D,  # type: ignore[call-arg]
-                            TP_3D=TP_3D,  # type: ignore[call-arg]
-                            FN_3D=FN_3D,  # type: ignore[call-arg]
-                        )
-                        for img in record.images
-                    ],
                 ),
             )
         return pd.DataFrame(sample_metrics)

--- a/examples/dataset/object_detection_3d/object_detection_3d/utils.py
+++ b/examples/dataset/object_detection_3d/object_detection_3d/utils.py
@@ -159,14 +159,12 @@ def load_data(df_raw: pd.DataFrame) -> pd.DataFrame:
                         side="left",  # type: ignore[call-arg]
                         # type: ignore[call-arg]
                         projection=create_velo_to_pixel_matrix(record.Tr_velo_to_cam, record.P2),
-                        velodyne_bboxes=bboxes_3d,  # type: ignore[call-arg]
                     ),
                     ImageAsset(
                         locator=record.right_image,
                         side="right",  # type: ignore[call-arg]
                         # type: ignore[call-arg]
                         projection=create_velo_to_pixel_matrix(record.Tr_velo_to_cam, record.P3),
-                        velodyne_bboxes=bboxes_3d,  # type: ignore[call-arg]
                     ),
                 ],
                 "velodyne": PointCloudAsset(locator=record.velodyne),


### PR DESCRIPTION
### Linked issue(s)

Fixes KOL-6029

### What change does this PR introduce and why?

3D bounding boxes are now automatically projected onto images contained in `List[ImageAsset]` columns. As such, bounding boxes no longer need to be included as a field on the individual `ImageAsset`s.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
