### PR TITLE
Add support for 3d bounding box matching

### DIFF
--- a/kolena/metrics/__init__.py
+++ b/kolena/metrics/__init__.py
@@ -19,6 +19,8 @@ from ._formula import recall
 from ._formula import specificity
 from ._geometry import InferenceMatches
 from ._geometry import iou
+from ._geometry import iou_2d
+from ._geometry import iou_3d_approx
 from ._geometry import match_inferences
 from ._geometry import match_inferences_multiclass
 from ._geometry import MulticlassInferenceMatches
@@ -31,6 +33,8 @@ __all__ = [
     "fpr",
     "specificity",
     "iou",
+    "iou_2d",
+    "iou_3d_approx",
     "InferenceMatches",
     "match_inferences",
     "match_inferences_multiclass",

--- a/tests/unit/metrics/test_geometry.py
+++ b/tests/unit/metrics/test_geometry.py
@@ -19,6 +19,7 @@ from typing import Union
 import pytest
 
 from kolena.annotation import BoundingBox
+from kolena.annotation import BoundingBox3D
 from kolena.annotation import LabeledBoundingBox
 from kolena.annotation import LabeledPolygon
 from kolena.annotation import Polygon
@@ -26,7 +27,8 @@ from kolena.annotation import ScoredBoundingBox
 from kolena.annotation import ScoredLabeledBoundingBox
 from kolena.annotation import ScoredLabeledPolygon
 from kolena.errors import InputValidationError
-from kolena.metrics import iou
+from kolena.metrics import iou_2d
+from kolena.metrics import iou_3d_approx
 from kolena.metrics import match_inferences
 from kolena.metrics import match_inferences_multiclass
 from kolena.metrics._geometry import GT
@@ -78,7 +80,17 @@ from kolena.metrics._geometry import Inf
     ],
 )
 def test__iou__bbox(box1: BoundingBox, box2: BoundingBox, expected_iou: float) -> None:
-    assert iou(box1, box2) == pytest.approx(expected_iou, abs=1e-5)
+    assert iou_2d(box1, box2) == pytest.approx(expected_iou, abs=1e-5)
+
+
+@pytest.mark.parametrize(
+    "box1, box2, expected_iou",
+    [
+        # TODO: Add tests
+    ],
+)
+def test__iou__bbox__3d(box1: BoundingBox3D, box2: BoundingBox3D, expected_iou: float) -> None:
+    assert iou_3d_approx(box1, box2) == pytest.approx(expected_iou, abs=5 * 1e-2)
 
 
 @pytest.mark.parametrize(
@@ -106,7 +118,7 @@ def test__iou__bbox(box1: BoundingBox, box2: BoundingBox, expected_iou: float) -
     ],
 )
 def test__iou(points1: Union[BoundingBox, Polygon], points2: Union[BoundingBox, Polygon], expected_iou: float) -> None:
-    iou_value = iou(points1, points2)
+    iou_value = iou_2d(points1, points2)
     assert iou_value == pytest.approx(expected_iou, abs=1e-5)
 
 


### PR DESCRIPTION
### Linked issue(s)

Fixes KOL-5576

### What change does this PR introduce and why?

Adds support for 3D annotations in `upload_object_detection_results`.

This PR leverages the same Pascal VOC logic used for 2D object detection and applies it to 3D object detection using an approximate IoU metric based on [this implementation](https://github.com/google-research-datasets/Objectron/blob/c06a65165a18396e1e00091981fd1652875c97b5/objectron/dataset/iou.py#L36) in Objectron.

Unlike the 2D case, where IoU has a straight-forward, closed-form solution, 3D IoU evaluation is often implemented in many different ways. For this reason, this PR also gives the user control the ability to use their own matching logic.

TODO:
- [ ] Allow users to supply their own matching function
- [ ] Add test cases

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
