### PR TITLE
Bump kolena version in examples

### DIFF
--- a/examples/dataset/age_estimation/pyproject.toml
+++ b/examples/dataset/age_estimation/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/automatic_speech_recognition/pyproject.toml
+++ b/examples/dataset/automatic_speech_recognition/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 s3fs = "^2023.5.0"
 jiwer = "^3.0.3"
 langid = "^1.1.6"

--- a/examples/dataset/classification/pyproject.toml
+++ b/examples/dataset/classification/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/crossing_pedestrian_detection/pyproject.toml
+++ b/examples/dataset/crossing_pedestrian_detection/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 s3fs = "^2023.5.0"
 smart-open = {extras = ["s3"], version = "^7.0.1"}
 numpy = "^1.19"

--- a/examples/dataset/face_recognition_11/pyproject.toml
+++ b/examples/dataset/face_recognition_11/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = ">=1.3.0"
+kolena = ">=1.23.0"
 s3fs = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"
 numpy = "^1"

--- a/examples/dataset/image_retrieval_by_text/pyproject.toml
+++ b/examples/dataset/image_retrieval_by_text/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
-kolena = {extras = ["metrics"], version = "^1.9.0"}
+kolena = {extras = ["metrics"], version = "^1.23.0"}
 s3fs = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"
 numpy = "^1.26.4"

--- a/examples/dataset/keypoint_detection/pyproject.toml
+++ b/examples/dataset/keypoint_detection/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/object_detection_2d/pyproject.toml
+++ b/examples/dataset/object_detection_2d/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = {extras = ["metrics"], version = "^1.9.0"}
+kolena = {extras = ["metrics"], version = "^1.23.0"}
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/object_detection_3d/pyproject.toml
+++ b/examples/dataset/object_detection_3d/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 pydantic = ">=2,<3"
 openmim = "^0.3.9"
 mmcv-lite = ">=2.0.0rc4"

--- a/examples/dataset/person_detection/pyproject.toml
+++ b/examples/dataset/person_detection/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = {extras = ["metrics"], version = "^1.9.0"}
+kolena = {extras = ["metrics"], version = "^1.23.0"}
 s3fs = "^2023.5.0"
 numpy = "^1.19"
 

--- a/examples/dataset/question_answering/pyproject.toml
+++ b/examples/dataset/question_answering/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.11"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 s3fs = "^2022.7.1"
 torch = [
   {markers = "sys_platform == 'darwin' and platform_machine == 'arm64'", url = "https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_11_0_arm64.whl"},

--- a/examples/dataset/rain_forecast/pyproject.toml
+++ b/examples/dataset/rain_forecast/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 s3fs = "^2022.7.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/dataset/search_embeddings/pyproject.toml
+++ b/examples/dataset/search_embeddings/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.13"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 s3fs = "^2023.5.0"
 kolena-embeddings = {version = "^0.6.0", source = "kolena-embeddings"}
 

--- a/examples/dataset/semantic_segmentation/pyproject.toml
+++ b/examples/dataset/semantic_segmentation/pyproject.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 opencv-python-headless = ">=4.6.0.66,<4.7"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/semantic_textual_similarity/pyproject.toml
+++ b/examples/dataset/semantic_textual_similarity/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 s3fs = "^2023.5.0"
 fsspec = "^2023.5.0"
 pandera = ">=0.9.0,<0.16"

--- a/examples/dataset/speaker_diarization/pyproject.toml
+++ b/examples/dataset/speaker_diarization/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 pyannote-metrics = "^3.2.1"
 s3fs = "^2023.10.0"
 pyannote-core = "^5.0.0"

--- a/examples/dataset/text_summarization/pyproject.toml
+++ b/examples/dataset/text_summarization/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-kolena = "^1.9.0"
+kolena = "^1.23.0"
 s3fs = "^2022.7.1"
 scikit-learn = "^1.1.2"
 numba = "^0.56.0"


### PR DESCRIPTION
### Linked issue(s)

#622 

### What change does this PR introduce and why?

Bumps `kolena` version in examples to `^1.23.0` - `1.9.0` is causing ugly dependency solutions in our examples resulting from #622  leading to checks failures ([example](https://app.circleci.com/pipelines/github/kolenaIO/kolena/4485/workflows/60d65e5d-df13-40b0-85cf-8c20594625bf/jobs/108987))

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
