### PR TITLE
build: avoid compatibility issue with numpy 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 numpy = [
-    { version = ">=1.19", python = ">=3.8,<3.11" },
-    { version = ">=1.23", python = ">=3.11" },
+    { version = ">=1.19,<2", python = ">=3.8,<3.11" },
+    { version = ">=1.23,<2", python = ">=3.11" },
 ]
 pandas = [
     { version = ">=1.1,<1.6", python = ">=3.8,<3.11" },


### PR DESCRIPTION
### Linked issue(s)
https://github.com/kolenaIO/kolena/pull/622

### What change does this PR introduce and why?
Ports numpy compatibility bound from https://github.com/kolenaIO/kolena/pull/622 to latest `0.100.x` version

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
