### PR TITLE
Replace SchemaModel with DataFrameModel

### DIFF
--- a/kolena/_experimental/search/_internal/datatypes.py
+++ b/kolena/_experimental/search/_internal/datatypes.py
@@ -19,7 +19,7 @@ from pandera.typing import Series
 from kolena._utils.dataframes.validators import _validate_locator  # noqa: F401
 
 
-class LocatorEmbeddingsDataFrameSchema(pa.SchemaModel):
+class LocatorEmbeddingsDataFrameSchema(pa.DataFrameModel):
     key: Series[pa.typing.String] = pa.Field(coerce=True, _validate_locator=())
     """Unique key corresponding to model used for embeddings extraction. This is typically a locator."""
 
@@ -32,7 +32,7 @@ class LocatorEmbeddingsDataFrameSchema(pa.SchemaModel):
     """
 
 
-class DatasetEmbeddingsDataFrameSchema(pa.SchemaModel):
+class DatasetEmbeddingsDataFrameSchema(pa.DataFrameModel):
     key: Series[pa.typing.String] = pa.Field(coerce=True, _validate_locator=())
     """Unique key corresponding to model used for embeddings extraction. This is typically a locator."""
 

--- a/kolena/_utils/dataframes/validators.py
+++ b/kolena/_utils/dataframes/validators.py
@@ -25,7 +25,7 @@ from pandera.typing import Series
 from kolena.errors import InputValidationError
 
 
-T = TypeVar("T", bound=pa.SchemaModel)
+T = TypeVar("T", bound=pa.DataFrameModel)
 
 
 def validate_df_schema(df: pd.DataFrame, schema: Type[T], trusted: bool = False) -> pd.DataFrame:

--- a/kolena/_utils/datatypes.py
+++ b/kolena/_utils/datatypes.py
@@ -43,7 +43,7 @@ from kolena._utils.validators import ValidatorConfig
 
 
 TDataFrame = TypeVar("TDataFrame", bound="LoadableDataFrame")
-TSchema = TypeVar("TSchema", bound=pa.SchemaModel)
+TSchema = TypeVar("TSchema", bound=pa.DataFrameModel)
 
 
 class LoadableDataFrame(ABC, pa.typing.DataFrame[TSchema], Generic[TSchema]):

--- a/kolena/workflow/_datatypes.py
+++ b/kolena/workflow/_datatypes.py
@@ -30,7 +30,7 @@ _SCALAR_TYPES = [str, bool, int, float]
 JSONObject = object
 
 
-class TestSampleDataFrameSchema(pa.SchemaModel):
+class TestSampleDataFrameSchema(pa.DataFrameModel):
     """General-purpose frame used for test samples in isolation or paired with ground truths and/or inferences."""
 
     test_sample: Series[JSONObject] = pa.Field(coerce=True)
@@ -67,7 +67,7 @@ class TestSampleDataFrame(LoadableDataFrame[TestSampleDataFrameSchema]):
         return df_out
 
 
-class TestSuiteTestSamplesDataFrameSchema(pa.SchemaModel):
+class TestSuiteTestSamplesDataFrameSchema(pa.DataFrameModel):
     """Data frame used for loading test samples grouped by test case."""
 
     test_case_id: Optional[Series[pa.typing.Int64]] = pa.Field(coerce=True)
@@ -98,7 +98,7 @@ class TestSuiteTestSamplesDataFrame(LoadableDataFrame[TestSuiteTestSamplesDataFr
         return df_out
 
 
-class TestCaseEditorDataFrameSchema(pa.SchemaModel):
+class TestCaseEditorDataFrameSchema(pa.DataFrameModel):
     test_case_name: Series[pa.typing.String] = pa.Field(nullable=True)
     test_sample_type: Series[pa.typing.String] = pa.Field(coerce=True)
     test_sample: Series[JSONObject] = pa.Field(coerce=True)  # TODO: validators?
@@ -126,7 +126,7 @@ class TestCaseEditorDataFrame(LoadableDataFrame[TestCaseEditorDataFrameSchema]):
         return cast(TestCaseEditorDataFrame, df_validated)
 
 
-class MetricsDataFrameSchema(pa.SchemaModel):
+class MetricsDataFrameSchema(pa.DataFrameModel):
     test_sample: Optional[Series[JSONObject]] = pa.Field(coerce=True)
     test_case_id: Optional[Series[pa.typing.Int64]] = pa.Field(coerce=True)
     configuration_display_name: Optional[Series[pa.typing.String]] = pa.Field(coerce=True, nullable=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ pandas = [
     { version = ">=1.5,<3", python = ">=3.11,<3.12" },
     { version = ">=2.1.1,<3", python = ">=3.12" },
 ]
-pandera = ">=0.9,<0.20.0"
+pandera = ">=0.9,<1"
 pydantic = ">=2,<3"
 dacite = ">=1.6,<2"
 requests = ">=2.20,<3"


### PR DESCRIPTION
### Linked issue(s)

#628 

### What change does this PR introduce and why?

Replaces `SchemaModel` with `DataFrameModel` and relaxes the pin on `pandera` version. Better to avoid using the un-deprecated name.

`SchemaModel` was previously [aliased](https://github.com/unionai-oss/pandera/blob/d2bfed03e107358d60266108478711cdbe704e9c/pandera/api/pandas/model.py#L197) to `DataFrameModel`

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
