### PR TITLE
Remove telemetry

### DIFF
--- a/kolena/_api/v1/token.py
+++ b/kolena/_api/v1/token.py
@@ -25,4 +25,3 @@ class ValidateResponse:
     tenant: str
     access_token: str
     token_type: str
-    tenant_telemetry: bool

--- a/kolena/_utils/instrumentation.py
+++ b/kolena/_utils/instrumentation.py
@@ -14,10 +14,7 @@
 import dataclasses
 import datetime
 import functools
-import inspect
 import json
-import traceback as tb
-from abc import ABCMeta
 from enum import Enum
 from typing import Any
 from typing import Callable
@@ -29,25 +26,10 @@ from kolena._api.v1.client_log import ClientLog as API
 from kolena._api.v1.core import TestRun as CoreAPI
 from kolena._api.v1.event import EventAPI
 from kolena._utils import krequests
-from kolena._utils.state import _client_state
 
 
 class DatadogLogLevels(str, Enum):
     ERROR = "error"
-
-
-def telemetry(func: Callable) -> Callable:
-    @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        if not _client_state.telemetry:  # no extra exception handling unless enabled
-            return func(*args, **kwargs)
-        try:
-            return func(*args, **kwargs)
-        except BaseException as e:
-            log_telemetry(e)
-            raise e
-
-    return wrapper
 
 
 def upload_log(message: str, status: str) -> None:
@@ -58,32 +40,6 @@ def upload_log(message: str, status: str) -> None:
         status=status,
     )
     krequests.post(endpoint_path=API.Path.UPLOAD.value, json=dataclasses.asdict(request))
-
-
-def log_telemetry(e: BaseException) -> None:
-    try:
-        stack = tb.format_stack()
-        exc_format = tb.format_exception(None, e, e.__traceback__)
-        combined = stack + exc_format
-        upload_log("".join(combined), DatadogLogLevels.ERROR.value)
-    except BaseException:
-        """
-        Attempting to upload the telemetry is best-effort. We don't want to have exceptions in that
-        process be thrown to the customer--instead they should get their original stacktrace.
-        """
-        ...
-
-
-class WithTelemetry(metaclass=ABCMeta):
-    """
-    Applies ``@telemetry`` to each "public" (non-underscored) service method declared on a subclass.
-    """
-
-    def __init_subclass__(cls) -> None:
-        for key, value in cls.__dict__.items():
-            if key.startswith("_") and not key == "__init__" or not callable(value) or inspect.isclass(value):
-                continue
-            setattr(cls, key, telemetry(value))
 
 
 def report_crash(id: int, endpoint_path: str) -> None:

--- a/kolena/_utils/krequests.py
+++ b/kolena/_utils/krequests.py
@@ -83,7 +83,6 @@ def _with_default_kwargs(**kwargs: Any) -> Dict[str, Any]:
             "Content-Type": "application/json",
             "X-Request-ID": uuid.uuid4().hex,
             "User-Agent": user_agent(client_name, client_version),
-            "X-Kolena-Telemetry": str(client_state.telemetry),
         },
     )
     # allow requests to override Content-Type as needed by for example file uploads

--- a/kolena/_utils/log.py
+++ b/kolena/_utils/log.py
@@ -22,7 +22,6 @@ from typing import TypeVar
 import termcolor
 from tqdm.auto import tqdm
 
-from kolena._utils.instrumentation import log_telemetry
 from kolena._utils.state import _client_state
 
 
@@ -72,9 +71,6 @@ def error(message: str, exception: Optional[BaseException], **kwargs: Any) -> No
     _print_header(file=sys.stderr)
     _print(message, **kwargs, color="red", file=sys.stderr)
     _logger.error(message, exc_info=exception, **kwargs)
-
-    if exception and _client_state.telemetry:
-        log_telemetry(exception)
 
 
 T = TypeVar("T")

--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -24,9 +24,8 @@ from typing import Optional
 
 import requests
 
-import kolena
 import kolena._api.v1.token as API
-from kolena._utils import krequests
+import kolena._utils
 from kolena._utils.serde import from_dict
 from kolena.errors import InvalidTokenError
 from kolena.errors import UnauthenticatedError
@@ -147,7 +146,7 @@ def get_token(
         proxies=proxies,
     )
     try:
-        krequests.raise_for_status(r)
+        kolena._utils.krequests.raise_for_status(r)
     except UnauthenticatedError as e:
         raise InvalidTokenError(e)
 

--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -24,8 +24,8 @@ from typing import Optional
 
 import requests
 
+import kolena
 import kolena._api.v1.token as API
-import kolena._utils
 from kolena._utils.serde import from_dict
 from kolena.errors import InvalidTokenError
 from kolena.errors import UnauthenticatedError

--- a/kolena/_utils/state.py
+++ b/kolena/_utils/state.py
@@ -54,7 +54,6 @@ class _ClientState:
         jwt_token: Optional[str] = None,
         tenant: Optional[str] = None,
         verbose: bool = False,
-        telemetry: bool = False,
         proxies: Optional[Dict[str, str]] = None,
         additional_request_headers: Optional[Dict[str, Any]] = None,
     ):
@@ -63,7 +62,6 @@ class _ClientState:
         self.jwt_token: Optional[str] = None
         self.tenant: Optional[str] = None
         self.verbose: bool = False
-        self.telemetry: bool = False
         self.proxies: Dict[str, str] = {}
         self.additional_request_headers: Optional[Dict[str, Any]] = None
         self.update(
@@ -72,7 +70,6 @@ class _ClientState:
             jwt_token=jwt_token,
             tenant=tenant,
             verbose=verbose,
-            telemetry=telemetry,
             proxies=proxies,
             additional_request_headers=additional_request_headers,
         )
@@ -84,7 +81,6 @@ class _ClientState:
         jwt_token: Optional[str] = None,
         tenant: Optional[str] = None,
         verbose: bool = False,
-        telemetry: bool = False,
         proxies: Optional[Dict[str, str]] = None,
         additional_request_headers: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -93,7 +89,6 @@ class _ClientState:
         self.jwt_token = jwt_token or self.jwt_token
         self.tenant = tenant or self.tenant
         self.verbose = verbose
-        self.telemetry = telemetry
         self.proxies = proxies or self.proxies
         self.additional_request_headers = additional_request_headers or self.additional_request_headers
 
@@ -103,7 +98,6 @@ class _ClientState:
         self.jwt_token = None
         self.tenant = None
         self.verbose = False
-        self.telemetry = False
         self.additional_request_headers = None
         self.proxies = {}
 

--- a/kolena/initialize.py
+++ b/kolena/initialize.py
@@ -129,13 +129,11 @@ def initialize(
         )
     assert api_token is not None
     init_response = state.get_token(api_token, proxies=proxies)
-    derived_telemetry = init_response.tenant_telemetry
     _client_state.update(
         api_token=api_token,
         jwt_token=init_response.access_token,
         tenant=init_response.tenant,
         verbose=verbose,
-        telemetry=derived_telemetry,
         proxies=proxies,
     )
 

--- a/kolena/workflow/model.py
+++ b/kolena/workflow/model.py
@@ -36,9 +36,7 @@ from kolena._utils.consts import BatchSize
 from kolena._utils.consts import FieldName
 from kolena._utils.endpoints import get_model_url
 from kolena._utils.frozen import Frozen
-from kolena._utils.instrumentation import telemetry
 from kolena._utils.instrumentation import with_event
-from kolena._utils.instrumentation import WithTelemetry
 from kolena._utils.serde import from_dict
 from kolena._utils.validators import validate_name
 from kolena._utils.validators import ValidatorConfig
@@ -55,7 +53,7 @@ from kolena.workflow.workflow import Workflow
 TestSample = TypeVar("TestSample", bound=BaseTestSample)
 
 
-class Model(Frozen, WithTelemetry, metaclass=ABCMeta):
+class Model(Frozen, metaclass=ABCMeta):
     """
     The descriptor of a model tested on Kolena. A model is a deterministic transformation from
     [`TestSample`][kolena.workflow.TestSample] inputs to [`Inference`][kolena.workflow.Inference] outputs.
@@ -88,7 +86,6 @@ class Model(Frozen, WithTelemetry, metaclass=ABCMeta):
 
     _id: int
 
-    @telemetry
     def __init_subclass__(cls) -> None:
         if not hasattr(cls, "workflow"):
             raise NotImplementedError(f"{cls.__name__} must implement class attribute 'workflow'")

--- a/kolena/workflow/test_case.py
+++ b/kolena/workflow/test_case.py
@@ -40,9 +40,7 @@ from kolena._utils.consts import BatchSize
 from kolena._utils.consts import FieldName
 from kolena._utils.dataframes.validators import validate_df_schema
 from kolena._utils.frozen import Frozen
-from kolena._utils.instrumentation import telemetry
 from kolena._utils.instrumentation import with_event
-from kolena._utils.instrumentation import WithTelemetry
 from kolena._utils.serde import from_dict
 from kolena._utils.validators import validate_name
 from kolena._utils.validators import ValidatorConfig
@@ -84,7 +82,7 @@ def _to_editor_data_frame(
     return TestCaseEditorDataFrame(validate_df_schema(df, TestCaseEditorDataFrame.get_schema(), trusted=True))
 
 
-class TestCase(Frozen, WithTelemetry, metaclass=ABCMeta):
+class TestCase(Frozen, metaclass=ABCMeta):
     """
     A test case holds a list of [test samples][kolena.workflow.TestSample] paired with
     [ground truths][kolena.workflow.GroundTruth] representing a testing dataset or a slice of a testing dataset.
@@ -112,7 +110,6 @@ class TestCase(Frozen, WithTelemetry, metaclass=ABCMeta):
 
     _id: int
 
-    @telemetry
     def __init_subclass__(cls) -> None:
         if not hasattr(cls, "workflow"):
             raise NotImplementedError(f"{cls.__name__} must implement class attribute 'workflow'")

--- a/kolena/workflow/test_run.py
+++ b/kolena/workflow/test_run.py
@@ -43,7 +43,6 @@ from kolena._utils.endpoints import get_results_url
 from kolena._utils.frozen import Frozen
 from kolena._utils.instrumentation import report_crash
 from kolena._utils.instrumentation import with_event
-from kolena._utils.instrumentation import WithTelemetry
 from kolena._utils.serde import from_dict
 from kolena._utils.validators import ValidatorConfig
 from kolena.errors import IncorrectUsageError
@@ -75,7 +74,7 @@ from kolena.workflow.evaluator_function import EvaluationResults
 from kolena.workflow.test_sample import _METADATA_KEY
 
 
-class TestRun(Frozen, WithTelemetry, metaclass=ABCMeta):
+class TestRun(Frozen, metaclass=ABCMeta):
     """
     A [`Model`][kolena.workflow.Model] tested on a [`TestSuite`][kolena.workflow.TestSuite] using a specific
     [`Evaluator`][kolena.workflow.Evaluator] implementation.

--- a/kolena/workflow/test_suite.py
+++ b/kolena/workflow/test_suite.py
@@ -36,9 +36,7 @@ from kolena._utils.consts import BatchSize
 from kolena._utils.consts import FieldName
 from kolena._utils.endpoints import get_test_suite_url
 from kolena._utils.frozen import Frozen
-from kolena._utils.instrumentation import telemetry
 from kolena._utils.instrumentation import with_event
-from kolena._utils.instrumentation import WithTelemetry
 from kolena._utils.serde import from_dict
 from kolena._utils.validators import validate_name
 from kolena._utils.validators import ValidatorConfig
@@ -52,7 +50,7 @@ from kolena.workflow.test_sample import _METADATA_KEY
 from kolena.workflow.workflow import Workflow
 
 
-class TestSuite(Frozen, WithTelemetry, metaclass=ABCMeta):
+class TestSuite(Frozen, metaclass=ABCMeta):
     """
     A test suite groups together one or more [test cases][kolena.workflow.TestCase]. Typically a test suite represents a
     benchmark test dataset, with test cases representing different meaningful subsets, or slices, or this benchmark.
@@ -91,7 +89,6 @@ class TestSuite(Frozen, WithTelemetry, metaclass=ABCMeta):
     _id: int
     _test_case_type: Type[TestCase]
 
-    @telemetry
     def __init_subclass__(cls) -> None:
         if not hasattr(cls, "workflow"):
             raise NotImplementedError(f"{cls.__name__} must implement class attribute 'workflow'")

--- a/tests/unit/test_initialize.py
+++ b/tests/unit/test_initialize.py
@@ -49,22 +49,11 @@ def mock_get_token(api_token: str, *args: Any, **kwargs: Any) -> ValidateRespons
         tenant="mock tenant",
         access_token=mock_jwt(api_token),
         token_type="mock token type",
-        tenant_telemetry=False,
-    )
-
-
-def mock_get_token_with_telemetry(api_token: str, *args: Any, **kwargs: Any) -> ValidateResponse:
-    return ValidateResponse(
-        tenant="mock tenant",
-        access_token=mock_jwt(api_token),
-        token_type="mock token type",
-        tenant_telemetry=True,
     )
 
 
 MOCK_TOKEN = "mock token"
 FIXED_TOKEN_RESPONSE = mock_get_token(MOCK_TOKEN)
-FIXED_TOKEN_RESPONSE_WITH_TELEMETRY = mock_get_token_with_telemetry(MOCK_TOKEN)
 
 
 @pytest.fixture(autouse=True)
@@ -96,16 +85,6 @@ def test__initialize__positional() -> None:
         kolena.initialize("bar")
         assert _client_state.api_token == "bar"
         assert _client_state.jwt_token is not None
-        assert not _client_state.telemetry
-        assert _client_state.additional_request_headers is None
-
-
-def test__initialize__telemetry() -> None:
-    with patch("kolena._utils.state.get_token", return_value=FIXED_TOKEN_RESPONSE_WITH_TELEMETRY):
-        kolena.initialize(api_token="bar")
-        assert _client_state.api_token == "bar"
-        assert _client_state.jwt_token is not None
-        assert _client_state.telemetry
         assert _client_state.additional_request_headers is None
 
 

--- a/tests/unit/test_krequests.py
+++ b/tests/unit/test_krequests.py
@@ -29,7 +29,6 @@ DEFAULT_HEADERS = {
     "Content-Type": "application/json",
     "X-Request-ID": None,
     "User-Agent": None,
-    "X-Kolena-Telemetry": "False",
 }
 DEFAULT_KWARGS = {"auth": None, "timeout": (15.05, 3600), "proxies": {}}
 
@@ -51,10 +50,10 @@ def clean_client_state() -> Iterator[None]:
         ({"timeout": (1, 60)}, None, None),  # attempt to override default args
         ({}, {"http": "dummy-proxy"}, {}),
         ({}, {}, {"some-header-key": "some-header-val"}),
-        ({}, {}, {"X-Kolena-Telemetry": "off"}),  # attempt to override default headers with client state
-        ({"headers": {"X-Kolena-Telemetry": "off"}}, {}, {}),  # attempt to override default headers with kwargs
+        ({}, {}, {}),  # attempt to override default headers with client state
+        ({"headers": {}}, {}, {}),  # attempt to override default headers with kwargs
         ({"headers": {"Content-Type": "application/octet-stream"}}, {}, {}),  # should allow overriding Content-Type
-        ({"url": "some-url", "data": {"key": "value"}}, {"http": "dummy-proxy"}, {"X-Kolena-Telemetry": "off"}),
+        ({"url": "some-url", "data": {"key": "value"}}, {"http": "dummy-proxy"}, {}),
     ],
 )
 def test__with_default_kwargs(

--- a/tests/unit/test_krequests.py
+++ b/tests/unit/test_krequests.py
@@ -50,10 +50,10 @@ def clean_client_state() -> Iterator[None]:
         ({"timeout": (1, 60)}, None, None),  # attempt to override default args
         ({}, {"http": "dummy-proxy"}, {}),
         ({}, {}, {"some-header-key": "some-header-val"}),
-        ({}, {}, {}),  # attempt to override default headers with client state
-        ({"headers": {}}, {}, {}),  # attempt to override default headers with kwargs
+        ({}, {}, {"User-Agent": "some-val"}),  # attempt to override default headers with client state
+        ({"headers": {"User-Agent": "some-val"}}, {}, {}),  # attempt to override default headers with kwargs
         ({"headers": {"Content-Type": "application/octet-stream"}}, {}, {}),  # should allow overriding Content-Type
-        ({"url": "some-url", "data": {"key": "value"}}, {"http": "dummy-proxy"}, {}),
+        ({"url": "some-url", "data": {"key": "value"}}, {"http": "dummy-proxy"}, {"User-Agent": "some-val"}),
     ],
 )
 def test__with_default_kwargs(


### PR DESCRIPTION
### Linked issue(s)
https://linear.app/kolena/issue/KOL-6307/remove-telemetry-from-python-sdk

### What change does this PR introduce and why?
Removes client telemetry. We do not get value out of this and it adds complexity to Python client.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
