### PR TITLE
Import `download_quality_standard_result` from `kolena._experimental`

### DIFF
--- a/kolena/_experimental/__init__.py
+++ b/kolena/_experimental/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from quality_standard import download_quality_standard_result
+from kolena._experimental.quality_standard import download_quality_standard_result

--- a/kolena/_experimental/__init__.py
+++ b/kolena/_experimental/__init__.py
@@ -11,3 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from quality_standard import download_quality_standard_result

--- a/tests/integration/_experimental/test_quality_standard.py
+++ b/tests/integration/_experimental/test_quality_standard.py
@@ -20,7 +20,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from kolena._experimental.quality_standard import download_quality_standard_result
+from kolena._experimental import download_quality_standard_result
 from kolena.dataset import upload_dataset
 from kolena.dataset.evaluation import _upload_results
 from kolena.dataset.evaluation import EvalConfig


### PR DESCRIPTION
### Linked issue(s)
Towards KOL-6428

### What change does this PR introduce and why?
Enables importing `download_quality_standard_result` from `kolena._experimental`. This is being done to align the import with the API reference doc for `kolena._experimental`

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
