### PR TITLE
Add argument to `load-by-name` to suppress 404 when creating a new dataset

### DIFF
--- a/kolena/_api/v2/dataset.py
+++ b/kolena/_api/v2/dataset.py
@@ -46,6 +46,7 @@ class LoadDatapointsRequest(BatchedLoad.BaseInitDownloadRequest):
 @dataclass(frozen=True)
 class LoadDatasetByNameRequest:
     name: str
+    raise_error_if_not_found: bool = True
 
 
 @dataclass(frozen=True)

--- a/kolena/_experimental/search/embeddings.py
+++ b/kolena/_experimental/search/embeddings.py
@@ -135,4 +135,5 @@ def upload_dataset_embeddings(dataset_name: str, key: str, df_embedding: pd.Data
     :raises InputValidationError: The provided input is not valid.
     """
     existing_dataset = _load_dataset_metadata(dataset_name)
+    assert existing_dataset
     _upload_dataset_embeddings(existing_dataset, key, df_embedding)

--- a/kolena/dataset/dataset.py
+++ b/kolena/dataset/dataset.py
@@ -169,20 +169,23 @@ def _upload_dataset_chunk(df: pd.DataFrame, load_uuid: str, id_fields: List[str]
     upload_data_frame(df=df_serialized, load_uuid=load_uuid)
 
 
-def _load_dataset_metadata(name: str) -> EntityData:
+def _load_dataset_metadata(name: str, raise_error_if_not_found: bool = True) -> Optional[EntityData]:
     """
     Load the metadata of a given dataset.
 
     :param name: The name of the dataset.
+    :param raise_error_if_not_found: Whether to raise NotFoundError if dataset does not exist.
     :return: The metadata of the dataset.
     """
-    response = krequests.put(Path.LOAD_DATASET, json=asdict(LoadDatasetByNameRequest(name=name)))
-    if response.status_code == requests.codes.not_found:
+    response = krequests.put(
+        Path.LOAD_DATASET,
+        json=asdict(LoadDatasetByNameRequest(name=name, raise_error_if_not_found=raise_error_if_not_found)),
+    )
+    if raise_error_if_not_found and (response.status_code == requests.codes.not_found or response.json() is None):
         raise NotFoundError(f"dataset {name} does not exist")
-
     response.raise_for_status()
 
-    return from_dict(EntityData, response.json())
+    return from_dict(EntityData, response.json()) if response.json() else None
 
 
 def _resolve_id_fields(
@@ -209,10 +212,7 @@ def _prepare_upload_dataset_request(
 ) -> Tuple[List[str], str]:
     load_uuid = init_upload().uuid
 
-    try:
-        existing_dataset = _load_dataset_metadata(name)
-    except NotFoundError:
-        existing_dataset = None
+    existing_dataset = _load_dataset_metadata(name, raise_error_if_not_found=False)
     if isinstance(df, pd.DataFrame):
         id_fields = _resolve_id_fields(df, id_fields, existing_dataset)
         validate_dataframe_ids(df, id_fields)

--- a/kolena/dataset/dataset.py
+++ b/kolena/dataset/dataset.py
@@ -181,11 +181,16 @@ def _load_dataset_metadata(name: str, raise_error_if_not_found: bool = True) -> 
         Path.LOAD_DATASET,
         json=asdict(LoadDatasetByNameRequest(name=name, raise_error_if_not_found=raise_error_if_not_found)),
     )
-    if raise_error_if_not_found and (response.status_code == requests.codes.not_found or response.json() is None):
-        raise NotFoundError(f"dataset {name} does not exist")
+    if response.status_code == requests.codes.not_found or (
+        response.status_code == requests.codes.ok and response.json() is None
+    ):
+        if raise_error_if_not_found:
+            raise NotFoundError(f"dataset {name} does not exist")
+        else:
+            return None
     response.raise_for_status()
 
-    return from_dict(EntityData, response.json()) if response.json() else None
+    return from_dict(EntityData, response.json())
 
 
 def _resolve_id_fields(

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -162,6 +162,7 @@ def download_results(
     """
     log.info(f"downloading results for model '{model}' on dataset '{dataset}'")
     existing_dataset = _load_dataset_metadata(dataset)
+    assert existing_dataset
 
     id_fields = existing_dataset.id_fields
 
@@ -210,6 +211,7 @@ def _prepare_upload_results_request(
     thresholded_fields: Optional[List[str]] = None,
 ) -> Tuple[str, int, int]:
     existing_dataset = _load_dataset_metadata(dataset)
+    assert existing_dataset
 
     id_fields = existing_dataset.id_fields
 

--- a/tests/integration/_experimental/helper.py
+++ b/tests/integration/_experimental/helper.py
@@ -18,6 +18,7 @@ from kolena.dataset.dataset import _load_dataset_metadata
 
 def create_quality_standard(dataset_name: str, quality_standard: dict) -> None:
     dataset = _load_dataset_metadata(dataset_name)
+    assert dataset
 
     response = krequests.put(
         QualityStandardPath.QUALITY_STANDARD,

--- a/tests/integration/dataset/test_dataset.py
+++ b/tests/integration/dataset/test_dataset.py
@@ -24,6 +24,7 @@ from kolena._api.v2.dataset import CommitData
 from kolena.dataset import download_dataset
 from kolena.dataset import upload_dataset
 from kolena.dataset.dataset import _fetch_dataset_history
+from kolena.dataset.dataset import _load_dataset_metadata
 from kolena.errors import NotFoundError
 from kolena.workflow.annotation import BoundingBox
 from kolena.workflow.annotation import LabeledBoundingBox
@@ -34,6 +35,13 @@ from tests.integration.helper import with_test_prefix
 
 TEST_DATASET_HISTORY_NAME = with_test_prefix(f"{__file__}::test__dataset_history")
 TEST_DATASET_HISTORY_VERSIONS = 10
+
+
+def test__load_dataset_metadata_dataset__not_exist() -> None:
+    name = with_test_prefix(f"{__file__}::test__load_dataset_metadata_dataset__not_exist")
+    with pytest.raises(NotFoundError):
+        _load_dataset_metadata(name)
+    assert _load_dataset_metadata(name, raise_error_if_not_found=False) is None
 
 
 def test__upload_dataset__empty() -> None:


### PR DESCRIPTION
### Linked issue(s)
Towards KOL-4762

### What change does this PR introduce and why?
Following https://github.com/kolenaIO/shipyard/pull/2256, add `raise_error_if_not_found` argument to `load-by-name` calls. This is default as `True` (no change from existing behavior) and is only `False` when we are uploading a dataset for which we currently expect a 404 error.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
