### PR TITLE
Extend OD matching functions to accept an optional required_match_fields parameter

### DIFF
--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -226,6 +226,7 @@ def _compute_metrics(
     threshold_strategy: Union[Literal["F1-Optimal"], float, Dict[str, float]] = 0.5,
     min_confidence_score: float = 0.5,
     batch_size: int = 10_000,
+    required_match_fields: Optional[List[str]] = None,
 ) -> Iterator[pd.DataFrame]:
     """
     Compute metrics for object detection.
@@ -241,6 +242,8 @@ def _compute_metrics(
     :param min_confidence_score: The minimum confidence score to consider for the evaluation. This is usually set to
         reduce noise by excluding inferences with low confidence score.
     :param batch_size: number of results to process per iteration.
+    :param Optional[List[str]] required_match_fields: Optionally specify a list of fields that must match between
+        the inference and ground truth for them to be considered a match.
     """
     is_multiclass = _check_multiclass(pred_df[ground_truth], pred_df[inference])
     match_fn = match_inferences_multiclass if is_multiclass else match_inferences
@@ -268,6 +271,7 @@ def _compute_metrics(
                 ignored_ground_truths=ignored_ground_truths,
                 mode="pascal",
                 iou_threshold=iou_threshold,
+                required_match_fields=required_match_fields,
             ),
         )
         all_thresholds.extend(inf.score for inf in inferences)
@@ -356,6 +360,7 @@ def _iter_object_detection_results(
     threshold_strategy: Union[Literal["F1-Optimal"], float, Dict[str, float]] = "F1-Optimal",
     min_confidence_score: float = 0.01,
     batch_size: int = 10_000,
+    required_match_fields: Optional[List[str]] = None,
 ) -> Iterator[pd.DataFrame]:
     _validate_column_present(df, raw_inferences_field)
 
@@ -373,6 +378,7 @@ def _iter_object_detection_results(
         threshold_strategy=threshold_strategy,
         min_confidence_score=min_confidence_score,
         batch_size=batch_size,
+        required_match_fields=required_match_fields,
     )
 
 
@@ -436,6 +442,7 @@ def upload_object_detection_results(
     threshold_strategy: Union[Literal["F1-Optimal"], float, Dict[str, float]] = "F1-Optimal",
     min_confidence_score: float = 0.01,
     batch_size: int = 10_000,
+    required_match_fields: Optional[List[str]] = None,
 ) -> None:
     """
     Compute metrics and upload results of the model computed by
@@ -460,6 +467,8 @@ def upload_object_detection_results(
     :param min_confidence_score: The minimum confidence score to consider for the evaluation. This is usually set to
         reduce noise by excluding inferences with low confidence score.
     :param batch_size: number of results to process per iteration.
+    :param Optional[List[str]] required_match_fields: Optionally specify a list of fields that must match between
+        the inference and ground truth for them to be considered a match.
     :return:
     """
     eval_config = dict(
@@ -477,6 +486,7 @@ def upload_object_detection_results(
         threshold_strategy=threshold_strategy,
         min_confidence_score=min_confidence_score,
         batch_size=batch_size,
+        required_match_fields=required_match_fields,
     )
     dataset.upload_results(
         dataset_name,

--- a/tests/unit/_experimental/object_detection/test_dataset.py
+++ b/tests/unit/_experimental/object_detection/test_dataset.py
@@ -240,6 +240,7 @@ def test__upload_object_detection_results_configurations(mocked_upload_results: 
                 iou_threshold=0.152,
                 threshold_strategy="F1-Optimal",
                 min_confidence_score=0.222,
+                required_match_fields=["frame_id"],
             )
 
     patched_metrics.assert_called_once()
@@ -252,4 +253,5 @@ def test__upload_object_detection_results_configurations(mocked_upload_results: 
         iou_threshold=0.152,
         threshold_strategy="F1-Optimal",
         min_confidence_score=0.222,
+        required_match_fields=["frame_id"],
     )


### PR DESCRIPTION
### Linked issue(s)
Fixes: KOL-6947

### What change does this PR introduce and why?
Extend OD matching functions to accept an optional required_match_fields parameter

This allows for restricting matches to situations when the ground truth and inference agree on a field.
One example use case for this is with video data, where the ground truth and inference should agree
on a `frame_id` for them to be considered a proper match.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
