### PR TITLE
Make BoundingBox derived fields more resilient

### DIFF
--- a/kolena/annotation.py
+++ b/kolena/annotation.py
@@ -91,8 +91,8 @@ class BoundingBox(Annotation):
         return _AnnotationType.BOUNDING_BOX
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "width", self.bottom_right[0] - self.top_left[0])
-        object.__setattr__(self, "height", self.bottom_right[1] - self.top_left[1])
+        object.__setattr__(self, "width", abs(self.bottom_right[0] - self.top_left[0]))
+        object.__setattr__(self, "height", abs(self.bottom_right[1] - self.top_left[1]))
         object.__setattr__(self, "area", self.width * self.height)
         object.__setattr__(self, "aspect_ratio", self.width / self.height if self.height != 0 else 0)
 

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -141,7 +141,11 @@ def test__serde__nested() -> None:
     [
         ((0, 0), (0, 0), dict(width=0, height=0, area=0, aspect_ratio=0)),
         ((10, 10), (10, 10), dict(width=0, height=0, area=0, aspect_ratio=0)),
+        # test different permutations to ensure that we're robust to coordinate swapping
         ((10, 10), (20, 30), dict(width=10, height=20, area=200, aspect_ratio=0.5)),
+        ((20, 30), (10, 10), dict(width=10, height=20, area=200, aspect_ratio=0.5)),
+        ((20, 10), (10, 30), dict(width=10, height=20, area=200, aspect_ratio=0.5)),
+        ((10, 30), (20, 10), dict(width=10, height=20, area=200, aspect_ratio=0.5)),
     ],
 )
 def test__bounding_box__derived(


### PR DESCRIPTION
### Linked issue(s)

Fixes: KOL-6104

### What change does this PR introduce and why?
Users have accidentally swapped top_left and bottom_right points, or input top_right and bottom_left as the bbox fields.

This change makes our derived fields (width, height, area, aspect ratio) resilient to these types of errors -- the calculation still works as long as we are provided with opposite corners.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
