### PR TITLE
fix: update broken model result link and remove experimental icon

### DIFF
--- a/docs/dataset/advanced-usage/quality-standard-results.md
+++ b/docs/dataset/advanced-usage/quality-standard-results.md
@@ -33,7 +33,7 @@ metric_group, metric)`.
 In order to automate deployment decisions with Kolena a team could:
 
 1. Define the metric requirements a model must meet in order to be considered for deployment.
-2. [Upload model results](../../reference/dataset/index.md##kolena.dataset.evaluation.upload_results) as part of a CI/CD
+2. [Upload model results](../../reference/dataset/index.md#kolena.dataset.evaluation.upload_results) as part of a CI/CD
    pipeline.
 3. [Download the dataset's quality standard
    results](../../reference/experimental/index.md#kolena._experimental.quality_standard.download_quality_standard_result)

--- a/docs/overrides/.icons/kolena/lab-test-16.svg
+++ b/docs/overrides/.icons/kolena/lab-test-16.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 60.1 (88133) - https://sketch.com -->
-    <title>pt-icon-lab-test-small</title>
-    <desc>Created with Sketch.</desc>
-    <g id="pt-icon-lab-test-small" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <path d="M11,1 C11.5522847,1 12,1.44771525 12,2 C12,2.55228475 11.5522847,3 11,3 L11,6 L14,13 L14,14.25 C14,14.6642136 13.6642136,15 13.25,15 L2.75,15 C2.33578644,15 2,14.6642136 2,14.25 L2,13 L5,6 L5,3 C4.44771525,3 4,2.55228475 4,2 C4,1.44771525 4.44771525,1 5,1 L11,1 Z M9,3 L7,3 L7,6 L5.286,10 L10.714,10 L9,6 L9,3 Z" id="Combined-Shape" fill="#000000"></path>
-    </g>
-</svg>

--- a/docs/overrides/.icons/kolena/lab-test-20.svg
+++ b/docs/overrides/.icons/kolena/lab-test-20.svg
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>pt-icon-lab-test</title>
-    <desc>Created with Sketch.</desc>
-    <g id="pt-icon-lab-test" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <path d="M13,2 C13.5522847,2 14,2.44771525 14,3 C14,3.55228475 13.5522847,4 13,4 L13,8 L17,16 L17,17 C17,17.5522847 16.5522847,18 16,18 L4,18 C3.44771525,18 3,17.5522847 3,17 L3,16 L7,8 L7,4 C6.44771525,4 6,3.55228475 6,3 C6,2.44771525 6.44771525,2 7,2 L13,2 Z M11,4 L9,4 L9,8 L7,12 L13,12 L11,8 L11,4 Z" id="Combined-Shape" fill="#000000"></path>
-    </g>
-</svg>

--- a/docs/reference/experimental/index.md
+++ b/docs/reference/experimental/index.md
@@ -1,4 +1,4 @@
 
-# :kolena-lab-test-20: `kolena._experimental`
+# `kolena._experimental`
 
 ::: kolena._experimental.quality_standard


### PR DESCRIPTION
### What change does this PR introduce and why?
Updates a broken link to `upload_results` in advanced usage quality-standard result doc. Removes experimental icon which was not coloured properly for dark mode.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
