### PR TITLE
Add IoU property to object detection inferences

### DIFF
--- a/kolena/_experimental/object_detection/__init__.py
+++ b/kolena/_experimental/object_detection/__init__.py
@@ -29,7 +29,7 @@ from .workflow import ThresholdConfiguration
 
 from .evaluator import ObjectDetectionEvaluator
 from .dataset import upload_object_detection_results
-from .dataset import create_object_detection_results
+from .dataset import iter_object_detection_results
 
 __all__ = [
     "TestSample",
@@ -46,6 +46,6 @@ __all__ = [
     "TestSuiteMetrics",
     "ThresholdConfiguration",
     "ObjectDetectionEvaluator",
-    "create_object_detection_results",
+    "iter_object_detection_results",
     "upload_object_detection_results",
 ]

--- a/kolena/_experimental/object_detection/__init__.py
+++ b/kolena/_experimental/object_detection/__init__.py
@@ -29,6 +29,7 @@ from .workflow import ThresholdConfiguration
 
 from .evaluator import ObjectDetectionEvaluator
 from .dataset import upload_object_detection_results
+from .dataset import create_object_detection_results
 
 __all__ = [
     "TestSample",
@@ -45,5 +46,6 @@ __all__ = [
     "TestSuiteMetrics",
     "ThresholdConfiguration",
     "ObjectDetectionEvaluator",
+    "create_object_detection_results",
     "upload_object_detection_results",
 ]

--- a/kolena/_experimental/object_detection/__init__.py
+++ b/kolena/_experimental/object_detection/__init__.py
@@ -30,6 +30,7 @@ from .workflow import ThresholdConfiguration
 from .evaluator import ObjectDetectionEvaluator
 from .dataset import upload_object_detection_results
 from .dataset import iter_object_detection_results
+from .dataset import create_object_detection_results
 
 __all__ = [
     "TestSample",
@@ -47,5 +48,6 @@ __all__ = [
     "ThresholdConfiguration",
     "ObjectDetectionEvaluator",
     "iter_object_detection_results",
+    "create_object_detection_results",
     "upload_object_detection_results",
 ]

--- a/kolena/_experimental/object_detection/__init__.py
+++ b/kolena/_experimental/object_detection/__init__.py
@@ -29,8 +29,8 @@ from .workflow import ThresholdConfiguration
 
 from .evaluator import ObjectDetectionEvaluator
 from .dataset import upload_object_detection_results
-from .dataset import iter_object_detection_results
-from .dataset import create_object_detection_results
+from .dataset import _iter_object_detection_results
+from .dataset import compute_object_detection_results
 
 __all__ = [
     "TestSample",
@@ -47,7 +47,6 @@ __all__ = [
     "TestSuiteMetrics",
     "ThresholdConfiguration",
     "ObjectDetectionEvaluator",
-    "iter_object_detection_results",
-    "create_object_detection_results",
+    "compute_object_detection_results",
     "upload_object_detection_results",
 ]

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -138,7 +138,7 @@ def multiclass_datapoint_metrics(
         for gt, inf in object_matches.unmatched_gt
         if inf is not None and inf.score >= thresholds[inf.label]
     ]
-    scores = [inf["score"] for inf in tp] + [inf["score"] for inf in fp]
+    scores = [inf["score"] for inf in tp] + [inf.score for inf in fp]
     labels = sorted(
         {inf.label for _, inf in object_matches.matched}
         .union(

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -321,6 +321,32 @@ def iter_object_detection_results(
     min_confidence_score: float = 0.01,
     batch_size: int = 10_000,
 ) -> Iterator[pd.DataFrame]:
+    """
+    Compute metrics of the model for the dataset.
+
+    Similar to
+    [`create_object_detection_results`](kolena._experimental.object_detection.create_object_detection_results),
+    but returns an `Iterator[DataFrame]` instead of a `DataFrame`. Useful if you do not want to load the entire result
+    set into memory.
+
+    Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
+    :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
+
+    :param dataset_name: Dataset name.
+    :param model_name: Model name.
+    :param df: Dataframe for model results.
+    :param ground_truths_field: Field name in datapoint with ground truth bounding boxes,
+    defaulting to `"ground_truths"`.
+    :param raw_inferences_field: Column in model result DataFrame with raw inference bounding boxes,
+    defaulting to `"raw_inferences"`.
+    :param iou_threshold: The [IoU ↗](../../metrics/iou.md) threshold, defaulting to `0.5`.
+    :param threshold_strategy: The confidence threshold strategy. It can either be a fixed confidence threshold such
+        as `0.5` or `0.75`, or `"F1-Optimal"` to find the threshold maximizing F1 score.
+    :param min_confidence_score: The minimum confidence score to consider for the evaluation. This is usually set to
+        reduce noise by excluding inferences with low confidence score.
+    :param batch_size: number of results to process per iteration.
+    :return: An `Iterator[DataFrame]` of the computed results
+    """
     _validate_column_present(df, raw_inferences_field)
 
     dataset_df = dataset.download_dataset(dataset_name)
@@ -350,6 +376,30 @@ def create_object_detection_results(
     min_confidence_score: float = 0.01,
     batch_size: int = 10_000,
 ) -> pd.DataFrame:
+    """
+    Compute metrics of the model for the dataset.
+
+    Similar to [`iter_object_detection_results`](kolena._experimental.object_detection.iter_object_detection_results),
+    but returns an `DataFrame` instead of an `Iterator[DataFrame]`.
+
+    Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
+    :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
+
+    :param dataset_name: Dataset name.
+    :param model_name: Model name.
+    :param df: Dataframe for model results.
+    :param ground_truths_field: Field name in datapoint with ground truth bounding boxes,
+    defaulting to `"ground_truths"`.
+    :param raw_inferences_field: Column in model result DataFrame with raw inference bounding boxes,
+    defaulting to `"raw_inferences"`.
+    :param iou_threshold: The [IoU ↗](../../metrics/iou.md) threshold, defaulting to `0.5`.
+    :param threshold_strategy: The confidence threshold strategy. It can either be a fixed confidence threshold such
+        as `0.5` or `0.75`, or `"F1-Optimal"` to find the threshold maximizing F1 score.
+    :param min_confidence_score: The minimum confidence score to consider for the evaluation. This is usually set to
+        reduce noise by excluding inferences with low confidence score.
+    :param batch_size: number of results to process per iteration.
+    :return: A `DataFrame` of the computed results
+    """
     results_iter = iter_object_detection_results(
         dataset_name,
         df,
@@ -376,7 +426,9 @@ def upload_object_detection_results(
     batch_size: int = 10_000,
 ) -> None:
     """
-    Compute metrics and upload results of the model for the dataset.
+    Compute metrics and upload results of the model computed by
+    [`iter_object_detection_results`][kolena._experimental.object_detection.iter_object_detection_results]
+    for the dataset.
 
     Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
     :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -324,10 +324,8 @@ def iter_object_detection_results(
     """
     Compute metrics of the model for the dataset.
 
-    Similar to
-    [`create_object_detection_results`](kolena._experimental.object_detection.create_object_detection_results),
-    but returns an `Iterator[DataFrame]` instead of a `DataFrame`. Useful if you do not want to load the entire result
-    set into memory.
+    Similar to `create_object_detection_results` but returns an `Iterator[DataFrame]` instead of a `DataFrame`.
+    Useful if you do not want to load the entire result set into memory.
 
     Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
     :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
@@ -378,8 +376,7 @@ def create_object_detection_results(
     """
     Compute metrics of the model for the dataset.
 
-    Similar to [`iter_object_detection_results`](kolena._experimental.object_detection.iter_object_detection_results),
-    but returns an `DataFrame` instead of an `Iterator[DataFrame]`.
+    Similar to `iter_object_detection_results`, but returns an `DataFrame` instead of an `Iterator[DataFrame]`.
 
     Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
     :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -310,7 +310,7 @@ def _validate_column_present(df: pd.DataFrame, col: str) -> None:
         raise IncorrectUsageError(f"Missing column '{col}'")
 
 
-def iter_object_detection_results(
+def _iter_object_detection_results(
     dataset_name: str,
     df: pd.DataFrame,
     *,
@@ -321,29 +321,6 @@ def iter_object_detection_results(
     min_confidence_score: float = 0.01,
     batch_size: int = 10_000,
 ) -> Iterator[pd.DataFrame]:
-    """
-    Compute metrics of the model for the dataset.
-
-    Similar to `create_object_detection_results` but returns an `Iterator[DataFrame]` instead of a `DataFrame`.
-    Useful if you do not want to load the entire result set into memory.
-
-    Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
-    :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
-
-    :param dataset_name: Dataset name.
-    :param df: Dataframe for model results.
-    :param ground_truths_field: Field name in datapoint with ground truth bounding boxes,
-    defaulting to `"ground_truths"`.
-    :param raw_inferences_field: Column in model result DataFrame with raw inference bounding boxes,
-    defaulting to `"raw_inferences"`.
-    :param iou_threshold: The [IoU ↗](../../metrics/iou.md) threshold, defaulting to `0.5`.
-    :param threshold_strategy: The confidence threshold strategy. It can either be a fixed confidence threshold such
-        as `0.5` or `0.75`, or `"F1-Optimal"` to find the threshold maximizing F1 score.
-    :param min_confidence_score: The minimum confidence score to consider for the evaluation. This is usually set to
-        reduce noise by excluding inferences with low confidence score.
-    :param batch_size: number of results to process per iteration.
-    :return: An `Iterator[DataFrame]` of the computed results
-    """
     _validate_column_present(df, raw_inferences_field)
 
     dataset_df = dataset.download_dataset(dataset_name)
@@ -362,7 +339,7 @@ def iter_object_detection_results(
     )
 
 
-def create_object_detection_results(
+def compute_object_detection_results(
     dataset_name: str,
     df: pd.DataFrame,
     *,
@@ -375,8 +352,6 @@ def create_object_detection_results(
 ) -> pd.DataFrame:
     """
     Compute metrics of the model for the dataset.
-
-    Similar to `iter_object_detection_results`, but returns an `DataFrame` instead of an `Iterator[DataFrame]`.
 
     Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
     :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
@@ -395,7 +370,7 @@ def create_object_detection_results(
     :param batch_size: number of results to process per iteration.
     :return: A `DataFrame` of the computed results
     """
-    results_iter = iter_object_detection_results(
+    results_iter = _iter_object_detection_results(
         dataset_name,
         df,
         ground_truths_field=ground_truths_field,
@@ -448,7 +423,7 @@ def upload_object_detection_results(
         threshold_strategy=threshold_strategy,
         min_confidence_score=min_confidence_score,
     )
-    results = iter_object_detection_results(
+    results = _iter_object_detection_results(
         dataset_name,
         df,
         ground_truths_field=ground_truths_field,

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -397,7 +397,7 @@ def upload_object_detection_results(
 ) -> None:
     """
     Compute metrics and upload results of the model computed by
-    [`iter_object_detection_results`][kolena._experimental.object_detection.iter_object_detection_results]
+    [`compute_object_detection_results`][kolena._experimental.object_detection.compute_object_detection_results]
     for the dataset.
 
     Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -44,13 +44,13 @@ def _bbox_matches_and_count_for_one_label(
     match_matched = []
     match_unmatched_gt = []
     match_unmatched_inf = []
-    for gt, inf in match.matched:
+    for gt, inf, _ in match.matched:
         if gt.label == label:
             match_matched.append((gt, inf))
     for gt, inf in match.unmatched_gt:
         if gt.label == label:
             match_unmatched_gt.append((gt, inf))
-    for inf in match.unmatched_inf:
+    for inf, _ in match.unmatched_inf:
         if inf.label == label:
             match_unmatched_inf.append(inf)
 
@@ -70,9 +70,9 @@ def _compute_thresholded_metrics(
 ) -> List[Dict[str, Any]]:
     metrics = []
     for threshold in thresholds:
-        count_tp = sum(1 for gt, inf in matches.matched if inf.score >= threshold)
-        count_fp = sum(1 for inf in matches.unmatched_inf if inf.score >= threshold)
-        count_fn = len(matches.unmatched_gt) + sum(1 for _, inf in matches.matched if inf.score < threshold)
+        count_tp = sum(1 for gt, inf, _ in matches.matched if inf.score >= threshold)
+        count_fp = sum(1 for inf, _ in matches.unmatched_inf if inf.score >= threshold)
+        count_fn = len(matches.unmatched_gt) + sum(1 for _, inf, _ in matches.matched if inf.score < threshold)
         if label:
             metrics.append(dict(threshold=threshold, label=label, tp=count_tp, fp=count_fp, fn=count_fn))
         else:
@@ -99,10 +99,14 @@ def single_class_datapoint_metrics(
     thresholds: float,
     all_thresholds: List[float],
 ) -> Dict[str, Any]:
-    tp = [{**gt._to_dict(), **inf._to_dict()} for gt, inf in object_matches.matched if inf.score >= thresholds]
-    fp = [inf for inf in object_matches.unmatched_inf if inf.score >= thresholds]
-    fn = object_matches.unmatched_gt + [gt for gt, inf in object_matches.matched if inf.score < thresholds]
-    scores = [inf["score"] for inf in tp] + [inf.score for inf in fp]
+    tp = [
+        {**gt._to_dict(), **inf._to_dict(), "iou": iou}
+        for gt, inf, iou in object_matches.matched
+        if inf.score >= thresholds
+    ]
+    fp = [{**inf._to_dict(), "iou": iou} for inf, iou in object_matches.unmatched_inf if inf.score >= thresholds]
+    fn = object_matches.unmatched_gt + [gt for gt, inf, _ in object_matches.matched if inf.score < thresholds]
+    scores = [inf["score"] for inf in tp] + [inf["score"] for inf in fp]
     thresholded = _compute_thresholded_metrics(object_matches, all_thresholds)
     return dict(
         TP=tp,
@@ -127,11 +131,17 @@ def multiclass_datapoint_metrics(
     all_thresholds: List[float],
 ) -> Dict[str, Any]:
     tp = [
-        {**gt._to_dict(), **inf._to_dict()} for gt, inf in object_matches.matched if inf.score >= thresholds[inf.label]
+        {**gt._to_dict(), **inf._to_dict(), "iou": iou}
+        for gt, inf, iou in object_matches.matched
+        if inf.score >= thresholds[inf.label]
     ]
-    fp = [inf for inf in object_matches.unmatched_inf if inf.score >= thresholds[inf.label]]
+    fp = [
+        {**inf._to_dict(), "iou": iou}
+        for inf, iou in object_matches.unmatched_inf
+        if inf.score >= thresholds[inf.label]
+    ]
     fn = [gt for gt, _ in object_matches.unmatched_gt] + [
-        gt for gt, inf in object_matches.matched if inf.score < thresholds[inf.label]
+        gt for gt, inf, _ in object_matches.matched if inf.score < thresholds[inf.label]
     ]
     confused = [
         dict(**inf._to_dict(), actual_label=gt.label)
@@ -140,14 +150,14 @@ def multiclass_datapoint_metrics(
     ]
     scores = [inf["score"] for inf in tp] + [inf.score for inf in fp]
     labels = sorted(
-        {inf.label for _, inf in object_matches.matched}
+        {inf.label for _, inf, _ in object_matches.matched}
         .union(
-            {inf.label for inf in object_matches.unmatched_inf},
+            {inf.label for inf, _ in object_matches.unmatched_inf},
         )
         .union({gt.label for gt, _ in object_matches.unmatched_gt}),
     )
-    inference_labels = {inf.label for _, inf in object_matches.matched}.union(
-        {inf.label for inf in object_matches.unmatched_inf},
+    inference_labels = {inf.label for _, inf, _ in object_matches.matched}.union(
+        {inf.label for inf, _ in object_matches.unmatched_inf},
     )
     fields = [
         ScoredLabel(label=label, score=thresholds[label])
@@ -310,6 +320,36 @@ def _validate_column_present(df: pd.DataFrame, col: str) -> None:
         raise IncorrectUsageError(f"Missing column '{col}'")
 
 
+def create_object_detection_results(
+    dataset_name: str,
+    model_name: str,
+    df: pd.DataFrame,
+    *,
+    ground_truths_field: str = "ground_truths",
+    raw_inferences_field: str = "raw_inferences",
+    iou_threshold: float = 0.5,
+    threshold_strategy: Union[Literal["F1-Optimal"], float, Dict[str, float]] = "F1-Optimal",
+    min_confidence_score: float = 0.01,
+    batch_size: int = 10_000,
+) -> Iterator[pd.DataFrame]:
+    _validate_column_present(df, raw_inferences_field)
+
+    dataset_df = dataset.download_dataset(dataset_name)
+    dataset_df = dataset_df[["locator", ground_truths_field]]
+    _validate_column_present(dataset_df, ground_truths_field)
+
+    merged_df = df.merge(dataset_df, on=["locator"])
+    return _compute_metrics(
+        merged_df,
+        ground_truth=ground_truths_field,
+        inference=raw_inferences_field,
+        iou_threshold=iou_threshold,
+        threshold_strategy=threshold_strategy,
+        min_confidence_score=min_confidence_score,
+        batch_size=batch_size,
+    )
+
+
 def upload_object_detection_results(
     dataset_name: str,
     model_name: str,
@@ -348,29 +388,20 @@ def upload_object_detection_results(
         threshold_strategy=threshold_strategy,
         min_confidence_score=min_confidence_score,
     )
-    _validate_column_present(df, raw_inferences_field)
-
-    dataset_df = dataset.download_dataset(dataset_name)
-    dataset_df = dataset_df[["locator", ground_truths_field]]
-    _validate_column_present(dataset_df, ground_truths_field)
-
-    merged_df = df.merge(dataset_df, on=["locator"])
+    results = create_object_detection_results(
+        dataset_name,
+        model_name,
+        df,
+        ground_truths_field,
+        raw_inferences_field,
+        iou_threshold,
+        threshold_strategy,
+        min_confidence_score,
+        batch_size,
+    )
     dataset.upload_results(
         dataset_name,
         model_name,
-        [
-            (
-                eval_config,
-                _compute_metrics(
-                    merged_df,
-                    ground_truth=ground_truths_field,
-                    inference=raw_inferences_field,
-                    iou_threshold=iou_threshold,
-                    threshold_strategy=threshold_strategy,
-                    min_confidence_score=min_confidence_score,
-                    batch_size=batch_size,
-                ),
-            ),
-        ],
+        [(eval_config, results)],
         thresholded_fields=["thresholded"],
     )

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -333,7 +333,6 @@ def iter_object_detection_results(
     :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
 
     :param dataset_name: Dataset name.
-    :param model_name: Model name.
     :param df: Dataframe for model results.
     :param ground_truths_field: Field name in datapoint with ground truth bounding boxes,
     defaulting to `"ground_truths"`.
@@ -386,7 +385,6 @@ def create_object_detection_results(
     :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
 
     :param dataset_name: Dataset name.
-    :param model_name: Model name.
     :param df: Dataframe for model results.
     :param ground_truths_field: Field name in datapoint with ground truth bounding boxes,
     defaulting to `"ground_truths"`.

--- a/kolena/_experimental/object_detection/utils.py
+++ b/kolena/_experimental/object_detection/utils.py
@@ -52,13 +52,13 @@ def _compute_sklearn_arrays(
     y_true: List[int] = []
     y_score: List[float] = []
     for image_bbox_matches in all_matches:
-        for _, bbox_inf, _ in image_bbox_matches.matched:  # TP (if above threshold)
+        for _, bbox_inf in image_bbox_matches.matched:  # TP (if above threshold)
             y_true.append(1)
             y_score.append(bbox_inf.score)
         for _ in image_bbox_matches.unmatched_gt:  # FN
             y_true.append(1)
             y_score.append(-1)
-        for bbox_inf, _ in image_bbox_matches.unmatched_inf:  # FP (if above threshold)
+        for bbox_inf in image_bbox_matches.unmatched_inf:  # FP (if above threshold)
             y_true.append(0)
             y_score.append(bbox_inf.score)
     return np.array(y_true), np.array(y_score)
@@ -276,7 +276,7 @@ def compute_confusion_matrix_plot(
 
     confusion_matrix: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
     for match in all_matches:
-        for gt, _, _ in match.matched:
+        for gt, _ in match.matched:
             actual_label = gt.label
             confusion_matrix[actual_label][actual_label] += 1
             labels.add(actual_label)
@@ -307,19 +307,19 @@ def _compute_sklearn_arrays_by_class(
 
     labels: Set[str] = set()
     for match in all_matches:
-        for _, bbox_inf, _ in match.matched:
+        for _, bbox_inf in match.matched:
             labels.add(bbox_inf.label)
         for bbox_gt, _ in match.unmatched_gt:
             labels.add(bbox_gt.label)
-        for bbox_inf, _ in match.unmatched_inf:
+        for bbox_inf in match.unmatched_inf:
             labels.add(bbox_inf.label)
 
     for label in labels:
         filtered_matchings: List[InferenceMatches] = [
             InferenceMatches(
-                matched=[(gt, inf, iou) for gt, inf, iou in match.matched if gt.label == label],
+                matched=[(gt, inf) for gt, inf in match.matched if gt.label == label],
                 unmatched_gt=[gt for gt, _ in match.unmatched_gt if gt.label == label],
-                unmatched_inf=[(inf, iou) for inf, iou in match.unmatched_inf if inf.label == label],
+                unmatched_inf=[inf for inf in match.unmatched_inf if inf.label == label],
             )
             for match in all_matches
         ]

--- a/kolena/metrics/_geometry.py
+++ b/kolena/metrics/_geometry.py
@@ -150,8 +150,9 @@ def _match_inferences_single_class_pascal_voc(
         best_gt_iou = 0.0
         for g, gt in enumerate(gt_objects):
             inf_gt_iou = iou(gt, inf)
-            best_gt_iou = max(best_gt_iou, inf_gt_iou)
-            # track the highest IoU over the threshold
+            if gt not in (ignored_ground_truths or []):
+                best_gt_iou = max(best_gt_iou, inf_gt_iou)
+                # track the highest IoU over the threshold
             if inf_gt_iou >= iou_threshold and inf_gt_iou > match_gt_iou:
                 match_gt_iou = inf_gt_iou
                 match_gt = g

--- a/kolena/metrics/_geometry.py
+++ b/kolena/metrics/_geometry.py
@@ -154,9 +154,10 @@ def _match_inferences_single_class_pascal_voc(
         best_gt_iou = 0.0
         for g, gt in enumerate(gt_objects):
             inf_gt_iou = iou(gt, inf)
+            # track the highest IoU, regardless of threshold
             if gt not in (ignored_ground_truths or []):
                 best_gt_iou = max(best_gt_iou, inf_gt_iou)
-                # track the highest IoU over the threshold
+            # track the highest IoU over the threshold
             if inf_gt_iou >= iou_threshold and inf_gt_iou > match_gt_iou:
                 match_gt_iou = inf_gt_iou
                 match_gt = g

--- a/kolena/metrics/_geometry.py
+++ b/kolena/metrics/_geometry.py
@@ -350,12 +350,12 @@ def match_inferences_multiclass(
 
     confused_matches = matching_function(
         unmatched_gt,
-        [inf for inf in unmatched_inf],
+        unmatched_inf,
         ignored_ground_truths=ignored_ground_truths,
         iou_threshold=iou_threshold,
     )
 
-    confused: List[Tuple[GT, Inf]] = []
+    confused = []
     for gt, inf in confused_matches.matched:
         assert hasattr(gt, "label") and hasattr(inf, "label")
         if gt.label != inf.label:

--- a/kolena/metrics/_geometry.py
+++ b/kolena/metrics/_geometry.py
@@ -299,9 +299,9 @@ def match_inferences_multiclass(
         [`MulticlassInferenceMatches`][kolena.metrics.MulticlassInferenceMatches] containing the matches
         (true positives), unmatched ground truths (false negatives), and unmatched inferences (false positives).
     """
-    matched: List[Tuple[GT, Inf, float]] = []
+    matched: List[Tuple[GT, Inf, IoU]] = []
     unmatched_gt: List[GT] = []
-    unmatched_inf: List[Tuple[Inf, float]] = []
+    unmatched_inf: List[Tuple[Inf, IoU]] = []
     gts_by_class: Dict[str, List[GT]] = defaultdict(list)
     infs_by_class: Dict[str, List[Inf]] = defaultdict(list)
     ignored_gts_by_class: Dict[str, List[GT]] = defaultdict(list)

--- a/tests/unit/metrics/test_geometry.py
+++ b/tests/unit/metrics/test_geometry.py
@@ -2456,6 +2456,9 @@ def test__match_inferences_multiclass(
     )
 
     assert expected_matched == [(gt, inf) for gt, inf, _ in matches.matched]
+    for gt, inf, iou_inf in matches.matched:
+        assert iou_inf == pytest.approx(iou(gt, inf), abs=1e-5)
+
     assert expected_unmatched_gt == [(gt, inf) for gt, inf, _ in matches.unmatched_gt]
     for gt, inf, iou_inf in matches.unmatched_gt:
         assert inf is None or iou(gt, inf) == pytest.approx(iou_inf, abs=1e-5)

--- a/tests/unit/metrics/test_geometry.py
+++ b/tests/unit/metrics/test_geometry.py
@@ -676,18 +676,13 @@ def test__match_inferences(
         ignored_ground_truths=ignored_ground_truths,
     )
 
-    assert expected_matched == [(gt, inf) for gt, inf in matches.matched]
+    assert expected_matched == matches.matched
     for gt, inf in matches.matched:
         assert inf.iou == pytest.approx(iou(gt, inf), abs=1e-5)
 
     assert expected_unmatched_gt == matches.unmatched_gt
 
-    for expected_inf, inf in zip(expected_unmatched_inf, matches.unmatched_inf):
-        # ignore iou for now, validated in next loop
-        expected_inf_dict, inf_dict = expected_inf._to_dict(), inf._to_dict()
-        for key in expected_inf_dict:
-            assert expected_inf_dict[key] == inf_dict[key]
-
+    assert expected_unmatched_inf == matches.unmatched_inf
     unignored_gt = [gt for gt in ground_truths if gt not in (ignored_ground_truths or [])]
     for inf in matches.unmatched_inf:
         expected_iou = max(iou(inf, gt) for gt in unignored_gt) if unignored_gt else 0.0
@@ -2464,20 +2459,15 @@ def test__match_inferences_multiclass(
         iou_threshold=0.5,
     )
 
-    assert expected_matched == [(gt, inf) for gt, inf in matches.matched]
+    assert expected_matched == matches.matched
     for gt, inf in matches.matched:
         assert inf.iou == pytest.approx(iou(gt, inf), abs=1e-5)
 
-    assert expected_unmatched_gt == [(gt, inf) for gt, inf in matches.unmatched_gt]
+    assert expected_unmatched_gt == matches.unmatched_gt
     for gt, inf in matches.unmatched_gt:
         assert inf is None or iou(gt, inf) == pytest.approx(inf.iou, abs=1e-5)
 
-    for expected_inf, inf in zip(expected_unmatched_inf, matches.unmatched_inf):
-        # ignore iou for now, validated in next loop
-        expected_inf_dict, inf_dict = expected_inf._to_dict(), inf._to_dict()
-        for key in expected_inf_dict:
-            assert expected_inf_dict[key] == inf_dict[key]
-
+    assert expected_unmatched_inf == matches.unmatched_inf
     unignored_gt = [gt for gt in ground_truths if gt not in (ignored_ground_truths or [])]
     for inf in matches.unmatched_inf:
         expected_iou = (
@@ -2561,20 +2551,15 @@ def test__match_inferences_multiclass__iou(
         iou_threshold=0.999,
     )
 
-    assert expected_matched == [(gt, inf) for gt, inf in matches.matched]
+    assert expected_matched == matches.matched
     for gt, inf in matches.matched:
         assert inf.iou == pytest.approx(iou(gt, inf), abs=1e-5)
 
-    assert expected_unmatched_gt == [(gt, inf) for gt, inf in matches.unmatched_gt]
+    assert expected_unmatched_gt == matches.unmatched_gt
     for gt, inf in matches.unmatched_gt:
         assert inf is None or iou(gt, inf) == pytest.approx(inf.iou, abs=1e-5)
 
-    for expected_inf, inf in zip(expected_unmatched_inf, matches.unmatched_inf):
-        # ignore iou for now, validated in next loop
-        expected_inf_dict, inf_dict = expected_inf._to_dict(), inf._to_dict()
-        for key in expected_inf_dict:
-            assert expected_inf_dict[key] == inf_dict[key]
-
+    assert expected_unmatched_inf == matches.unmatched_inf
     for inf in matches.unmatched_inf:
         expected_iou = max(iou(inf, gt) for gt in ground_truths) if ground_truths else 0.0
         assert inf.iou == pytest.approx(expected_iou, abs=1e-5)

--- a/tests/unit/metrics/test_geometry.py
+++ b/tests/unit/metrics/test_geometry.py
@@ -676,13 +676,22 @@ def test__match_inferences(
         ignored_ground_truths=ignored_ground_truths,
     )
 
-    assert expected_matched == [(gt, inf) for gt, inf, _ in matches.matched]
+    assert expected_matched == [(gt, inf) for gt, inf in matches.matched]
+    for gt, inf in matches.matched:
+        assert inf.iou == pytest.approx(iou(gt, inf), abs=1e-5)
+
     assert expected_unmatched_gt == matches.unmatched_gt
-    assert expected_unmatched_inf == [inf for inf, _ in matches.unmatched_inf]
+
+    for expected_inf, inf in zip(expected_unmatched_inf, matches.unmatched_inf):
+        # ignore iou for now, validated in next loop
+        expected_inf_dict, inf_dict = expected_inf._to_dict(), inf._to_dict()
+        for key in expected_inf_dict:
+            assert expected_inf_dict[key] == inf_dict[key]
+
     unignored_gt = [gt for gt in ground_truths if gt not in (ignored_ground_truths or [])]
-    for inf, iou_inf in matches.unmatched_inf:
+    for inf in matches.unmatched_inf:
         expected_iou = max(iou(inf, gt) for gt in unignored_gt) if unignored_gt else 0.0
-        assert iou_inf == pytest.approx(expected_iou, abs=1e-5)
+        assert inf.iou == pytest.approx(expected_iou, abs=1e-5)
 
 
 def test__match_inferences__invalid_mode() -> None:
@@ -2455,23 +2464,28 @@ def test__match_inferences_multiclass(
         iou_threshold=0.5,
     )
 
-    assert expected_matched == [(gt, inf) for gt, inf, _ in matches.matched]
-    for gt, inf, iou_inf in matches.matched:
-        assert iou_inf == pytest.approx(iou(gt, inf), abs=1e-5)
+    assert expected_matched == [(gt, inf) for gt, inf in matches.matched]
+    for gt, inf in matches.matched:
+        assert inf.iou == pytest.approx(iou(gt, inf), abs=1e-5)
 
-    assert expected_unmatched_gt == [(gt, inf) for gt, inf, _ in matches.unmatched_gt]
-    for gt, inf, iou_inf in matches.unmatched_gt:
-        assert inf is None or iou(gt, inf) == pytest.approx(iou_inf, abs=1e-5)
+    assert expected_unmatched_gt == [(gt, inf) for gt, inf in matches.unmatched_gt]
+    for gt, inf in matches.unmatched_gt:
+        assert inf is None or iou(gt, inf) == pytest.approx(inf.iou, abs=1e-5)
 
-    assert expected_unmatched_inf == [inf for inf, _ in matches.unmatched_inf]
+    for expected_inf, inf in zip(expected_unmatched_inf, matches.unmatched_inf):
+        # ignore iou for now, validated in next loop
+        expected_inf_dict, inf_dict = expected_inf._to_dict(), inf._to_dict()
+        for key in expected_inf_dict:
+            assert expected_inf_dict[key] == inf_dict[key]
+
     unignored_gt = [gt for gt in ground_truths if gt not in (ignored_ground_truths or [])]
-    for inf, iou_inf in matches.unmatched_inf:
+    for inf in matches.unmatched_inf:
         expected_iou = (
             max(iou(inf, gt) for gt in unignored_gt if gt.label == inf.label)
             if any(gt.label == inf.label for gt in unignored_gt)
             else 0.0
         )
-        assert iou_inf == pytest.approx(expected_iou, abs=1e-5)
+        assert inf.iou == pytest.approx(expected_iou, abs=1e-5)
 
 
 def test__match_inferences_multiclass__invalid_mode() -> None:
@@ -2547,15 +2561,20 @@ def test__match_inferences_multiclass__iou(
         iou_threshold=0.999,
     )
 
-    assert expected_matched == [(gt, inf) for gt, inf, _ in matches.matched]
-    for gt, inf, iou_inf in matches.matched:
-        assert iou(gt, inf) == pytest.approx(iou_inf, abs=1e-5)
+    assert expected_matched == [(gt, inf) for gt, inf in matches.matched]
+    for gt, inf in matches.matched:
+        assert inf.iou == pytest.approx(iou(gt, inf), abs=1e-5)
 
-    assert expected_unmatched_gt == [(gt, inf) for gt, inf, _ in matches.unmatched_gt]
-    for gt, inf, iou_inf in matches.unmatched_gt:
-        assert inf is None or iou(gt, inf) == pytest.approx(iou_inf, abs=1e-5)
+    assert expected_unmatched_gt == [(gt, inf) for gt, inf in matches.unmatched_gt]
+    for gt, inf in matches.unmatched_gt:
+        assert inf is None or iou(gt, inf) == pytest.approx(inf.iou, abs=1e-5)
 
-    assert expected_unmatched_inf == [inf for inf, _ in matches.unmatched_inf]
-    for inf, iou_inf in matches.unmatched_inf:
+    for expected_inf, inf in zip(expected_unmatched_inf, matches.unmatched_inf):
+        # ignore iou for now, validated in next loop
+        expected_inf_dict, inf_dict = expected_inf._to_dict(), inf._to_dict()
+        for key in expected_inf_dict:
+            assert expected_inf_dict[key] == inf_dict[key]
+
+    for inf in matches.unmatched_inf:
         expected_iou = max(iou(inf, gt) for gt in ground_truths) if ground_truths else 0.0
-        assert iou_inf == pytest.approx(expected_iou, abs=1e-5)
+        assert inf.iou == pytest.approx(expected_iou, abs=1e-5)


### PR DESCRIPTION
### Linked issue(s)

Fixes KOL-6202

### What change does this PR introduce and why?

This PR attaches the best IoU found over the ground truths to the inferences in the calculation of object detection results. This enables users to differentiate between different kinds of false positives (i.e. localization errors vs background detection).

Additionally, this PR exposes new functions `iter_object_detection_results` and `create_object_detection_results` to allow users to generate object detection results without uploading them. This is expected to be useful for users who would like to be able to post-process their object detection results before upload.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
