### PR TITLE
chore: Add event tracking to `download_quality_standard_result`

### DIFF
--- a/kolena/_api/v1/event.py
+++ b/kolena/_api/v1/event.py
@@ -63,6 +63,9 @@ class EventAPI:
         FETCH_DATASET_MODEL_RESULT = "sdk-dataset-model-result-fetched"
         UPLOAD_DATASET_MODEL_RESULT = "sdk-dataset-model-result-uploaded"
 
+        # quality-standard
+        FETCH_QUALITY_STANDARD_RESULT = "sdk-quality-standard-result-fetched"
+
     @dataclass(frozen=True)
     class RecordEventRequest:
         event_name: str

--- a/kolena/_experimental/quality_standard.py
+++ b/kolena/_experimental/quality_standard.py
@@ -17,9 +17,11 @@ from typing import Union
 
 import pandas as pd
 
+from kolena._api.v1.event import EventAPI
 from kolena._api.v2.quality_standard import Path
 from kolena._utils import krequests_v2 as krequests
 from kolena._utils import log
+from kolena._utils.instrumentation import with_event
 
 
 def _format_quality_standard_result_df(quality_standard_result: dict) -> pd.DataFrame:
@@ -46,6 +48,7 @@ def _format_quality_standard_result_df(quality_standard_result: dict) -> pd.Data
     return df.pivot(columns=["model", "eval_config", "metric_group", "metric"], values="value")
 
 
+@with_event(event_name=EventAPI.Event.FETCH_QUALITY_STANDARD_RESULT)
 def download_quality_standard_result(
     dataset: str,
     models: List[str],


### PR DESCRIPTION
### Linked issue(s)
Fixes KOL-6640

### What change does this PR introduce and why?
Adds event tracking to `download_quality_standard_result` to gather usage metrics.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
