### PR TITLE
chore: replace removed ms simple icons

### DIFF
--- a/docs/connecting-cloud-storage/azure-blob-storage.md
+++ b/docs/connecting-cloud-storage/azure-blob-storage.md
@@ -2,7 +2,7 @@
 icon: simple/microsoftazure
 ---
 
-# Connecting Cloud Storage: <nobr>:simple-microsoftazure: Azure Blob Storage</nobr>
+# Connecting Cloud Storage: <nobr>:material-microsoft-azure: Azure Blob Storage</nobr>
 
 Kolena connects with [Azure Blob Storage](https://azure.microsoft.com/en-ca/products/storage/blobs)
 to load files (e.g. images, videos, documents) directly into your browser for visualization.

--- a/docs/connecting-cloud-storage/azure-blob-storage.md
+++ b/docs/connecting-cloud-storage/azure-blob-storage.md
@@ -1,5 +1,5 @@
 ---
-icon: simple/microsoftazure
+icon: material/microsoft-azure
 ---
 
 # Connecting Cloud Storage: <nobr>:material-microsoft-azure: Azure Blob Storage</nobr>

--- a/docs/connecting-cloud-storage/index.md
+++ b/docs/connecting-cloud-storage/index.md
@@ -31,7 +31,7 @@ Integrations can be managed by organization administrators by navigating to the 
 
     Integrate with Google Cloud Storage.
 
-- [:simple-microsoftazure: Azure Blob Storage](./azure-blob-storage.md)
+- [:material-microsoft-azure: Azure Blob Storage](./azure-blob-storage.md)
 
     ---
 


### PR DESCRIPTION
### Linked issue(s)

### What change does this PR introduce and why?

- icons are removed upstream: https://github.com/simple-icons/simple-icons/pull/10019
- the building failure due to removed icons blocks the docs unit tests: https://github.com/kolenaIO/kolena/pull/645

updated icons
<img width="1222" alt="Screen Shot 2024-07-16 at 5 52 57 PM" src="https://github.com/user-attachments/assets/04d4d964-32cd-4706-8917-d82afa7b0ebf">

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
