### PR TITLE
grant/cs/prepopulate datatype map

### DIFF
--- a/kolena/_experimental/workflow/thresholded.py
+++ b/kolena/_experimental/workflow/thresholded.py
@@ -14,9 +14,7 @@
 from abc import ABCMeta
 from dataclasses import dataclass
 from dataclasses import fields
-from typing import Any
 
-from kolena._utils.datatypes import _register_data_type
 from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
@@ -92,9 +90,6 @@ class ThresholdedMetrics(TypedDataObject[_MetricsType], metaclass=PreventThresho
     """
 
     threshold: float
-
-    def __init_subclass__(cls, **kwargs: Any):
-        _register_data_type(cls)
 
     @classmethod
     def _data_type(cls) -> _MetricsType:

--- a/kolena/_experimental/workflow/thresholded.py
+++ b/kolena/_experimental/workflow/thresholded.py
@@ -17,6 +17,7 @@ from dataclasses import fields
 from typing import Any
 
 from kolena._utils.datatypes import _register_data_type
+from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
 
@@ -34,8 +35,8 @@ class _MetricsType(DataType):
     THRESHOLDED = "THRESHOLDED"
 
     @staticmethod
-    def _data_category() -> str:
-        return "METRICS"
+    def _data_category() -> DataCategory:
+        return DataCategory.METRICS
 
 
 @dataclass(frozen=True)

--- a/kolena/_utils/datatypes.py
+++ b/kolena/_utils/datatypes.py
@@ -17,6 +17,7 @@ from abc import ABC
 from abc import ABCMeta
 from abc import abstractmethod
 from collections import OrderedDict
+from collections.abc import Sequence
 from enum import Enum
 from typing import Any
 from typing import cast
@@ -221,7 +222,7 @@ class DataObject(metaclass=ABCMeta):
             field_type = field_type or field.type
             origin = get_origin(field_type)  # non-None for typing.X types
 
-            if origin is list:
+            if origin is list or origin is Sequence:
                 (arg,) = get_args(field_type)
                 if not isinstance(field_value, list):
                     return default_value_or_raise(field, field_value)

--- a/kolena/_utils/datatypes.py
+++ b/kolena/_utils/datatypes.py
@@ -102,7 +102,7 @@ class DataCategory(str, Enum):
 
 def _get_full_type(obj: Type["TypedDataObject"]) -> str:
     data_type = obj._data_type()
-    return f"{data_type._data_category()}/{data_type.value}"
+    return f"{data_type._data_category().value}/{data_type.value}"
 
 
 def _get_data_type(name: str) -> Optional[Type["TypedDataObject"]]:
@@ -329,5 +329,5 @@ class TypedDataObject(Generic[U], DataObject, metaclass=ABCMeta):
     def _to_dict(self) -> Dict[str, Any]:
         self_dict = super()._to_dict()
         self_type = self._data_type()
-        self_dict[DATA_TYPE_FIELD] = f"{self_type._data_category()}/{self_type.value}"
+        self_dict[DATA_TYPE_FIELD] = f"{self_type._data_category().value}/{self_type.value}"
         return self_dict

--- a/kolena/_utils/datatypes.py
+++ b/kolena/_utils/datatypes.py
@@ -36,6 +36,7 @@ import pandera as pa
 from pydantic.dataclasses import dataclass
 from pydantic.dataclasses import is_pydantic_dataclass
 
+from kolena._utils import log
 from kolena._utils.dataframes.validators import validate_df_schema
 from kolena._utils.validators import ValidatorConfig
 
@@ -111,6 +112,8 @@ def _get_data_type(name: str) -> Optional[Type["TypedDataObject"]]:
             data_category, _ = name.split("/")
             module = DataCategory(data_category).data_category_to_module_name()
             importlib.import_module(module)
+        except (ValueError, ModuleNotFoundError) as e:
+            log.error(f"Failed to import module for data type '{name}'", e)
         finally:
             return _DATA_TYPE_MAP.get(name, None)
     return class_type

--- a/kolena/annotation.py
+++ b/kolena/annotation.py
@@ -33,14 +33,12 @@ rendered on top of the image.
 import dataclasses
 from abc import ABCMeta
 from functools import reduce
-from typing import Any
 from typing import Dict
 from typing import List
 from typing import Tuple
 
 from pydantic.dataclasses import dataclass
 
-from kolena._utils.datatypes import _register_data_type
 from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
@@ -66,9 +64,6 @@ class _AnnotationType(DataType):
 @dataclass(frozen=True, config=ValidatorConfig)
 class Annotation(TypedDataObject[_AnnotationType], metaclass=ABCMeta):
     """The base class for all annotation types."""
-
-    def __init_subclass__(cls, **kwargs: Any):
-        _register_data_type(cls)
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/annotation.py
+++ b/kolena/annotation.py
@@ -41,6 +41,7 @@ from typing import Tuple
 from pydantic.dataclasses import dataclass
 
 from kolena._utils.datatypes import _register_data_type
+from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
 from kolena._utils.validators import ValidatorConfig
@@ -58,8 +59,8 @@ class _AnnotationType(DataType):
     TIME_SEGMENT = "TIME_SEGMENT"
 
     @staticmethod
-    def _data_category() -> str:
-        return "ANNOTATION"
+    def _data_category() -> DataCategory:
+        return DataCategory.ANNOTATION
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/asset.py
+++ b/kolena/asset.py
@@ -32,6 +32,7 @@ from typing import Optional
 from pydantic.dataclasses import dataclass
 
 from kolena._utils.datatypes import _register_data_type
+from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
 from kolena._utils.validators import ValidatorConfig
@@ -46,8 +47,8 @@ class _AssetType(DataType):
     AUDIO = "AUDIO"
 
     @staticmethod
-    def _data_category() -> str:
-        return "ASSET"
+    def _data_category() -> DataCategory:
+        return DataCategory.ASSET
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/asset.py
+++ b/kolena/asset.py
@@ -26,12 +26,10 @@ The following asset types are available:
 
 """
 from abc import ABCMeta
-from typing import Any
 from typing import Optional
 
 from pydantic.dataclasses import dataclass
 
-from kolena._utils.datatypes import _register_data_type
 from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
@@ -54,9 +52,6 @@ class _AssetType(DataType):
 @dataclass(frozen=True, config=ValidatorConfig)
 class Asset(TypedDataObject[_AssetType], metaclass=ABCMeta):
     """Base class for all asset types."""
-
-    def __init_subclass__(cls, **kwargs: Any):
-        _register_data_type(cls)
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/dataset/dataset.py
+++ b/kolena/dataset/dataset.py
@@ -45,7 +45,6 @@ from kolena._utils.batched_load import upload_data_frame
 from kolena._utils.consts import BatchSize
 from kolena._utils.dataframes.transformers import df_apply
 from kolena._utils.dataframes.transformers import json_normalize
-from kolena._utils.datatypes import _deserialize_dataobject
 from kolena._utils.datatypes import _serialize_dataobject
 from kolena._utils.datatypes import DATA_TYPE_FIELD
 from kolena._utils.endpoints import get_dataset_url
@@ -59,6 +58,7 @@ from kolena.dataset._common import validate_batch_size
 from kolena.dataset._common import validate_dataframe_ids
 from kolena.errors import InputValidationError
 from kolena.io import _dataframe_object_serde
+from kolena.io import _deserialize_dataobject
 
 _FIELD_ID = "id"
 _FIELD_LOCATOR = "locator"

--- a/kolena/io.py
+++ b/kolena/io.py
@@ -26,7 +26,7 @@ from typing import Union
 import pandas as pd
 
 from kolena._utils.dataframes.transformers import df_apply
-from kolena._utils.datatypes import _DATA_TYPE_MAP
+from kolena._utils.datatypes import _get_data_type
 from kolena._utils.datatypes import DATA_TYPE_FIELD
 from kolena._utils.datatypes import DataObject
 
@@ -44,7 +44,7 @@ def _deserialize_dataobject(x: Any) -> Any:
 
     if isinstance(x, dict):
         if data_type := x.pop(DATA_TYPE_FIELD, None):
-            if typed_dataobject := _DATA_TYPE_MAP.get(data_type):
+            if typed_dataobject := _get_data_type(data_type):
                 return typed_dataobject._from_dict(x)
         else:
             return {k: _deserialize_dataobject(v) for k, v in x.items()}

--- a/kolena/workflow/plot.py
+++ b/kolena/workflow/plot.py
@@ -43,7 +43,7 @@ from kolena._utils.validators import ValidatorConfig
 NumberSeries = Sequence[Union[float, int]]
 """A sequence of numeric values."""
 
-NullableNumberSeries = list[Union[float, int, None]]
+NullableNumberSeries = Sequence[Union[float, int, None]]
 """A sequence of numeric values or `None`."""
 
 

--- a/kolena/workflow/plot.py
+++ b/kolena/workflow/plot.py
@@ -40,10 +40,10 @@ from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
 from kolena._utils.validators import ValidatorConfig
 
-NumberSeries = Sequence[Union[float, int]]
+NumberSeries = list[Union[float, int]]
 """A sequence of numeric values."""
 
-NullableNumberSeries = Sequence[Union[float, int, None]]
+NullableNumberSeries = list[Union[float, int, None]]
 """A sequence of numeric values or `None`."""
 
 

--- a/kolena/workflow/plot.py
+++ b/kolena/workflow/plot.py
@@ -34,6 +34,7 @@ from typing import Union
 import numpy as np
 from pydantic.dataclasses import dataclass
 
+from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataObject
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
@@ -53,8 +54,8 @@ class _PlotType(DataType):
     BAR = "BAR"
 
     @staticmethod
-    def _data_category() -> str:
-        return "PLOT"
+    def _data_category() -> DataCategory:
+        return DataCategory.PLOT
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/plot.py
+++ b/kolena/workflow/plot.py
@@ -40,7 +40,7 @@ from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
 from kolena._utils.validators import ValidatorConfig
 
-NumberSeries = list[Union[float, int]]
+NumberSeries = Sequence[Union[float, int]]
 """A sequence of numeric values."""
 
 NullableNumberSeries = list[Union[float, int, None]]

--- a/kolena/workflow/test_sample.py
+++ b/kolena/workflow/test_sample.py
@@ -58,6 +58,7 @@ from pydantic import StrictStr
 from pydantic.dataclasses import dataclass
 
 from kolena._utils.datatypes import _register_data_type
+from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
 from kolena._utils.validators import ValidatorConfig
@@ -127,8 +128,8 @@ class _TestSampleType(DataType):
     CUSTOM = "CUSTOM"
 
     @staticmethod
-    def _data_category() -> str:
-        return "TEST_SAMPLE"
+    def _data_category() -> DataCategory:
+        return DataCategory.TEST_SAMPLE
 
 
 @dataclass(frozen=True, config=ValidatorConfig)

--- a/kolena/workflow/test_sample.py
+++ b/kolena/workflow/test_sample.py
@@ -57,7 +57,6 @@ from pydantic import StrictInt
 from pydantic import StrictStr
 from pydantic.dataclasses import dataclass
 
-from kolena._utils.datatypes import _register_data_type
 from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
@@ -150,9 +149,6 @@ class TestSample(TypedDataObject[_TestSampleType], metaclass=ABCMeta):
     [`Model`][kolena.workflow.Model] computes inferences, or when an implementation of
     [`Evaluator`][kolena.workflow.Evaluator] evaluates metrics.
     """
-
-    def __init_subclass__(cls, **kwargs: Any):
-        _register_data_type(cls)
 
     @staticmethod
     def _data_type() -> _TestSampleType:

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -44,7 +44,7 @@ def test__serde__simple() -> None:
     assert obj_dict == {
         "label": "test",
         "points": [[1, 1], [2, 2], [3, 3]],
-        DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.POLYGON.value}",
+        DATA_TYPE_FIELD: f"{_AnnotationType._data_category().value}/{_AnnotationType.POLYGON.value}",
     }
     assert LabeledPolygon._from_dict(obj_dict) == obj
 
@@ -59,7 +59,7 @@ def test__serde__derived() -> None:
         "height": 0,
         "area": 0,
         "aspect_ratio": 0,
-        DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.BOUNDING_BOX.value}",
+        DATA_TYPE_FIELD: f"{_AnnotationType._data_category().value}/{_AnnotationType.BOUNDING_BOX.value}",
     }
     # deserialization from dict containing all fields, including derived
     assert BoundingBox._from_dict(obj_dict) == obj
@@ -87,7 +87,7 @@ def test__serde__derived__extended(dataclass_decorator: Callable[..., Any]) -> N
         "a": "a",
         "b": False,
         "c": 0,
-        DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.BOUNDING_BOX.value}",
+        DATA_TYPE_FIELD: f"{_AnnotationType._data_category().value}/{_AnnotationType.BOUNDING_BOX.value}",
     }
     assert ExtendedBoundingBox._from_dict(obj_dict) == obj
 
@@ -131,7 +131,7 @@ def test__serde__nested() -> None:
     assert obj_dict["e"] == {
         "points": [[0, 0], [1, 1], [2, 2], [0, 0]],
         "label": "e",
-        DATA_TYPE_FIELD: f"{_AnnotationType._data_category()}/{_AnnotationType.POLYGON.value}",
+        DATA_TYPE_FIELD: f"{_AnnotationType._data_category().value}/{_AnnotationType.POLYGON.value}",
     }
     assert Tester._from_dict(obj_dict) == obj
 

--- a/tests/unit/test_asset.py
+++ b/tests/unit/test_asset.py
@@ -42,7 +42,10 @@ def test__serialize__locator(asset_class: Type[Asset], asset_type: _AssetType) -
     asset = asset_class(locator=locator)  # type: ignore
     asset_dict = asset._to_dict()
 
-    assert asset_dict == {"locator": locator, DATA_TYPE_FIELD: f"{_AssetType._data_category()}/{asset_type.value}"}
+    assert asset_dict == {
+        "locator": locator,
+        DATA_TYPE_FIELD: f"{_AssetType._data_category().value}/{asset_type.value}",
+    }
     assert asset == asset_class._from_dict(asset_dict)
 
 
@@ -53,7 +56,7 @@ def test__serialize__video() -> None:
 
     assert asset_dict == {
         "locator": locator,
-        DATA_TYPE_FIELD: f"{_AssetType.VIDEO._data_category()}/{_AssetType.VIDEO.value}",
+        DATA_TYPE_FIELD: f"{_AssetType.VIDEO._data_category().value}/{_AssetType.VIDEO.value}",
         "thumbnail": None,
         "start": 0,
         "end": 1,

--- a/tests/unit/test_deserialize_dataobject.py
+++ b/tests/unit/test_deserialize_dataobject.py
@@ -1,0 +1,60 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from kolena.io import _deserialize_dataobject
+
+
+def test__deserialize_dataobject() -> None:
+    bounding_box = {
+        "top_left": [242.49460056994644, 636.9814293847943],
+        "bottom_right": [1150.4028821200359, 920.0],
+        "data_type": "ANNOTATION/BOUNDING_BOX",
+        "label": "ego_vehicle",
+    }
+
+    image = {"locator": "s3://bucket/key", "data_type": "TEST_SAMPLE/IMAGE"}
+    curve = {
+        "curves": [{"x": [1.0, 2.0, 3.0], "y": [4.0, 5.0, 6.0]}],
+        "data_type": "PLOT/CURVE",
+        "title": "test",
+        "x_label": "x_label",
+        "y_label": "y_label",
+    }
+    image_asset = {"locator": "s3://bucket/key", "data_type": "ASSET/IMAGE"}
+    thresholded = {"threshold": 0.3, "data_type": "METRICS/THRESHOLDED"}
+
+    deserialized_bounding_box = _deserialize_dataobject(bounding_box)
+    deserialized_image = _deserialize_dataobject(image)
+    deserialized_image_asset = _deserialize_dataobject(image_asset)
+    deserialized_thresholded = _deserialize_dataobject(thresholded)
+    deserialized_curve = _deserialize_dataobject(curve)
+    from kolena.workflow.plot import Curve, CurvePlot
+    from kolena.annotation import BoundingBox
+    from kolena._experimental.workflow import ThresholdedMetrics
+    from kolena.asset import ImageAsset
+    from kolena.workflow.test_sample import Image
+
+    assert deserialized_bounding_box == BoundingBox(
+        top_left=[242.49460056994644, 636.9814293847943],
+        bottom_right=[1150.4028821200359, 920.0],
+        label="ego_vehicle",
+    )
+    assert deserialized_image == Image(locator="s3://bucket/key")
+    assert deserialized_curve == CurvePlot(
+        curves=[Curve(x=[1, 2, 3], y=[4, 5, 6])],
+        title="test",
+        x_label="x_label",
+        y_label="y_label",
+    )
+    assert deserialized_image_asset == ImageAsset(locator="s3://bucket/key")
+    assert deserialized_thresholded == ThresholdedMetrics(threshold=0.3)

--- a/tests/unit/workflow/test_plot.py
+++ b/tests/unit/workflow/test_plot.py
@@ -97,7 +97,7 @@ def test__curve_plot__serialize() -> None:
         "x_label": "x",
         "y_label": "y",
         "curves": [{"label": "a", "x": [1, 2, 3], "y": [2, 3, 4], "extra": None}],
-        "data_type": f"{_PlotType._data_category()}/{_PlotType.CURVE.value}",
+        "data_type": f"{_PlotType._data_category().value}/{_PlotType.CURVE.value}",
         "x_config": None,
         "y_config": {"type": "log"},
     }
@@ -149,7 +149,7 @@ def test__confusion_matrix__serialize() -> None:
         y_label="y",
         labels=["a", "b"],
         matrix=[[90, 10], [20, 80]],
-        data_type=f"{_PlotType._data_category()}/{_PlotType.CONFUSION_MATRIX.value}",
+        data_type=f"{_PlotType._data_category().value}/{_PlotType.CONFUSION_MATRIX.value}",
     )
 
     # TODO: list of lists fails to deserialize, but not critical for plots (plots are never pulled down)
@@ -217,7 +217,7 @@ def test__histogram__serialize() -> None:
         "labels": ["a", "b"],
         "x_config": None,
         "y_config": {"type": "log"},
-        "data_type": f"{_PlotType._data_category()}/{_PlotType.HISTOGRAM.value}",
+        "data_type": f"{_PlotType._data_category().value}/{_PlotType.HISTOGRAM.value}",
     }
 
 

--- a/tests/unit/workflow/test_test_sample.py
+++ b/tests/unit/workflow/test_test_sample.py
@@ -336,7 +336,7 @@ def test__serialize() -> None:
         l=LabeledPolygon(label="test", points=[(1, 1), (2, 2), (3, 3)])._to_dict(),
         m=BoundingBox(top_left=(0, 0), bottom_right=(10, 10))._to_dict(),
         n=[1, 2, 3],
-        data_type=f"{_TestSampleType._data_category()}/{_TestSampleType.CUSTOM.value}",
+        data_type=f"{_TestSampleType._data_category().value}/{_TestSampleType.CUSTOM.value}",
     )
 
     assert Tester._from_dict(obj_dict) == obj


### PR DESCRIPTION
Based on @consoull's work [here](https://github.com/kolenaIO/kolena/pull/570) 

### Linked issue(s)
Fixes KOL-5860

### What change does this PR introduce and why?
Fixes a bug where `_DATA_TYPE_MAP` is missing Annotation, Asset, TestSample, Thresholded if the corresponding `TypedDataObject` has not been subclassed in the current Python process.


### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
