### PR TITLE
Fix spelling of upload

### DIFF
--- a/tests/integration/dataset/test_dataset.py
+++ b/tests/integration/dataset/test_dataset.py
@@ -37,7 +37,7 @@ TEST_DATASET_HISTORY_VERSIONS = 10
 
 
 def test__upload_dataset__empty() -> None:
-    name = with_test_prefix(f"{__file__}::test__uplaod_dataset__empty")
+    name = with_test_prefix(f"{__file__}::test__upload_dataset__empty")
     upload_dataset(name, pd.DataFrame(columns=["locator"]), id_fields=["locator"])
 
     assert download_dataset(name).empty


### PR DESCRIPTION
Tiny fix: Change the spelling of "upload" in the integration test `tests/integration/dataset/test_dataset.py::test__upload_dataset__empty`.