### PR TITLE
chore: remove build without 'insider'

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -105,9 +105,6 @@ jobs:
       - run:
           name: Checkout LFS blobs
           command: git lfs pull
-      - run:
-          name: Build documentation without 'insiders' packages
-          command: poetry run mkdocs build
       - add_ssh_keys: # add github.com SSH key fingerprint to access private repo forks
           fingerprints: [ "15:8b:d4:ac:1f:cd:2f:d3:92:a7:4c:aa:46:81:0b:7d" ]
       - run:


### PR DESCRIPTION
### Linked issue(s)

### What change does this PR introduce and why?

- to unblock the ci issue like [here](https://app.circleci.com/pipelines/github/kolenaIO/kolena/4567/workflows/367a86e1-a9e9-4f68-a363-54637469387b/jobs/111500)
- i can reproduce the issue with a fresh installed kolena env without insider packages
  - `microsoftazure.svg` is only available at [here](https://github.com/kolenaIO/mkdocs-material-insiders/blob/fa7ed01691e0ca1c24791a3944361b6c59543360/material/templates/.icons/simple/microsoftazure.svg?plain=1) in the [mkdocs-material-insiders](https://github.com/kolenaIO/mkdocs-material-insiders) rather than https://github.com/squidfunk/mkdocs-material/tree/master/material/templates/.icons/simple

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
