### PR TITLE
Preserve inference properties when matching

### DIFF
--- a/kolena/metrics/_geometry.py
+++ b/kolena/metrics/_geometry.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import dataclasses
 from collections import defaultdict
 from typing import Dict
 from typing import Generic
@@ -98,8 +97,9 @@ Inf = TypeVar("Inf", bound=Union[ScoredBoundingBox, ScoredPolygon, ScoredLabeled
 
 
 def _inf_with_iou(inf: Inf, iou_val: float) -> Inf:
-    args_without_iou = {key: value for key, value in inf._to_dict().items() if key != "iou"}
-    return dataclasses.replace(inf, **args_without_iou, iou=iou_val)  # type: ignore[call-arg]
+    args_without_iou = {key: value for key, value in inf._to_dict().items() if key not in ["iou", "data_type"]}
+    out: Inf = inf.__class__(**args_without_iou, iou=iou_val)  # type: ignore[call-arg,assignment]
+    return out
 
 
 @dataclass(frozen=True)

--- a/kolena/metrics/_geometry.py
+++ b/kolena/metrics/_geometry.py
@@ -98,7 +98,8 @@ Inf = TypeVar("Inf", bound=Union[ScoredBoundingBox, ScoredPolygon, ScoredLabeled
 
 
 def _inf_with_iou(inf: Inf, iou_val: float) -> Inf:
-    return dataclasses.replace(inf, iou=iou_val)  # type: ignore[call-arg]
+    args_without_iou = {key: value for key, value in inf._to_dict().items() if key != "iou"}
+    return dataclasses.replace(inf, **args_without_iou, iou=iou_val)  # type: ignore[call-arg]
 
 
 @dataclass(frozen=True)

--- a/kolena/metrics/_geometry.py
+++ b/kolena/metrics/_geometry.py
@@ -97,8 +97,12 @@ Inf = TypeVar("Inf", bound=Union[ScoredBoundingBox, ScoredPolygon, ScoredLabeled
 
 
 def _inf_with_iou(inf: Inf, iou_val: float) -> Inf:
-    args_without_iou = {key: value for key, value in inf._to_dict().items() if key not in ["iou", "data_type"]}
-    out: Inf = inf.__class__(**args_without_iou, iou=iou_val)  # type: ignore[call-arg,assignment]
+    input_args = {
+        key: value
+        for key, value in inf._to_dict().items()
+        if key not in ["width", "height", "area", "aspect_ratio", "iou", "data_type"]
+    }
+    out: Inf = inf.__class__(**input_args, iou=iou_val)  # type: ignore[call-arg,assignment]
     return out
 
 

--- a/kolena/metrics/_geometry.py
+++ b/kolena/metrics/_geometry.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import dataclasses
 from collections import defaultdict
 from typing import Dict
 from typing import Generic
@@ -97,12 +98,9 @@ Inf = TypeVar("Inf", bound=Union[ScoredBoundingBox, ScoredPolygon, ScoredLabeled
 
 
 def _inf_with_iou(inf: Inf, iou_val: float) -> Inf:
-    input_args = {
-        key: value
-        for key, value in inf._to_dict().items()
-        if key not in ["width", "height", "area", "aspect_ratio", "iou", "data_type"]
-    }
-    out: Inf = inf.__class__(**input_args, iou=iou_val)  # type: ignore[call-arg,assignment]
+    exclude = ["iou"] + [f.name for f in dataclasses.fields(inf) if not f.init]
+    obj = {k: v for k, v in vars(inf).items() if k not in exclude}
+    out: Inf = inf.__class__(**obj, iou=iou_val)  # type: ignore[call-arg,assignment]
     return out
 
 

--- a/tests/unit/metrics/test_geometry.py
+++ b/tests/unit/metrics/test_geometry.py
@@ -689,6 +689,30 @@ def test__match_inferences(
         assert inf.iou == pytest.approx(expected_iou, abs=1e-5)
 
 
+def test__match_inferences__preserves_extra_props_tp() -> None:
+    ground_truths = [BoundingBox(top_left=(1, 1), bottom_right=(6, 6))]
+    inferences = [
+        # type: ignore[call-arg]
+        ScoredLabeledBoundingBox(score=0.9, label="cow", top_left=(1, 1), bottom_right=(6, 6), flavor="cherry"),
+    ]
+    matches = match_inferences(ground_truths, inferences)
+    matched_inf = matches.matched[0][1]
+    assert hasattr(matched_inf, "flavor")
+    assert matched_inf.flavor == "cherry"
+
+
+def test__match_inferences__preserves_extra_props_fp() -> None:
+    ground_truths = []
+    inferences = [
+        # type: ignore[call-arg]
+        ScoredLabeledBoundingBox(score=0.9, label="cow", top_left=(1, 1), bottom_right=(6, 6), flavor="cherry"),
+    ]
+    matches = match_inferences(ground_truths, inferences)
+    unmatched_inf = matches.unmatched_inf[0]
+    assert hasattr(unmatched_inf, "flavor")
+    assert unmatched_inf.flavor == "cherry"
+
+
 def test__match_inferences__invalid_mode() -> None:
     with pytest.raises(InputValidationError):
         match_inferences(
@@ -2563,3 +2587,27 @@ def test__match_inferences_multiclass__iou(
     for inf in matches.unmatched_inf:
         expected_iou = max(iou(inf, gt) for gt in ground_truths) if ground_truths else 0.0
         assert inf.iou == pytest.approx(expected_iou, abs=1e-5)
+
+
+def test__match_inferences_multiclass__preserves_extra_props_tp() -> None:
+    ground_truths = [LabeledBoundingBox(top_left=(1, 1), bottom_right=(6, 6), label="cow")]
+    inferences = [
+        # type: ignore[call-arg]
+        ScoredLabeledBoundingBox(score=0.9, label="cow", top_left=(1, 1), bottom_right=(6, 6), flavor="cherry"),
+    ]
+    matches = match_inferences_multiclass(ground_truths, inferences)
+    matched_inf = matches.matched[0][1]
+    assert hasattr(matched_inf, "flavor")
+    assert matched_inf.flavor == "cherry"
+
+
+def test__match_inferences_multiclass__preserves_extra_props_fp() -> None:
+    ground_truths = [LabeledBoundingBox(top_left=(1, 1), bottom_right=(6, 6), label="cow")]
+    inferences = [
+        # type: ignore[call-arg]
+        ScoredLabeledBoundingBox(score=0.9, label="cow", top_left=(1, 1), bottom_right=(6, 6), flavor="cherry"),
+    ]
+    matches = match_inferences_multiclass(ground_truths, inferences)
+    unmatched_inf = matches.unmatched_inf[0]
+    assert hasattr(unmatched_inf, "flavor")
+    assert unmatched_inf.flavor == "cherry"

--- a/tests/unit/metrics/test_geometry.py
+++ b/tests/unit/metrics/test_geometry.py
@@ -2577,26 +2577,3 @@ def test__match_inferences_multiclass__iou(
     for inf in matches.unmatched_inf:
         expected_iou = max(iou(inf, gt) for gt in ground_truths) if ground_truths else 0.0
         assert inf.iou == pytest.approx(expected_iou, abs=1e-5)
-
-
-def test__match_inferences_multiclass__preserves_extra_props_tp() -> None:
-    ground_truths = [LabeledBoundingBox(top_left=(1, 1), bottom_right=(6, 6), label="cow")]
-    inferences = [
-        # type: ignore[call-arg]
-        ScoredLabeledBoundingBox(score=0.9, label="cow", top_left=(1, 1), bottom_right=(6, 6), flavor="cherry"),
-    ]
-    matches = match_inferences_multiclass(ground_truths, inferences)
-    matched_inf = matches.matched[0][1]
-    assert hasattr(matched_inf, "flavor")
-    assert matched_inf.flavor == "cherry"
-
-
-def test__match_inferences_multiclass__preserves_extra_props_fp() -> None:
-    ground_truths = [LabeledBoundingBox(top_left=(7, 7), bottom_right=(10, 10), label="cow")]
-    inferences = [
-        # type: ignore[call-arg]
-        ScoredLabeledBoundingBox(score=0.9, label="cow", top_left=(1, 1), bottom_right=(6, 6), flavor="cherry"),
-    ]
-    matches = match_inferences_multiclass(ground_truths, inferences)
-    unmatched_inf = matches.unmatched_inf[0]
-    assert hasattr(unmatched_inf, "flavor")

--- a/tests/unit/metrics/test_geometry.py
+++ b/tests/unit/metrics/test_geometry.py
@@ -114,7 +114,7 @@ def test__iou(points1: Union[BoundingBox, Polygon], points2: Union[BoundingBox, 
 def test__inf_with_iou() -> None:
     inf = ScoredLabeledBoundingBox(score=0.9, label="cow", top_left=(1, 1), bottom_right=(6, 6))
     inf_iou = _inf_with_iou(inf, 1)
-    assert inf_iou.inf == 1
+    assert inf_iou.iou == 1
 
 
 def test__inf_with_iou_preserves_extra_props() -> None:

--- a/tests/unit/metrics/test_geometry.py
+++ b/tests/unit/metrics/test_geometry.py
@@ -2602,7 +2602,7 @@ def test__match_inferences_multiclass__preserves_extra_props_tp() -> None:
 
 
 def test__match_inferences_multiclass__preserves_extra_props_fp() -> None:
-    ground_truths = [LabeledBoundingBox(top_left=(1, 1), bottom_right=(6, 6), label="cow")]
+    ground_truths = [LabeledBoundingBox(top_left=(7, 7), bottom_right=(10, 10), label="cow")]
     inferences = [
         # type: ignore[call-arg]
         ScoredLabeledBoundingBox(score=0.9, label="cow", top_left=(1, 1), bottom_right=(6, 6), flavor="cherry"),


### PR DESCRIPTION
### Linked issue(s)

Related to KOL-6304

### What change does this PR introduce and why?

Preserves additional properties added when adding `iou` to inference matches produced by `match_inferences`.

`dataclasses.replace` only preserves properties which exist in the class definition, but not any extra properties that may be allowed (via `extra='allow'` in the pydantic validation configuration).

This PR ensures that inference annotations retain any additional properties after being matched.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
