### PR TITLE
fix: match _try_parse("NaN") behaviour with json.parse("NaN")

### DIFF
--- a/kolena/_utils/dataframes/transformers.py
+++ b/kolena/_utils/dataframes/transformers.py
@@ -88,6 +88,10 @@ def _try_parse(value: Any) -> Any:
     if isinstance(value, float) and math.isnan(value):
         return None
 
+    # Match behaviour: json.loads("NaN") == float('nan')
+    if isinstance(value, str) and value == "NaN":
+        return None
+
     # Convert empty strings to None
     if isinstance(value, str) and value == "":
         return None

--- a/tests/unit/utils/dataframes/test_transformers.py
+++ b/tests/unit/utils/dataframes/test_transformers.py
@@ -113,6 +113,9 @@ def test__try_parse() -> None:
     # Test NaN value
     assert _try_parse(float("nan")) is None
 
+    # Test string "NaN"
+    assert _try_parse("NaN") is None
+
     # Test other string
     assert _try_parse("hello") == "hello"
 


### PR DESCRIPTION
### Linked issue(s)

### What change does this PR introduce and why?

Before #600, `json.parse` was previously used where `_try_parse` is now used. `json.parse("NaN")` returns a float `nan` value, while `_try_parse("NaN")` currently returns a string `"NaN"`. This PR changes the behaviour of `_try_parse("NaN")` to match that of `json.parse("NaN")`, i.e. `_try_parse("NaN")` is changed to return a float `nan`.

This change will resolve this shipyard test failure: https://app.circleci.com/pipelines/github/kolenaIO/shipyard/8026/workflows/eb6a354a-43af-4210-ad28-0d03a7e06032/jobs/149222?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
