### PR TITLE
Fix treatment of single class vs multiclass thresholded objects

### DIFF
--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -150,14 +150,21 @@ def multiclass_datapoint_metrics(
     ]
     scores = [inf["score"] for inf in tp] + [inf.score for inf in fp]
     labels = sorted(
+        {_safe_get_label(inf) for _, inf in object_matches.matched}
+        .union(
+            {_safe_get_label(inf) for inf in object_matches.unmatched_inf},
+        )
+        .union(
+            {_safe_get_label(gt) for gt, _ in object_matches.unmatched_gt},
+        )
+        .difference({None}),
+    )
+    inference_labels = (
         {inf.label for _, inf in object_matches.matched}
         .union(
-            {inf.label for inf in object_matches.unmatched_inf},
+            {_safe_get_label(inf) for inf in object_matches.unmatched_inf},
         )
-        .union({gt.label for gt, _ in object_matches.unmatched_gt}),
-    )
-    inference_labels = {inf.label for _, inf in object_matches.matched}.union(
-        {inf.label for inf in object_matches.unmatched_inf},
+        .difference({None})
     )
     fields = [
         ScoredLabel(label=label, score=thresholds[label])

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -105,11 +105,14 @@ def single_class_datapoint_metrics(
     fn = object_matches.unmatched_gt + [gt for gt, inf in object_matches.matched if inf.score < thresholds]
     scores = [inf["score"] for inf in tp] + [inf.score for inf in fp]
     labels = list(
-        {_safe_get_label(inf) for _, inf in object_matches.matched if _safe_get_label(inf) is not None}
+        {_safe_get_label(inf) for _, inf in object_matches.matched}
         .union(
-            {_safe_get_label(inf) for inf in object_matches.unmatched_inf if _safe_get_label(inf) is not None},
+            {_safe_get_label(inf) for inf in object_matches.unmatched_inf},
         )
-        .union({_safe_get_label(gt) for gt in object_matches.unmatched_gt if _safe_get_label(gt) is not None}),
+        .union(
+            {_safe_get_label(gt) for gt in object_matches.unmatched_gt},
+        )
+        .difference({None}),
     )
     label = None if len(labels) == 0 else labels[0]
 

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -148,10 +148,12 @@ def multiclass_datapoint_metrics(
         if inf is not None and inf.score >= thresholds[inf.label]
     ]
     scores = [inf["score"] for inf in tp] + [inf.score for inf in fp]
-    labels = _get_labels_from_objects(
-        [inf for _, inf in object_matches.matched]
-        + [inf for inf in object_matches.unmatched_inf]
-        + [gt for gt, _ in object_matches.unmatched_gt],
+    labels = sorted(
+        _get_labels_from_objects(
+            [inf for _, inf in object_matches.matched]
+            + [inf for inf in object_matches.unmatched_inf]
+            + [gt for gt, _ in object_matches.unmatched_gt],
+        ),
     )
     inference_labels = _get_labels_from_objects(
         [inf for _, inf in object_matches.matched] + [inf for inf in object_matches.unmatched_inf],

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -104,7 +104,18 @@ def single_class_datapoint_metrics(
     fp = [inf for inf in object_matches.unmatched_inf if inf.score >= thresholds]
     fn = object_matches.unmatched_gt + [gt for gt, inf in object_matches.matched if inf.score < thresholds]
     scores = [inf["score"] for inf in tp] + [inf.score for inf in fp]
-    thresholded = _compute_thresholded_metrics(object_matches, all_thresholds)
+    try:
+        label = list(
+            {inf.label for _, inf in object_matches.matched}
+            .union(
+                {inf.label for inf in object_matches.unmatched_inf},
+            )
+            .union({gt.label for gt in object_matches.unmatched_gt}),
+        )[0]
+    except AttributeError:
+        label = None
+
+    thresholded = _compute_thresholded_metrics(object_matches, all_thresholds, label)
     return dict(
         TP=tp,
         FP=fp,

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from typing import Any
 from typing import cast
 from typing import Dict
+from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import Literal
@@ -104,15 +105,10 @@ def single_class_datapoint_metrics(
     fp = [inf for inf in object_matches.unmatched_inf if inf.score >= thresholds]
     fn = object_matches.unmatched_gt + [gt for gt, inf in object_matches.matched if inf.score < thresholds]
     scores = [inf["score"] for inf in tp] + [inf.score for inf in fp]
-    labels = list(
-        {_safe_get_label(inf) for _, inf in object_matches.matched}
-        .union(
-            {_safe_get_label(inf) for inf in object_matches.unmatched_inf},
-        )
-        .union(
-            {_safe_get_label(gt) for gt in object_matches.unmatched_gt},
-        )
-        .difference({None}),
+    labels = _get_labels_from_objects(
+        [inf for _, inf in object_matches.matched]
+        + [inf for inf in object_matches.unmatched_inf]
+        + [gt for gt in object_matches.unmatched_gt],
     )
     label = None if len(labels) == 0 else labels[0]
 
@@ -152,22 +148,13 @@ def multiclass_datapoint_metrics(
         if inf is not None and inf.score >= thresholds[inf.label]
     ]
     scores = [inf["score"] for inf in tp] + [inf.score for inf in fp]
-    labels = sorted(
-        {_safe_get_label(inf) for _, inf in object_matches.matched}
-        .union(
-            {_safe_get_label(inf) for inf in object_matches.unmatched_inf},
-        )
-        .union(
-            {_safe_get_label(gt) for gt, _ in object_matches.unmatched_gt},
-        )
-        .difference({None}),
+    labels = _get_labels_from_objects(
+        [inf for _, inf in object_matches.matched]
+        + [inf for inf in object_matches.unmatched_inf]
+        + [gt for gt, _ in object_matches.unmatched_gt],
     )
-    inference_labels = (
-        {inf.label for _, inf in object_matches.matched}
-        .union(
-            {_safe_get_label(inf) for inf in object_matches.unmatched_inf},
-        )
-        .difference({None})
+    inference_labels = _get_labels_from_objects(
+        [inf for _, inf in object_matches.matched] + [inf for inf in object_matches.unmatched_inf],
     )
     fields = [
         ScoredLabel(label=label, score=thresholds[label])
@@ -329,6 +316,12 @@ def _safe_get_label(obj: object) -> Optional[str]:
         return str(obj.label)
 
     return None
+
+
+def _get_labels_from_objects(objs: Iterable[object]) -> List[str]:
+    maybe_labels = {_safe_get_label(obj) for obj in objs}
+    labels = [label for label in maybe_labels if label is not None]
+    return labels
 
 
 def _check_multiclass(ground_truth: pd.Series, inference: pd.Series) -> bool:

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -333,7 +333,7 @@ def _check_multiclass(ground_truth: pd.Series, inference: pd.Series) -> bool:
         {_safe_get_label(inf) for inf in itertools.chain.from_iterable(_filter_null(inference))},
     )
     if None in labels:
-        return len(labels) >= 3
+        return False
 
     return len(labels) >= 2
 

--- a/tests/integration/_experimental/object_detection/test_dataset.py
+++ b/tests/integration/_experimental/object_detection/test_dataset.py
@@ -180,7 +180,7 @@ def test__upload_results__single_class(annotation: str, gts: ObjectAnnotations, 
     _assert_result_bbox_contains_fields(df_results, ["TP", "FN"], ["foo"])
 
     thresholded_object = df_results["thresholded"].iloc[0][0]
-    assert "label" not in thresholded_object
+    assert ("label" in thresholded_object) == (annotation in ["labeled_bboxes", "labeled_polygons"])
     assert "threshold" in thresholded_object
 
 

--- a/tests/unit/_experimental/object_detection/test_dataset.py
+++ b/tests/unit/_experimental/object_detection/test_dataset.py
@@ -111,7 +111,7 @@ object_detection = pytest.importorskip("kolena._experimental.object_detection", 
                 None,
             ],
             # expected
-            True,
+            False,
         ),
     ],
 )


### PR DESCRIPTION
### Linked issue(s)

Fixes KOL-6703

### What change does this PR introduce and why?

Fixes an edge case in `upload_object_detection_results` where all ground truths and inferences have the same label.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
