### PR TITLE
feat: better format dataset result download response

### DIFF
--- a/kolena/_experimental/search/embeddings.py
+++ b/kolena/_experimental/search/embeddings.py
@@ -41,7 +41,6 @@ from kolena.dataset._common import validate_dataframe_ids
 from kolena.dataset.dataset import _load_dataset_metadata
 from kolena.dataset.dataset import _to_serialized_dataframe
 from kolena.errors import InputValidationError
-from kolena.errors import NotFoundError
 
 
 def upload_embeddings(key: str, embeddings: List[Tuple[str, np.ndarray]]) -> None:
@@ -106,8 +105,6 @@ def upload_dataset_embeddings(dataset_name: str, key: str, df_embedding: pd.Data
 
     # prepare the id objects of the dataset
     existing_dataset = _load_dataset_metadata(dataset_name)
-    if not existing_dataset:
-        raise NotFoundError(f"dataset {dataset_name} does not exist")
     id_fields = existing_dataset.id_fields
     validate_dataframe_ids(df_embedding, id_fields)
     df_serialized_datapoint_id_object = _to_serialized_dataframe(

--- a/kolena/dataset/__init__.py
+++ b/kolena/dataset/__init__.py
@@ -16,10 +16,12 @@ from kolena.dataset.dataset import upload_dataset
 from kolena.dataset.dataset import download_dataset
 from kolena.dataset.evaluation import upload_results
 from kolena.dataset.evaluation import download_results
+from kolena.dataset.evaluation import EvalConfigResults
 
 __all__ = [
     "upload_dataset",
     "download_dataset",
     "upload_results",
     "download_results",
+    "EvalConfigResults",
 ]

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -159,7 +159,7 @@ def download_results(
 
     :param dataset: The name of the dataset.
     :param model: The name of the model.
-    :return: Tuple of DataFrame of datapoints and list of [`EvalConfigResults`](kolena.dataset.EvalConfigResults).
+    :return: Tuple of DataFrame of datapoints and list of [`EvalConfigResults`][kolena.dataset.EvalConfigResults].
     """
     log.info(f"downloading results for model '{model}' on dataset '{dataset}'")
     existing_dataset = _load_dataset_metadata(dataset)
@@ -283,7 +283,7 @@ def upload_results(
 
     :param dataset: The name of the dataset.
     :param model: The name of the model.
-    :param results: Either a DataFrame or a list of [`EvalConfigResults`](kolena.dataset.EvalConfigResults).
+    :param results: Either a DataFrame or a list of [`EvalConfigResults`][kolena.dataset.EvalConfigResults].
     :param thresholded_fields: Columns in result DataFrame containing data associated with different thresholds.
 
     :return: None

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -53,7 +53,6 @@ from kolena.dataset.dataset import _load_dataset_metadata
 from kolena.dataset.dataset import _to_deserialized_dataframe
 from kolena.dataset.dataset import _to_serialized_dataframe
 from kolena.errors import IncorrectUsageError
-from kolena.errors import NotFoundError
 
 EvalConfig = Optional[Dict[str, Any]]
 """
@@ -163,8 +162,6 @@ def download_results(
     """
     log.info(f"downloading results for model '{model}' on dataset '{dataset}'")
     existing_dataset = _load_dataset_metadata(dataset)
-    if not existing_dataset:
-        raise NotFoundError(f"dataset {dataset} does not exist")
 
     id_fields = existing_dataset.id_fields
 
@@ -213,8 +210,6 @@ def _prepare_upload_results_request(
     thresholded_fields: Optional[List[str]] = None,
 ) -> Tuple[str, int, int]:
     existing_dataset = _load_dataset_metadata(dataset)
-    if not existing_dataset:
-        raise NotFoundError(f"dataset {dataset} does not exist")
 
     id_fields = existing_dataset.id_fields
 

--- a/tests/integration/_experimental/helper.py
+++ b/tests/integration/_experimental/helper.py
@@ -18,7 +18,6 @@ from kolena.dataset.dataset import _load_dataset_metadata
 
 def create_quality_standard(dataset_name: str, quality_standard: dict) -> None:
     dataset = _load_dataset_metadata(dataset_name)
-    assert dataset
 
     response = krequests.put(
         QualityStandardPath.QUALITY_STANDARD,

--- a/tests/integration/_experimental/object_detection/test_dataset.py
+++ b/tests/integration/_experimental/object_detection/test_dataset.py
@@ -163,7 +163,7 @@ def test__upload_results__single_class(annotation: str, gts: ObjectAnnotations, 
 
     _, results = download_results(name, name)
     assert len(results) == 1
-    assert results[0][0] == eval_config
+    assert results[0].eval_config == eval_config
 
     df_results = results[0][1]
     expected_columns = {
@@ -286,8 +286,8 @@ def test__upload_results__multiclass(annotation: str, gts: ObjectAnnotations, in
 
     _, results = download_results(name, name)
     assert len(results) == 2
-    assert results[0][0] == eval_config_one
-    assert results[1][0] == eval_config_two
+    assert results[0].eval_config == eval_config_one
+    assert results[1].eval_config == eval_config_two
 
     df_results_one = results[0][1]
     df_results_two = results[1][1]

--- a/tests/integration/dataset/test_evaluation.py
+++ b/tests/integration/dataset/test_evaluation.py
@@ -19,6 +19,7 @@ import pytest
 
 from kolena.dataset import download_dataset
 from kolena.dataset import download_results
+from kolena.dataset import EvalConfigResults
 from kolena.dataset import upload_dataset
 from kolena.dataset.evaluation import _upload_results
 from kolena.errors import IncorrectUsageError
@@ -51,6 +52,12 @@ def get_df_result(n: int = 20) -> pd.DataFrame:
     return pd.DataFrame(records)
 
 
+def check_eval_config_result_tuples(eval_config_results: list[EvalConfigResults]) -> None:
+    for eval_config_result in eval_config_results:
+        assert eval_config_result.eval_config == eval_config_result[0]
+        assert_frame_equal(eval_config_result.results, eval_config_result[1])
+
+
 def test__upload_results() -> None:
     dataset_name = with_test_prefix(f"{__file__}::test__upload_results")
     model_name = with_test_prefix(f"{__file__}::test__upload_results")
@@ -71,9 +78,11 @@ def test__upload_results() -> None:
     assert response.eval_config_id is not None
 
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     eval_cfg, fetched_df_result = df_results_by_eval[0]
     assert len(df_results_by_eval) == 1
     assert eval_cfg is None
+    assert_frame_equal(fetched_df_dp, fetched_df_result, ID_FIELDS)
     expected_df_dp = df_dp[3:10].reset_index(drop=True)
     expected_df_result = df_result.drop(columns=[JOIN_COLUMN])[3:10].reset_index(drop=True)
     assert_frame_equal(fetched_df_dp, expected_df_dp, dp_columns)
@@ -98,9 +107,11 @@ def test__upload_results__iterator_input() -> None:
     assert response.eval_config_id is not None
 
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     eval_cfg, fetched_df_result = df_results_by_eval[0]
     assert len(df_results_by_eval) == 1
     assert eval_cfg is None
+    assert_frame_equal(fetched_df_dp, fetched_df_result, ID_FIELDS)
     expected_df_dp = df_dp[3:10].reset_index(drop=True)
     expected_df_result = df_result.drop(columns=[JOIN_COLUMN])[3:10].reset_index(drop=True)
     assert_frame_equal(fetched_df_dp, expected_df_dp, dp_columns)
@@ -130,9 +141,11 @@ def test__upload_results__align_manually() -> None:
     assert response.eval_config_id is not None
 
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     eval_cfg, fetched_df_result = df_results_by_eval[0]
     assert len(df_results_by_eval) == 1
     assert eval_cfg is None
+    assert_frame_equal(fetched_df_dp, fetched_df_result, ID_FIELDS)
     expected_df_dp = df_dp[3:10].reset_index(drop=True)
     expected_df_result = df_result.drop(columns=[JOIN_COLUMN])[3:10].reset_index(drop=True)
     assert_frame_equal(fetched_df_dp, expected_df_dp, dp_columns)
@@ -167,6 +180,7 @@ def test__upload_results__multiple_eval_configs() -> None:
     assert len(response.eval_config_id) == 2
 
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     assert len(df_results_by_eval) == 2
     expected_df_dp = df_dp[3:10].reset_index(drop=True)
     assert_frame_equal(fetched_df_dp, expected_df_dp, dp_columns)
@@ -176,6 +190,8 @@ def test__upload_results__multiple_eval_configs() -> None:
     fetched_eval_config_2, fetched_df_result_2 = df_results_by_eval[1]
     assert fetched_eval_config_1 == eval_config_1
     assert fetched_eval_config_2 == eval_config_2
+    assert_frame_equal(fetched_df_dp, fetched_df_result_1, ID_FIELDS)
+    assert_frame_equal(fetched_df_dp, fetched_df_result_2, ID_FIELDS)
     expected_df_result_1 = df_result_1.drop(columns=[JOIN_COLUMN])[3:10].reset_index(drop=True)
     expected_df_result_2 = df_result_2.drop(columns=[JOIN_COLUMN])[3:10].reset_index(drop=True)
     assert_frame_equal(fetched_df_result_1, expected_df_result_1, result_columns_1)
@@ -210,6 +226,7 @@ def test__upload_results__multiple_eval_configs__iterator_input() -> None:
     assert len(response.eval_config_id) == 2
 
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     assert len(df_results_by_eval) == 2
     expected_df_dp = df_dp[3:10].reset_index(drop=True)
     assert_frame_equal(fetched_df_dp, expected_df_dp, dp_columns)
@@ -218,6 +235,8 @@ def test__upload_results__multiple_eval_configs__iterator_input() -> None:
     fetched_eval_config_2, fetched_df_result_2 = df_results_by_eval[1]
     assert fetched_eval_config_1 == eval_config_1
     assert fetched_eval_config_2 == eval_config_2
+    assert_frame_equal(fetched_df_dp, fetched_df_result_1, ID_FIELDS)
+    assert_frame_equal(fetched_df_dp, fetched_df_result_2, ID_FIELDS)
     expected_df_result_1 = df_result_1.drop(columns=[JOIN_COLUMN])[3:10].reset_index(drop=True)
     expected_df_result_2 = df_result_2.drop(columns=[JOIN_COLUMN])[3:10].reset_index(drop=True)
     result_columns_1.remove(JOIN_COLUMN)
@@ -255,6 +274,7 @@ def test__upload_results__multiple_eval_configs__partial_uploading() -> None:
 
     expected_df_dp = df_dp.reset_index(drop=True)
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     assert len(df_results_by_eval) == 2
     assert_frame_equal(fetched_df_dp, expected_df_dp, dp_columns)
 
@@ -263,6 +283,8 @@ def test__upload_results__multiple_eval_configs__partial_uploading() -> None:
     fetched_eval_config_2, fetched_df_result_2 = df_results_by_eval[1]
     assert fetched_eval_config_1 == eval_config_1
     assert fetched_eval_config_2 == eval_config_2
+    assert_frame_equal(fetched_df_dp, fetched_df_result_1, ID_FIELDS)
+    assert_frame_equal(fetched_df_dp, fetched_df_result_2, ID_FIELDS)
     # verify the partial results with placeholder
     expected_df_result_1_partial = (
         df_result.drop(columns=[JOIN_COLUMN])[result_columns_1].reset_index(drop=True).astype("object")
@@ -289,6 +311,7 @@ def test__upload_results__multiple_eval_configs__partial_uploading() -> None:
     assert len(response.eval_config_id) == 2
 
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     assert len(df_results_by_eval) == 2
     assert_frame_equal(fetched_df_dp, expected_df_dp, dp_columns)
 
@@ -297,6 +320,8 @@ def test__upload_results__multiple_eval_configs__partial_uploading() -> None:
     fetched_eval_config_2, fetched_df_result_2 = df_results_by_eval[1]
     assert fetched_eval_config_1 == eval_config_1
     assert fetched_eval_config_2 == eval_config_2
+    assert_frame_equal(fetched_df_dp, fetched_df_result_1, ID_FIELDS)
+    assert_frame_equal(fetched_df_dp, fetched_df_result_2, ID_FIELDS)
     expected_df_result_1 = df_result.drop(columns=[JOIN_COLUMN])[result_columns_1].reset_index(drop=True)
     expected_df_result_2 = df_result.drop(columns=[JOIN_COLUMN])[result_columns_2].reset_index(drop=True)
     assert_frame_equal(fetched_df_result_1, expected_df_result_1, result_columns_1)
@@ -349,7 +374,9 @@ def test__upload_results__missing_result() -> None:
     assert response.eval_config_id is not None
 
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     eval_cfg, fetched_df_result = df_results_by_eval[0]
+    assert_frame_equal(fetched_df_dp, fetched_df_result, ID_FIELDS)
     assert len(df_results_by_eval) == 1
     assert eval_cfg is None
     expected_df_dp = df_dp[3:10].reset_index(drop=True)
@@ -360,9 +387,11 @@ def test__upload_results__missing_result() -> None:
     # add 3 new datapoints, then we should have missing results in the db records
     upload_dataset(dataset_name, df_dp[:10][dp_columns], id_fields=ID_FIELDS)
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     eval_cfg, fetched_df_result = df_results_by_eval[0]
     assert len(df_results_by_eval) == 1
     assert eval_cfg is None
+    assert_frame_equal(fetched_df_dp, fetched_df_result, ID_FIELDS)
     expected_df_dp = pd.concat([df_dp[3:10], df_dp[:3]]).sort_values(JOIN_COLUMN).reset_index(drop=True)
     expected_df_result = pd.concat(
         [
@@ -400,6 +429,7 @@ def test__upload_results__upload_none() -> None:
     assert response.eval_config_id is not None
 
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     eval_cfg, fetched_df_result = df_results_by_eval[0]
     expected_df_dp = df_dp.reset_index(drop=True)
     expected_df_result = pd.concat(
@@ -413,6 +443,7 @@ def test__upload_results__upload_none() -> None:
     )
     assert len(df_results_by_eval) == 1
     assert eval_cfg is None
+    assert_frame_equal(fetched_df_dp, fetched_df_result, ID_FIELDS)
     assert_frame_equal(fetched_df_dp, expected_df_dp, dp_columns)
     assert_frame_equal(fetched_df_result, expected_df_result, result_columns)
 
@@ -445,18 +476,31 @@ def test__upload_results__thresholded() -> None:
     assert response.n_updated == 0
 
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     eval_cfg, fetched_df_result = df_results_by_eval[0]
     assert len(df_results_by_eval) == 1
     assert eval_cfg is None
+    assert_frame_equal(fetched_df_dp, fetched_df_result, ID_FIELDS)
     expected_df_dp = df_dp[3:10].reset_index(drop=True)
     expected_df_result = df_result.drop(columns=[JOIN_COLUMN])[3:10].reset_index(drop=True)
     assert_frame_equal(fetched_df_dp, expected_df_dp, dp_columns)
     assert_frame_equal(fetched_df_result, expected_df_result, result_columns)
 
 
-def test__download_results__not_exist() -> None:
-    dataset_name = with_test_prefix(f"{__file__}::test__download_results__not_exist")
-    model_name = with_test_prefix(f"{__file__}::test__download_results__not_exist")
+def test__download_results__dataset_does_not_exist() -> None:
+    dataset_name = with_test_prefix(f"{__file__}::test__download_results__dataset_does_not_exist")
+    model_name = with_test_prefix(f"{__file__}::test__download_results__dataset_does_not_exist")
+    with pytest.raises(NotFoundError) as exc_info:
+        download_results(dataset_name, model_name)
+    exc_info_value = str(exc_info.value)
+    assert "does not exist" in exc_info_value
+
+
+def test__download_results__model_does_not_exist() -> None:
+    dataset_name = with_test_prefix(f"{__file__}::test__download_results__model_does_not_exist")
+    model_name = with_test_prefix(f"{__file__}::test__download_results__model_does_not_exist")
+    df_dp = get_df_dp()
+    upload_dataset(dataset_name, df_dp, id_fields=ID_FIELDS)
     with pytest.raises(NotFoundError) as exc_info:
         download_results(dataset_name, model_name)
     exc_info_value = str(exc_info.value)
@@ -477,7 +521,7 @@ def test__download_results__reset_dataset() -> None:
     response = _upload_results(
         dataset_name,
         model_name,
-        [(eval_config, df_result)],
+        [EvalConfigResults(eval_config, df_result)],
     )
     assert response.n_inserted == 10
     assert response.n_updated == 0
@@ -485,11 +529,13 @@ def test__download_results__reset_dataset() -> None:
     assert response.eval_config_id is not None
 
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     eval_cfg, fetched_df_result = df_results_by_eval[0]
     assert not fetched_df_dp.empty
     assert not fetched_df_result.empty
     assert len(df_results_by_eval) == 1
     assert eval_cfg == eval_config
+    assert_frame_equal(fetched_df_dp, fetched_df_result, ID_FIELDS)
 
     # reset dataset by updating id_fields, no results are kept
     upload_dataset(dataset_name, df_dp[dp_columns], id_fields=[*ID_FIELDS, "locator"])
@@ -504,11 +550,12 @@ def test__download_results__preserve_none() -> None:
     model_name = with_test_prefix(f"{__file__}::test__download_results__preserve_none")
 
     data = [{"a": None, "id": 1}, {"a": float("inf"), "id": 2}, {"a": np.nan, "id": 3}, {"a": 42, "id": 4}]
+    id_fields = ["id"]
     df_dp = pd.DataFrame.from_dict(data, dtype=object)
     assert df_dp["a"][0] is None
     assert np.isinf(df_dp["a"][1])
     assert np.isnan(df_dp["a"][2])
-    upload_dataset(dataset_name, df_dp, id_fields=["id"])
+    upload_dataset(dataset_name, df_dp, id_fields=id_fields)
 
     response = _upload_results(dataset_name, model_name, df_dp)
     assert response.n_inserted == 4
@@ -517,14 +564,16 @@ def test__download_results__preserve_none() -> None:
     assert response.eval_config_id is not None
 
     fetched_df_dp, df_results_by_eval = download_results(dataset_name, model_name)
+    check_eval_config_result_tuples(df_results_by_eval)
     eval_cfg, fetched_df_result = df_results_by_eval[0]
     assert not fetched_df_dp.empty
     assert not fetched_df_result.empty
     assert len(df_results_by_eval) == 1
     assert eval_cfg is None
+    assert_frame_equal(fetched_df_dp, fetched_df_result, id_fields)
 
     assert_frame_equal(fetched_df_dp, df_dp)
-    assert_frame_equal(fetched_df_result, df_dp[["a"]])
+    assert_frame_equal(fetched_df_result, df_dp, ["a"])
     assert fetched_df_dp["a"][0] is None
     assert np.isinf(fetched_df_dp["a"][1])
     assert np.isnan(fetched_df_dp["a"][2])


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-5941

Formatting the `download_results()` response better. Instead of having to rely on indexing the output such as:
```
response = download_results(dataset, model)
datapoints = response[0]
eval_config = response[1][0][0]
results = response[1][0][1]
```

We can now do:
```
response = download_results(dataset, model)
datapoints = response[0]
eval_config = response[1][0].eval_config
results = response[1][0].results
```

This change is backward compatible with the existing pattern of regular tuples, and the same change is applied to `upload_results()`

Updated API ref page:
<img width="904" alt="image" src="https://github.com/kolenaIO/kolena/assets/145366880/2277486c-b40c-4468-85fe-98d2a2d2729a">


### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
