### PR TITLE
build: avoid compatibility issue with numpy 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.8,<3.13"
 numpy = [
-    { version = ">=1.19", python = ">=3.8,<3.11" },
-    { version = ">=1.23", python = ">=3.11,<3.12" },
-    { version = ">=1.26", python = ">=3.12" },
+    { version = ">=1.19,<2", python = ">=3.8,<3.11" },
+    { version = ">=1.23,<2", python = ">=3.11,<3.12" },
+    { version = ">=1.26,<2", python = ">=3.12" },
 ]
 pandas = [
     { version = ">=1.1,<3", python = ">=3.8,<3.11" },


### PR DESCRIPTION
### Linked issue(s)

### What change does this PR introduce and why?

- numpy 2.0.0 was released at June 16th.
- to fix the example integration tests like [this](https://app.circleci.com/pipelines/github/kolenaIO/kolena/4446/workflows/dc5b7464-b44a-40e3-8e54-4007fff1d488/jobs/107327)
  - https://github.com/unionai-oss/pandera/issues/1685

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
