### PR TITLE
Pin scipy to < 1.14 for python 3.9, pandera to < 0.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ pyarrow = ">=8"
 click = ">=8"
 scikit-learn = { version = ">=1.2,<2", optional = true }
 scipy = [  # transient dependency of scikit-learn, pin required to unbreak installs on specific Python versions
-    { version = ">=1,<1.11", python = ">=3.8,<3.10", optional = true },
+    { version = ">=1,<1.11", python = ">=3.8,<3.9", optional = true },
+    { version = ">=1,<1.14", python = "3.9", optional = true },
     { version = ">=1.12,<2", python = ">=3.12", optional = true }
 ]
 lzstring = "^1.0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ click = ">=8"
 scikit-learn = { version = ">=1.2,<2", optional = true }
 scipy = [  # transient dependency of scikit-learn, pin required to unbreak installs on specific Python versions
     { version = ">=1,<1.11", python = ">=3.8,<3.9", optional = true },
-    { version = ">=1,<1.14", python = "3.9", optional = true },
+    { version = ">=1,<1.14", python = ">=3.9,<3.10", optional = true },
     { version = ">=1.12,<2", python = ">=3.12", optional = true }
 ]
 lzstring = "^1.0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ pyarrow = ">=8"
 click = ">=8"
 scikit-learn = { version = ">=1.2,<2", optional = true }
 scipy = [  # transient dependency of scikit-learn, pin required to unbreak installs on specific Python versions
-    { version = ">=1,<1.11", python = ">=3.8,<3.9", optional = true },
+    { version = ">=1,<1.11", python = ">=3.8,<3.10", optional = true },
     { version = ">=1.12,<2", python = ">=3.12", optional = true }
 ]
 lzstring = "^1.0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ pandas = [
     { version = ">=1.5,<3", python = ">=3.11,<3.12" },
     { version = ">=2.1.1,<3", python = ">=3.12" },
 ]
-pandera = ">=0.9,<1"
+pandera = ">=0.9,<0.20.0"
 pydantic = ">=2,<3"
 dacite = ">=1.6,<2"
 requests = ">=2.20,<3"


### PR DESCRIPTION
### Linked issue(s)

#627 

### What change does this PR introduce and why?

**Pins `scipy<1.14` version for python `3.9`:**`scipy` dropped support for `3.9` as of `1.14.0` (see [here](https://github.com/scipy/scipy/commit/c4f735e345ff1db0b80a937b5075a669ea75673a)). This broke our support for python `3.9` (see [here](https://app.circleci.com/pipelines/github/kolenaIO/kolena/4489/workflows/aadf1ace-eba0-4592-8287-7298cc649bea?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) for examples)

**Pins `pandera<0.20.0`:** `pandera` "[deprecated](https://github.com/unionai-oss/pandera/releases/tag/v0.20.0)" (read, "dropped") `SchemaModel` as of `0.20.0`, which breaks `kolena.workflow` ([example](https://github.com/kolenaIO/kolena/blob/501f96a2e7759b56b52082a753bd4900b219f3ba/kolena/workflow/_datatypes.py#L33))

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
