### PR TITLE
Update experimental API reference docs to include IS and OD

### DIFF
--- a/docs/reference/experimental/index.md
+++ b/docs/reference/experimental/index.md
@@ -4,6 +4,10 @@
 ::: kolena._experimental.quality_standard
     options:
         show_root_heading: true
+::: kolena._experimental.search
+    options:
+        show_root_heading: true
+        members: ["upload_dataset_embeddings"]
 ::: kolena._experimental.object_detection
     options:
         members: ["compute_object_detection_results", "upload_object_detection_results"]

--- a/docs/reference/experimental/index.md
+++ b/docs/reference/experimental/index.md
@@ -2,5 +2,13 @@
 # Experimental Features
 
 ::: kolena._experimental.quality_standard
-::: kolena._experimental.object_detection.dataset
-::: kolena._experimental.instance_segmentation.dataset
+    options:
+        show_root_heading: true
+::: kolena._experimental.object_detection
+    options:
+        members: ["compute_object_detection_results", "upload_object_detection_results"]
+        show_root_heading: true
+::: kolena._experimental.instance_segmentation
+    options:
+        members: ["upload_instance_segmentation_results"]
+        show_root_heading: true

--- a/docs/reference/experimental/index.md
+++ b/docs/reference/experimental/index.md
@@ -1,4 +1,6 @@
 
-# :kolena-lab-test-20: `kolena._experimental`
+# Experimental Features
 
 ::: kolena._experimental.quality_standard
+::: kolena._experimental.object_detection.dataset
+::: kolena._experimental.instance_segmentation.dataset

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -51,4 +51,10 @@ This section contains detailed API reference documentation for `kolena`.
 
     Helper utilities for creating custom metrics
 
+- [`kolena._experimental`](./experimental/index.md)
+
+    ---
+
+    Experimental features
+
 </div>

--- a/kolena/_experimental/__init__.py
+++ b/kolena/_experimental/__init__.py
@@ -11,7 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from kolena._experimental.instance_segmentation.dataset import upload_instance_segmentation_results
-from kolena._experimental.object_detection.dataset import compute_object_detection_results
-from kolena._experimental.object_detection.dataset import upload_object_detection_results
 from kolena._experimental.quality_standard import download_quality_standard_result

--- a/kolena/_experimental/__init__.py
+++ b/kolena/_experimental/__init__.py
@@ -11,4 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from kolena._experimental.instance_segmentation.dataset import upload_instance_segmentation_results
+from kolena._experimental.object_detection.dataset import compute_object_detection_results
+from kolena._experimental.object_detection.dataset import upload_object_detection_results
 from kolena._experimental.quality_standard import download_quality_standard_result

--- a/kolena/_experimental/instance_segmentation/dataset.py
+++ b/kolena/_experimental/instance_segmentation/dataset.py
@@ -35,8 +35,8 @@ def upload_instance_segmentation_results(
     """
     Compute metrics and upload results of the model for the dataset.
 
-    Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
-    :inference in the Dataframe `df` should be a list of scored [`Polygons`][kolena.annotation.Polygon].
+    Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint and
+    an `inference` column that should be a list of scored [`Polygons`][kolena.annotation.Polygon].
 
     :param dataset_name: Dataset name.
     :param model_name: Model name.

--- a/kolena/_experimental/instance_segmentation/dataset.py
+++ b/kolena/_experimental/instance_segmentation/dataset.py
@@ -11,26 +11,54 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Dict
+from typing import Literal
+from typing import Union
+
+import pandas as pd
+
 from kolena._experimental.object_detection.dataset import upload_object_detection_results
 
 
-upload_instance_segmentation_results = upload_object_detection_results
-"""
-Compute metrics and upload results of the model for the dataset.
+def upload_instance_segmentation_results(
+    dataset_name: str,
+    model_name: str,
+    df: pd.DataFrame,
+    *,
+    ground_truths_field: str = "ground_truths",
+    raw_inferences_field: str = "raw_inferences",
+    iou_threshold: float = 0.5,
+    threshold_strategy: Union[Literal["F1-Optimal"], float, Dict[str, float]] = "F1-Optimal",
+    min_confidence_score: float = 0.01,
+    batch_size: int = 10_000,
+) -> None:
+    """
+    Compute metrics and upload results of the model for the dataset.
 
-Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
-:inference in the Dataframe `df` should be a list of scored [`Polygons`][kolena.annotation.Polygon].
+    Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
+    :inference in the Dataframe `df` should be a list of scored [`Polygons`][kolena.annotation.Polygon].
 
-:param dataset_name: Dataset name.
-:param model_name: Model name.
-:param df: Dataframe for model results.
-:param ground_truths_field: Field name in datapoint with ground truth polygons, defaulting to `"ground_truths"`.
-:param raw_inferences_field: Column in model result DataFrame with raw inference polygons,
-defaulting to `"raw_inferences"`.
-:param iou_threshold: The [IoU ↗](../../metrics/iou.md) threshold, defaulting to `0.5`.
-:param threshold_strategy: The confidence threshold strategy. It can either be a fixed confidence threshold such
-    as `0.5` or `0.75`, or `"F1-Optimal"` to find the threshold maximizing F1 score..
-:param min_confidence_score: The minimum confidence score to consider for the evaluation. This is usually set to
-    reduce noise by excluding inferences with low confidence score.
-:return:
-"""
+    :param dataset_name: Dataset name.
+    :param model_name: Model name.
+    :param df: Dataframe for model results.
+    :param ground_truths_field: Field name in datapoint with ground truth polygons, defaulting to `"ground_truths"`.
+    :param raw_inferences_field: Column in model result DataFrame with raw inference polygons,
+    defaulting to `"raw_inferences"`.
+    :param iou_threshold: The [IoU ↗](../../metrics/iou.md) threshold, defaulting to `0.5`.
+    :param threshold_strategy: The confidence threshold strategy. It can either be a fixed confidence threshold such
+        as `0.5` or `0.75`, or `"F1-Optimal"` to find the threshold maximizing F1 score..
+    :param min_confidence_score: The minimum confidence score to consider for the evaluation. This is usually set to
+        reduce noise by excluding inferences with low confidence score.
+    :return:
+    """
+    return upload_object_detection_results(
+        dataset_name,
+        model_name,
+        df,
+        ground_truths_field=ground_truths_field,
+        raw_inferences_field=raw_inferences_field,
+        iou_threshold=iou_threshold,
+        threshold_strategy=threshold_strategy,
+        min_confidence_score=min_confidence_score,
+        batch_size=batch_size,
+    )

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -353,8 +353,8 @@ def compute_object_detection_results(
     """
     Compute metrics of the model for the dataset.
 
-    Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
-    :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
+    Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint and
+    an `inference` column that should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
 
     :param dataset_name: Dataset name.
     :param df: Dataframe for model results.
@@ -400,8 +400,8 @@ def upload_object_detection_results(
     [`compute_object_detection_results`][kolena._experimental.object_detection.compute_object_detection_results]
     for the dataset.
 
-    Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint. Column
-    :inference in the Dataframe `df` should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
+    Dataframe `df` should include a `locator` column that would match to that of corresponding datapoint and
+    an `inference` column that should be a list of scored [`BoundingBoxes`][kolena.annotation.BoundingBox].
 
     :param dataset_name: Dataset name.
     :param model_name: Model name.


### PR DESCRIPTION
### Linked issue(s):
Fixes KOL-6559

### What change does this PR introduce and why?
Updates experimental API reference docs to include instance_segmentation and object_detection packages.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
