### PR TITLE
fix: adding space between disable and markdown syntax

### DIFF
--- a/docs/metrics/averaging-methods.md
+++ b/docs/metrics/averaging-methods.md
@@ -32,6 +32,7 @@ Let’s consider the following multiclass classification metrics, computed acros
 **unweighted** mean of all the per-class scores:
 
 <!-- markdownlint-disable MD013 -->
+
 $$
 \begin{align}
 \text{F}_{1 \, \text{macro}} &= \frac{\text{F}_{1 \, \texttt{Airplane}} + \text{F}_{1 \, \texttt{Boat}} + \text{F}_{1 \, \texttt{Car}}}{3} \\[1em]
@@ -39,6 +40,7 @@ $$
 &= 0.58
 \end{align}
 $$
+
 <!-- markdownlint-enable MD013 -->
 
 ### Micro Average
@@ -71,6 +73,7 @@ What about **micro F<sub>1</sub>**?
 Plug the micro-averaged values for precision and recall into the standard formula for F<sub>1</sub>-score:
 
 <!-- markdownlint-disable MD013 -->
+
 $$
 \begin{align}
 \text{F}_{1 \, \text{micro}} &= 2 \times \frac{\text{Precision}_\text{micro} \times \text{Recall}_\text{micro}}{\text{Precision}_\text{micro} + \text{Recall}_\text{micro}} \\[1em]
@@ -78,6 +81,7 @@ $$
 &= 0.6
 \end{align}
 $$
+
 <!-- markdownlint-enable MD013 -->
 
 Note that precision, recall, and F<sub>1</sub>-score all have the same value: $0.6$. This is because micro-averaging essentially
@@ -100,6 +104,7 @@ words, support is the sum of true positive (TP) and false negative (FN) counts. 
 class’s support relative to the sum of all support values:
 
 <!-- markdownlint-disable MD013 -->
+
 $$
 \begin{align}
 \text{F}_{1 \, \text{weighted}} &= \left( \text{F}_{1 \, \texttt{Airplane}} \times \tfrac{\text{#}\ \texttt{Airplane}}{\text{# Total}} \right)
@@ -109,6 +114,7 @@ $$
 &= 0.64
 \end{align}
 $$
+
 <!-- markdownlint-enable MD013 -->
 
 ## Which Method Should I Use?

--- a/docs/metrics/bertscore.md
+++ b/docs/metrics/bertscore.md
@@ -34,12 +34,14 @@ $\hat{x} = \langle\hat{x}_1, \hat{x}_2, ..., \hat{x}_m\rangle$, we first use BER
 embeddings for both reference and candidate sentences.
 
 <!-- markdownlint-disable MD013 -->
+
 $$
 \begin{align}
     & BERT(\langle x_1, x_2, ..., x_n \rangle) = \langle \mathbf{x_1}, \mathbf{x_2}, ..., \mathbf{x_n} \rangle \\
     & BERT(\langle \hat{x}_1, \hat{x}_2, ..., \hat{x}_m \rangle) = \langle \mathbf{\hat{x}_1}, \mathbf{\hat{x}_2}, ..., \mathbf{\hat{x}_m} \rangle
 \end{align}
 $$
+
 <!-- markdownlint-enable MD013 -->
 
 <center><p style="font-size:small;">Note that we will use <b>bold</b> text to indicate vectors, like a word embedding</p></center>
@@ -56,9 +58,11 @@ pre-normalized. With these definitions, we can now calculate the BERT-precision,
 #### BERT-Precision
 
 <!-- markdownlint-disable MD013 -->
+
 $$
 P_\text{BERT} = \frac{1}{|\hat{x}|} \sum_{\mathbf{\hat{x}_j} \in \hat{x}} \underbrace{\max_{\mathbf{x_i} \in x}\overbrace{\mathbf{x_i}^\top \mathbf{\hat{x}_j}}^\text{cosine similarity}}_\text{greedy matching}
 $$
+
 <!-- markdownlint-enable MD013 -->
 
 Though the formula may seem intimidating, BERT-precision is conceptually similar to the
@@ -70,9 +74,11 @@ thus, why we use greedy matching.
 #### BERT-Recall
 
 <!-- markdownlint-disable MD013 -->
+
 $$
 R_\text{BERT} = \frac{1}{|x|} \sum_{\mathbf{x_i} \in x} \underbrace{\max_{\mathbf{\hat{x}_j} \in \hat{x}}\overbrace{\mathbf{x_i}^\top \mathbf{\hat{x}_j}}^\text{cosine similarity}}_\text{greedy matching}
 $$
+
 <!-- markdownlint-enable MD013 -->
 
 Once again, the BERT-recall is conceptually similar to the [recall formula](recall.md). Note that we flip $\hat{x}$ with
@@ -126,6 +132,7 @@ To showcase the value of BERTScore, let's consider the following candidate and r
 ??? example "Semantically Similar Texts"
 
     <!-- markdownlint-disable MD013 -->
+
     | Candidate Text | Reference Text |
     | --- | --- |
     | The sun set behind the mountains, casting a warm, orange glow across the horizon. | As the mountains obscured the sun, a warm, orange glow painted the horizon. |
@@ -133,6 +140,7 @@ To showcase the value of BERTScore, let's consider the following candidate and r
     | The adventurous explorer trekked through the dense jungle, searching for hidden treasures. | In search of hidden treasures, the intrepid explorer ventured through the dense jungle. |
     | Laughter echoed through the park as children played on the swings and slides. | Children's laughter filled the park as they enjoyed the swings and slides. |
     | The old bookstore was filled with the scent of well-worn pages, a haven for book lovers. | A haven for book lovers, the old bookstore exuded the fragrance of well-read pages. |
+
     <!-- markdownlint-enable MD013 -->
 
     Using the following code and the [`bert-score`](https://pypi.org/project/bert-score/) package:

--- a/docs/metrics/bleu.md
+++ b/docs/metrics/bleu.md
@@ -39,17 +39,21 @@ to candidate texts that are very short in length, but mostly contain n-grams in 
 The BLEU score is mathematically defined as:
 
 <!-- markdownlint-disable MD013 -->
+
 $$\begin{align*} \text{BLEU} &= \text{Brevity Penalty} \times \text{n-gram Overlap} \\
 &= \min\left(1, \, \exp\left(1 - \frac{\text{reference length}}{\text{output length}}\right)\right) \times \prod_{i=1}^{4}\text{i-gram Precision}^{\frac{1}{4}}
 \end{align*}$$
+
 <!-- markdownlint-enable MD013 -->
 
 where the i-gram precision is calculated as:
 
 <!-- markdownlint-disable MD013 -->
+
 $$
 p_i = \frac{\text{Clipped} \text{ count of matching i-grams in candidate text}^1}{\text{Total number of i-grams in candidate text}}
 $$
+
 <!-- markdownlint-enable MD013 -->
 
 <div class="footnote-content">
@@ -94,32 +98,38 @@ understanding. While a high BLEU score is promising, it doesn't guarantee flawle
     **Generated Sentence**:
 
     <!-- markdownlint-disable MD013 -->
+
     | n | n-grams |
     | ---   | ---                        |
     | 1 | [`Fall`, `leaves`, `rustled`, `softly`, `beneath`, `our`, `weary`, `feet`]|
     | 2 | [`Fall leaves`, `leaves rustled`, `rustled softly`, `softly beneath`, `beneath our`, `our weary`, `weary feet`]|
     | 3 | [`Fall leaves rustled`, `leaves rustled softly`, `rustled softly beneath`, `softly beneath our`, `beneath our weary`, `our weary feet`] |
     | 4 | [`Fall leaves rustled softly`, `leaves rustled softly beneath`, `rustled softly beneath our`, `softly beneath our weary`, `beneath our weary feet`]  |
+
     <!-- markdownlint-enable MD013 -->
 
     **Reference Sentence**:
 
     <!-- markdownlint-disable MD013 -->
+
     | n | n-grams |
     | --- | --- |
     | 1 | [`Crisp`, `autumn`, `leaves`, `rustled`, `softly`, `beneath`, `our`, `weary`, `feet`]|
     | 2 | [`Crisp autumn`, `autumn leaves`, `leaves rustled`, `rustled softly`, `softly beneath`, `beneath our`, `our weary`, `weary feet`]|
     | 3 | [`Crisp autumn leaves`, `autumn leaves rustled`, `leaves rustled softly`, `rustled softly beneath`, `softly beneath our`, `beneath our weary`, `our weary feet`]|
     | 4 | [`Crisp autumn leaves rustled`, `autumn leaves rustled softly`, `leaves rustled softly beneath`, `rustled softly beneath our`, `softly beneath our weary`, `beneath our weary feet`]|
+
     <!-- markdownlint-enable MD013 -->
 
 ??? example "Step 2: Calculate n-gram Overlap"
     Next, let's calculate the clipped precision scores for each of the n-grams. Recall that the precision formula is:
 
     <!-- markdownlint-disable MD013 -->
+
     $$
     p_i = \frac{\text{Clipped} \text{ count of matching i-grams in machine-generated text}^1}{\text{Total number of i-grams in machine-generated text}}
     $$
+
     <!-- markdownlint-enable MD013 -->
 
     <center>

--- a/docs/metrics/diarization-error-rate.md
+++ b/docs/metrics/diarization-error-rate.md
@@ -110,6 +110,7 @@ inference[Segment(23, 25)] = 'B'
     Using the formula, we get:
 
     <!-- markdownlint-disable MD013 -->
+
     $$
     \begin{align*}
     \text{DER} &= \frac{\text{false alarm} + \text{missed detection} + \text{speaker confusion}}{\text{ground truth duration}} \\
@@ -117,6 +118,7 @@ inference[Segment(23, 25)] = 'B'
                &= 0.4
     \end{align*}
     $$
+
     <!-- markdownlint-enable MD013 -->
 
     Our diarization error rate is 0.4.

--- a/docs/metrics/f1-score.md
+++ b/docs/metrics/f1-score.md
@@ -165,9 +165,11 @@ The **F$_\beta$-score** is a generic form of the F<sub>1</sub>-score with a weig
 recall is considered $\beta$ times more important than precision:
 
 <!-- markdownlint-disable MD013 -->
+
 $$
 \text{F}_{\beta} = \frac {(1 + \beta^2) \times \text{precision} \times \text{recall}} {(\beta^2 \times \text{precision}) + \text{recall}}
 $$
+
 <!-- markdownlint-enable MD013 -->
 
 The three most common values for the beta parameter are as follows:

--- a/docs/metrics/meteor.md
+++ b/docs/metrics/meteor.md
@@ -17,9 +17,11 @@ We define METEOR as the product of two components - the Unigram Precision / Reca
 Penalty. That is,
 
 <!-- markdownlint-disable MD013 -->
+
 $$
 \text{METEOR} = \underbrace{\text{FMean}}_{\text{Harmonic Mean of Unigram Precision/Recall}} * \underbrace{(1 - \text{Penalty})}_{\text{Word Order Penalty}}
 $$
+
 <!-- markdownlint-enable MD013 -->
 
 To understand the formula, let's break down each component into their respective parts.
@@ -71,8 +73,10 @@ To understand the formula, let's break down each component into their respective
     We can break up our candidate sentence into two chunks to map it to our reference sentence.
 
     <!-- markdownlint-disable MD013 -->
+
     Candidate: $\underbrace{\text{Under the starry night}}_{\text{Chunk 2}} \space \underbrace{\text{we danced with}}_{\text{Chunk 1}} \space\text{glee}$ <br>
     Reference: $\underbrace{\text{We danced with}}_{\text{Chunk 1}} \space\text{joy}\space \underbrace{\text{under the starry night}}_{\text{Chunk 2}}$
+
     <!-- markdownlint-enable MD013 -->
 
     Between the two chunks, we have matched 7 unigrams. This gives us a penalty score of $0.5 \times \frac{2}{7} = 0.143$.
@@ -102,9 +106,11 @@ Lets try the same reference example with a slightly different candidate.
     8 chunks, since no adjacent words can be mapped to the reference sentence.
 
     <!-- markdownlint-disable MD013 -->
+
     Candidate: $\underbrace{\text{Danced}}_\text{Chunk 2}\space\underbrace{\text{we}}_\text{Chunk 1}\space\underbrace{\text{with}}_\text{Chunk 3}\space\underbrace{\text{under}}_\text{Chunk 5}\space\underbrace{\text{joy}}_\text{Chunk 4}\space\underbrace{\text{the}}_\text{Chunk 6}\space\underbrace{\text{night}}_\text{Chunk 8}\space\underbrace{\text{starry}}_\text{Chunk 7}\space$
 
     Reference: $\underbrace{\text{We}}_\text{Chunk 1}\space\underbrace{\text{danced}}_\text{Chunk 2}\space\underbrace{\text{with}}_\text{Chunk 3}\space\underbrace{\text{joy}}_\text{Chunk 4}\space\underbrace{\text{under}}_\text{Chunk 5}\space\underbrace{\text{the}}_\text{Chunk 6}\space\underbrace{\text{starry}}_\text{Chunk 7}\space\underbrace{\text{night}}_\text{Chunk 8}\space$
+
     <!-- markdownlint-enable MD013 -->
 
     Between the eight chunks, we have matched 8 unigrams. This gives us a penalty score of $0.5 \times \frac{8}{8} = 0.5$.

--- a/docs/metrics/rouge-n.md
+++ b/docs/metrics/rouge-n.md
@@ -26,9 +26,11 @@ reference texts.
 Mathematically, we define ROUGE-N as follows:
 
 <!-- markdownlint-disable MD013 -->
+
 $$
 \text{ROUGE-N} = \frac{\sum_{S \in \text{Reference Texts}} \sum_{\text{n-gram} \in S} \text{Match}(\text{n-gram})}{\sum_{S \in \text{Reference Texts}} \sum_{\text{n-gram} \in S} \text{Count}(\text{n-gram})}
 $$
+
 <!-- markdownlint-enable MD013 -->
 
 where $\text{Match(n-gram)}$ is the maximum number of n-grams co-occuring in a candidate text and set of reference
@@ -108,11 +110,13 @@ Assume we have the same following candidate and reference texts:
     Splitting our candidate and reference texts into bigrams, we get the following:
 
     <!-- markdownlint-disable MD013 -->
+
     | | |
     | --- | --- |
     | <nobr>**Reference #1**</nobr> | [`A fast`, `fast brown`, `brown dog`, `dog jumps`, `jumps over`, `over a`, `a sleeping`, `sleeping fox`] |
     | <nobr>**Reference #2**</nobr> | [`A quick`, `quick brown`, `brown dog`, `dog jumps`, `jumps over`, `over the`, `the fox`] |
     | **Candidate** | [`The quick`, `quick brown`, `brown fox`, `fox jumps`, `jumps over`, `over the`, `the lazy`, `lazy dog`] |
+
     <!-- markdownlint-enable MD013 -->
 
 ??? example "Step 2: Calculate ROUGE"

--- a/docs/metrics/wer-cer-mer.md
+++ b/docs/metrics/wer-cer-mer.md
@@ -112,6 +112,7 @@ Let's calculate the word error rate between the following reference and candidat
     With each errors counted, we can calculate our WER. Using the formula,
 
     <!-- markdownlint-disable MD013 -->
+
     $$
     \begin{align*}
     \text{WER} &= \frac{\text{Substitutions} + \text{Deletions} + \text{Insertions}}{\text{# of Words in Reference}} \\
@@ -120,6 +121,7 @@ Let's calculate the word error rate between the following reference and candidat
                &= 0.375
     \end{align*}
     $$
+
     <!-- markdownlint-enable MD013 -->
 
 
@@ -171,6 +173,7 @@ Let's calculate the character error rate using the same reference and candidate 
     With each errors counted, we can calculate our CER. Using the formula,
 
     <!-- markdownlint-disable MD013 -->
+
     $$
     \begin{align*}
     \text{CER} &= \frac{\text{Substitutions} + \text{Deletions} + \text{Insertions}}{\text{# of Characters in Reference}} \\
@@ -179,6 +182,7 @@ Let's calculate the character error rate using the same reference and candidate 
                &= 0.318
     \end{align*}
     $$
+
     <!-- markdownlint-enable MD013 -->
 
 
@@ -199,9 +203,11 @@ While WER and CER focus on errors, Match Error Rate takes a slightly different a
 on correct matches. Similar to WER, it is calculated using word-level [substitutions, deletions, and insertions](#substitutions-deletions-and-insertions).
 
 <!-- markdownlint-disable MD013 -->
+
 $$
 \text{MER} = \frac{\text{Substitutions} + \text{Deletions} + \text{Insertions}}{\text{Substitutions} + \text{Deletions} + \text{Insertions} + \text{# of Correct Matches}}
 $$
+
 <!-- markdownlint-enable MD013 -->
 
 ### Example
@@ -233,6 +239,7 @@ Let's calculate the match error rate using the same reference and candidate text
     With each errors counted, we can calculate our MER. Using the formula,
 
     <!-- markdownlint-disable MD013 -->
+
     $$
     \begin{align*}
     \text{MER} &= \frac{\text{Substitutions} + \text{Deletions} + \text{Insertions}}{\text{Substitutions} + \text{Deletions} + \text{Insertions} + \text{# of Correct Matches}} \\
@@ -241,6 +248,7 @@ Let's calculate the match error rate using the same reference and candidate text
                &= 0.353
     \end{align*}
     $$
+
     <!-- markdownlint-enable MD013 -->
 
 

--- a/docs/workflow/advanced-usage/nesting-test-case-metrics.md
+++ b/docs/workflow/advanced-usage/nesting-test-case-metrics.md
@@ -10,11 +10,13 @@ When computing [test case metrics][kolena.workflow.MetricsTestCase] in an
 metrics within a given test case.
 
 <!-- markdownlint-disable MD013 -->
+
 <figure markdown>
   ![Class-level metrics](../../assets/images/nesting-test-case-metrics-light.jpg#only-light)
   ![Class-level metrics](../../assets/images/nesting-test-case-metrics-dark.jpg#only-dark)
   <figcaption markdown>Class-level metrics for the `airplane`, `bear`, `bench`, etc. classes reported for the test case `complete :: coco-2014-val [Object Detection]`</figcaption>
 </figure>
+
 <!-- markdownlint-enable MD013 -->
 
 Here are a few examples of scenarios where this pattern might be warranted:


### PR DESCRIPTION
### Linked issue(s)

- to render the table and latex in the nested `???` blocks properly.
- adding it everywhere for consistency.

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
