### PR TITLE
chore: kolena client support for pydantic v1

### DIFF
--- a/examples/workflow/classification/classification/workflow.py
+++ b/examples/workflow/classification/classification/workflow.py
@@ -128,7 +128,7 @@ class TestSampleMetricsSingleClass(MetricsTestSample):
 
     missing_inference: bool = False
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         object.__setattr__(self, "missing_inference", self.classification is None)
 
 
@@ -160,7 +160,7 @@ class TestSampleMetrics(MetricsTestSample):
 
     missing_inference: bool = False
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         object.__setattr__(self, "missing_inference", self.classification is None)
 
 

--- a/examples/workflow/classification/classification/workflow.py
+++ b/examples/workflow/classification/classification/workflow.py
@@ -128,7 +128,7 @@ class TestSampleMetricsSingleClass(MetricsTestSample):
 
     missing_inference: bool = False
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         object.__setattr__(self, "missing_inference", self.classification is None)
 
 
@@ -160,7 +160,7 @@ class TestSampleMetrics(MetricsTestSample):
 
     missing_inference: bool = False
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         object.__setattr__(self, "missing_inference", self.classification is None)
 
 

--- a/examples/workflow/object_detection_3d/object_detection_3d/workflow.py
+++ b/examples/workflow/object_detection_3d/object_detection_3d/workflow.py
@@ -36,7 +36,7 @@ class TestSample(Image):
     image_projection: List[float]  # row-major (4x4)
     right: Optional[ImageAsset] = None
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         if len(self.velodyne_to_camera_transformation) != 16:
             raise ValueError(
                 f"{type(self).__name__} must have valid 16 floats \

--- a/examples/workflow/object_detection_3d/object_detection_3d/workflow.py
+++ b/examples/workflow/object_detection_3d/object_detection_3d/workflow.py
@@ -36,7 +36,7 @@ class TestSample(Image):
     image_projection: List[float]  # row-major (4x4)
     right: Optional[ImageAsset] = None
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         if len(self.velodyne_to_camera_transformation) != 16:
             raise ValueError(
                 f"{type(self).__name__} must have valid 16 floats \

--- a/kolena/_api/v1/batched_load.py
+++ b/kolena/_api/v1/batched_load.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from enum import Enum
 
-from pydantic.dataclasses import dataclass
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 class BatchedLoad:

--- a/kolena/_api/v1/client_log.py
+++ b/kolena/_api/v1/client_log.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from enum import Enum
 
-from pydantic.dataclasses import dataclass
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 class ClientLog:

--- a/kolena/_api/v1/core.py
+++ b/kolena/_api/v1/core.py
@@ -18,9 +18,8 @@ from typing import List
 from typing import Optional
 from typing import Set
 
-from pydantic.dataclasses import dataclass
-
 from kolena._api.v1.batched_load import BatchedLoad
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 class Model:
@@ -196,3 +195,10 @@ class TestRun:
     @dataclass(frozen=True)
     class MarkCrashedRequest:
         test_run_id: int
+
+
+Model.LoadAllResponse.__pydantic_model__.update_forward_refs()  # type: ignore
+TestCase.SingleProcessResponse.__pydantic_model__.update_forward_refs()  # type: ignore[attr-defined]
+TestCase.BulkProcessRequest.__pydantic_model__.update_forward_refs()  # type: ignore[attr-defined]
+TestCase.BulkProcessResponse.__pydantic_model__.update_forward_refs()  # type: ignore[attr-defined]
+TestSuite.LoadAllResponse.__pydantic_model__.update_forward_refs()  # type: ignore

--- a/kolena/_api/v1/event.py
+++ b/kolena/_api/v1/event.py
@@ -16,11 +16,12 @@ from typing import Dict
 from typing import Optional
 from typing import Union
 
-from pydantic.dataclasses import dataclass
 from pydantic.types import StrictBool
 from pydantic.types import StrictFloat
 from pydantic.types import StrictInt
 from pydantic.types import StrictStr
+
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 class EventAPI:

--- a/kolena/_api/v1/event.py
+++ b/kolena/_api/v1/event.py
@@ -16,11 +16,10 @@ from typing import Dict
 from typing import Optional
 from typing import Union
 
-from pydantic.types import StrictBool
-from pydantic.types import StrictFloat
-from pydantic.types import StrictInt
-from pydantic.types import StrictStr
-
+from kolena._utils.pydantic_v1 import StrictBool
+from kolena._utils.pydantic_v1 import StrictFloat
+from kolena._utils.pydantic_v1 import StrictInt
+from kolena._utils.pydantic_v1 import StrictStr
 from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 

--- a/kolena/_api/v1/generic.py
+++ b/kolena/_api/v1/generic.py
@@ -181,3 +181,10 @@ class Search:
     @dataclass(frozen=True)
     class UploadEmbeddingsResponse:
         n_samples: int
+
+
+TestRun.CreateOrRetrieveRequest.__pydantic_model__.update_forward_refs()  # type: ignore
+TestRun.UploadTestSampleMetricsRequest.__pydantic_model__.update_forward_refs()  # type: ignore
+TestRun.UploadTestSampleThresholdedMetricsRequest.__pydantic_model__.update_forward_refs()  # type: ignore
+Workflow.EvaluatorResponse.__pydantic_model__.update_forward_refs()  # type: ignore
+Workflow.ListEvaluatorsResponse.__pydantic_model__.update_forward_refs()  # type: ignore

--- a/kolena/_api/v1/generic.py
+++ b/kolena/_api/v1/generic.py
@@ -17,9 +17,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from pydantic.dataclasses import dataclass
-
 from kolena._api.v1.batched_load import BatchedLoad
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 class Model:

--- a/kolena/_api/v1/repository.py
+++ b/kolena/_api/v1/repository.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from enum import Enum
 
-from pydantic.dataclasses import dataclass
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 @dataclass(frozen=True)

--- a/kolena/_api/v2/dataset.py
+++ b/kolena/_api/v2/dataset.py
@@ -17,9 +17,9 @@ from typing import List
 from typing import Optional
 
 from pydantic import conint
-from pydantic.dataclasses import dataclass
 
 from kolena._api.v1.batched_load import BatchedLoad
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 class Path(str, Enum):

--- a/kolena/_api/v2/dataset.py
+++ b/kolena/_api/v2/dataset.py
@@ -16,9 +16,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from pydantic import conint
-
 from kolena._api.v1.batched_load import BatchedLoad
+from kolena._utils.pydantic_v1 import conint
 from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 

--- a/kolena/_api/v2/model.py
+++ b/kolena/_api/v2/model.py
@@ -17,9 +17,8 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from pydantic.dataclasses import dataclass
-
 from kolena._api.v1.batched_load import BatchedLoad
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 class Path(str, Enum):

--- a/kolena/_api/v2/search.py
+++ b/kolena/_api/v2/search.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 from enum import Enum
 
-from pydantic.dataclasses import dataclass
-
 from kolena._api.v1.batched_load import BatchedLoad
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 class Path(str, Enum):

--- a/kolena/_experimental/instance_segmentation/workflow.py
+++ b/kolena/_experimental/instance_segmentation/workflow.py
@@ -15,10 +15,9 @@ import dataclasses
 from typing import List
 from typing import Union
 
-from pydantic.dataclasses import dataclass
-
 from kolena._experimental.object_detection.workflow import TestSample as BaseTestSample
 from kolena._experimental.object_detection.workflow import ThresholdConfiguration
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena.workflow import define_workflow
 from kolena.workflow import GroundTruth as BaseGroundTruth
 from kolena.workflow import Inference as BaseInference

--- a/kolena/_experimental/instance_segmentation/workflow.py
+++ b/kolena/_experimental/instance_segmentation/workflow.py
@@ -48,7 +48,7 @@ class GroundTruth(BaseGroundTruth):
 
     n_polygons: int = dataclasses.field(default_factory=lambda: 0)
 
-    def __post_init__(self):
+    def __post_init_post_parse__(self):
         object.__setattr__(self, "n_polygons", len(self.polygons))
 
 

--- a/kolena/_experimental/instance_segmentation/workflow.py
+++ b/kolena/_experimental/instance_segmentation/workflow.py
@@ -48,7 +48,7 @@ class GroundTruth(BaseGroundTruth):
 
     n_polygons: int = dataclasses.field(default_factory=lambda: 0)
 
-    def __post_init_post_parse__(self):
+    def __post_init__(self):
         object.__setattr__(self, "n_polygons", len(self.polygons))
 
 

--- a/kolena/_experimental/object_detection/workflow.py
+++ b/kolena/_experimental/object_detection/workflow.py
@@ -17,8 +17,7 @@ from typing import Literal
 from typing import Optional
 from typing import Union
 
-from pydantic.dataclasses import dataclass
-
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena.workflow import define_workflow
 from kolena.workflow import EvaluatorConfiguration
 from kolena.workflow import GroundTruth as BaseGroundTruth

--- a/kolena/_experimental/object_detection/workflow.py
+++ b/kolena/_experimental/object_detection/workflow.py
@@ -61,7 +61,7 @@ class GroundTruth(BaseGroundTruth):
 
     n_bboxes: int = dataclasses.field(default_factory=lambda: 0)
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         object.__setattr__(self, "n_bboxes", len(self.bboxes))
 
 

--- a/kolena/_experimental/object_detection/workflow.py
+++ b/kolena/_experimental/object_detection/workflow.py
@@ -61,7 +61,7 @@ class GroundTruth(BaseGroundTruth):
 
     n_bboxes: int = dataclasses.field(default_factory=lambda: 0)
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         object.__setattr__(self, "n_bboxes", len(self.bboxes))
 
 

--- a/kolena/_experimental/workflow/thresholded.py
+++ b/kolena/_experimental/workflow/thresholded.py
@@ -101,7 +101,7 @@ class ThresholdedMetrics(TypedDataObject[_MetricsType], metaclass=PreventThresho
         """
         return _MetricsType.THRESHOLDED
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         for field in fields(self):
             field_value = getattr(self, field.name)
             if isinstance(field_value, dict):

--- a/kolena/_experimental/workflow/thresholded.py
+++ b/kolena/_experimental/workflow/thresholded.py
@@ -101,7 +101,7 @@ class ThresholdedMetrics(TypedDataObject[_MetricsType], metaclass=PreventThresho
         """
         return _MetricsType.THRESHOLDED
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         for field in fields(self):
             field_value = getattr(self, field.name)
             if isinstance(field_value, dict):

--- a/kolena/_utils/datatypes.py
+++ b/kolena/_utils/datatypes.py
@@ -34,11 +34,11 @@ from typing import Union
 import numpy as np
 import pandas as pd
 import pandera as pa
-from pydantic.dataclasses import dataclass
-from pydantic.dataclasses import is_pydantic_dataclass
 
 from kolena._utils import log
 from kolena._utils.dataframes.validators import validate_df_schema
+from kolena._utils.pydantic_v1 import Extra
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.validators import ValidatorConfig
 
 
@@ -72,8 +72,7 @@ def _double_under(input: str) -> bool:
 def _allow_extra(cls: Type[T]) -> bool:
     # `pydantic.dataclasses.is_built_in_dataclass` would have false-positive when a stdlib-dataclass decorated
     # class extends a pydantic dataclass
-    pydantic_config: dict = getattr(cls, "__pydantic_config__", {})
-    return is_pydantic_dataclass(cls) and pydantic_config.get("extra", "ignore") == "allow"
+    return "__pydantic_model__" in vars(cls) and cls.__pydantic_model__.Config.extra == Extra.allow  # type: ignore
 
 
 # used to track data_type string -> TypedDataObject

--- a/kolena/_utils/geometry.py
+++ b/kolena/_utils/geometry.py
@@ -14,10 +14,10 @@
 from typing import List
 from typing import Tuple
 
-from pydantic import validate_call
 from shapely.geometry import Polygon
 from shapely.validation import make_valid
 
+from kolena._utils.pydantic_v1 import validate_arguments
 from kolena._utils.validators import ValidatorConfig
 
 
@@ -25,7 +25,7 @@ def make_valid_polygon(points: List[Tuple[float, float]]) -> None:
     return make_valid(Polygon(points))
 
 
-@validate_call(config=ValidatorConfig)
+@validate_arguments(config=ValidatorConfig)
 def validate_polygon(points: List[Tuple[float, float]]) -> None:
     try:
         make_valid_polygon(points)

--- a/kolena/_utils/inference_validators.py
+++ b/kolena/_utils/inference_validators.py
@@ -11,18 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pydantic import validate_call
-
+from kolena._utils.pydantic_v1 import validate_arguments
 from kolena._utils.validators import ValidatorConfig
 
 
-@validate_call(config=ValidatorConfig)
+@validate_arguments(config=ValidatorConfig)
 def validate_label(label: str) -> None:
     if label.strip() == "":
         raise ValueError("label must contain non-whitespace characters", label)
 
 
-@validate_call(config=ValidatorConfig)
+@validate_arguments(config=ValidatorConfig)
 def validate_confidence(confidence: float) -> None:
     if not (0 <= confidence <= 1):
         raise ValueError("confidence must be between 0 and 1 (inclusive)", confidence)

--- a/kolena/_utils/pydantic_v1/__init__.py
+++ b/kolena/_utils/pydantic_v1/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from importlib import metadata
+
+try:
+    from pydantic.v1 import *  # noqa: F401 F403
+except ImportError:
+    from pydantic import *  # type: ignore # noqa: F401 F403
+
+
+try:
+    _PYDANTIC_MAJOR_VERSION: int = int(metadata.version("pydantic").split(".")[0])
+except metadata.PackageNotFoundError:
+    _PYDANTIC_MAJOR_VERSION = 0

--- a/kolena/_utils/pydantic_v1/dataclasses.py
+++ b/kolena/_utils/pydantic_v1/dataclasses.py
@@ -1,0 +1,18 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    from pydantic.v1.dataclasses import *  # noqa: F401 F403
+except ImportError:
+    from pydantic.dataclasses import *  # type: ignore # noqa: F401 F403

--- a/kolena/_utils/validators.py
+++ b/kolena/_utils/validators.py
@@ -13,16 +13,15 @@
 # limitations under the License.
 from typing import Optional
 
-from pydantic import ConfigDict
-
 from kolena._utils.consts import FieldName
+from kolena._utils.pydantic_v1 import Extra
 
 
-# Pydantic configuration for dataclasses and @validate_call decorators
-ValidatorConfig = ConfigDict(
-    arbitrary_types_allowed=True,
-    extra="allow",  # do not fail when unrecognized values are provided
-)
+# Pydantic configuration for dataclasses and @validate_arguments decorators
+class ValidatorConfig:
+    arbitrary_types_allowed = True
+    smart_union = True
+    extra = Extra.allow  # do not fail when unrecognized values are provided
 
 
 def validate_name(field: str, field_name: Optional[FieldName] = None) -> None:

--- a/kolena/annotation.py
+++ b/kolena/annotation.py
@@ -91,7 +91,7 @@ class BoundingBox(Annotation):
     def _data_type() -> _AnnotationType:
         return _AnnotationType.BOUNDING_BOX
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         object.__setattr__(self, "width", abs(self.bottom_right[0] - self.top_left[0]))
         object.__setattr__(self, "height", abs(self.bottom_right[1] - self.top_left[1]))
         object.__setattr__(self, "area", self.width * self.height)
@@ -145,7 +145,7 @@ class Polygon(Annotation):
     def _data_type() -> _AnnotationType:
         return _AnnotationType.POLYGON
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         if len(self.points) < 3:
             raise ValueError(f"{type(self).__name__} must have at least three points ({len(self.points)} provided)")
 
@@ -231,7 +231,7 @@ class BoundingBox3D(Annotation):
     def _data_type() -> _AnnotationType:
         return _AnnotationType.BOUNDING_BOX_3D
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         object.__setattr__(self, "volume", reduce(lambda a, b: a * b, self.dimensions))
 
 
@@ -406,7 +406,7 @@ class TextSegment(Annotation):
     end: int
     """Zero-indexed end index (exclusive) of the text segment."""
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         if self.start < 0:
             raise ValueError(f"Start index must be non-negative ({self.start} provided)")
         if self.end < 0:

--- a/kolena/annotation.py
+++ b/kolena/annotation.py
@@ -38,11 +38,10 @@ from typing import Dict
 from typing import List
 from typing import Tuple
 
-from pydantic.dataclasses import dataclass
-
 from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.validators import ValidatorConfig
 
 

--- a/kolena/annotation.py
+++ b/kolena/annotation.py
@@ -91,7 +91,7 @@ class BoundingBox(Annotation):
     def _data_type() -> _AnnotationType:
         return _AnnotationType.BOUNDING_BOX
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         object.__setattr__(self, "width", abs(self.bottom_right[0] - self.top_left[0]))
         object.__setattr__(self, "height", abs(self.bottom_right[1] - self.top_left[1]))
         object.__setattr__(self, "area", self.width * self.height)
@@ -145,7 +145,7 @@ class Polygon(Annotation):
     def _data_type() -> _AnnotationType:
         return _AnnotationType.POLYGON
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         if len(self.points) < 3:
             raise ValueError(f"{type(self).__name__} must have at least three points ({len(self.points)} provided)")
 
@@ -231,7 +231,7 @@ class BoundingBox3D(Annotation):
     def _data_type() -> _AnnotationType:
         return _AnnotationType.BOUNDING_BOX_3D
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         object.__setattr__(self, "volume", reduce(lambda a, b: a * b, self.dimensions))
 
 
@@ -406,7 +406,7 @@ class TextSegment(Annotation):
     end: int
     """Zero-indexed end index (exclusive) of the text segment."""
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         if self.start < 0:
             raise ValueError(f"Start index must be non-negative ({self.start} provided)")
         if self.end < 0:

--- a/kolena/asset.py
+++ b/kolena/asset.py
@@ -28,11 +28,10 @@ The following asset types are available:
 from abc import ABCMeta
 from typing import Optional
 
-from pydantic.dataclasses import dataclass
-
 from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.validators import ValidatorConfig
 
 

--- a/kolena/asset.py
+++ b/kolena/asset.py
@@ -134,7 +134,7 @@ class VideoAsset(BaseVideoAsset):
     end: Optional[float] = None
     """Optionally specify end time of video snippet, in seconds."""
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         if self.start is not None and self.end is not None and self.start > self.end:
             raise ValueError(f"Specified start time '{self.start}' is after specified end time '{self.end}'")
         if self.start is not None and self.end is not None and (self.start < 0 or self.end < 0):

--- a/kolena/asset.py
+++ b/kolena/asset.py
@@ -134,7 +134,7 @@ class VideoAsset(BaseVideoAsset):
     end: Optional[float] = None
     """Optionally specify end time of video snippet, in seconds."""
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         if self.start is not None and self.end is not None and self.start > self.end:
             raise ValueError(f"Specified start time '{self.start}' is after specified end time '{self.end}'")
         if self.start is not None and self.end is not None and (self.start < 0 or self.end < 0):

--- a/kolena/metrics/_geometry.py
+++ b/kolena/metrics/_geometry.py
@@ -24,10 +24,10 @@ from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
-from pydantic.dataclasses import dataclass
 from shapely.geometry import Polygon as ShapelyPolygon
 from shapely.validation import make_valid
 
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena.annotation import BoundingBox
 from kolena.annotation import Polygon
 from kolena.annotation import ScoredBoundingBox

--- a/kolena/workflow/define_workflow.py
+++ b/kolena/workflow/define_workflow.py
@@ -15,8 +15,7 @@ from typing import cast
 from typing import Tuple
 from typing import Type
 
-from pydantic import validate_call
-
+from kolena._utils.pydantic_v1 import validate_arguments
 from kolena._utils.validators import ValidatorConfig
 from kolena.workflow import GroundTruth
 from kolena.workflow import Inference
@@ -27,7 +26,7 @@ from kolena.workflow import TestSuite
 from kolena.workflow import Workflow
 
 
-@validate_call(config=ValidatorConfig)
+@validate_arguments(config=ValidatorConfig)
 def define_workflow(
     name: str,
     test_sample_type: Type[TestSample],

--- a/kolena/workflow/evaluator.py
+++ b/kolena/workflow/evaluator.py
@@ -19,13 +19,12 @@ from typing import Optional
 from typing import Tuple
 from typing import Type
 
-from pydantic import validate_call
-from pydantic.dataclasses import dataclass
-
 from kolena._api.v1.generic import TestRun as API
 from kolena._utils.datatypes import DataObject
 from kolena._utils.datatypes import get_args
 from kolena._utils.datatypes import get_origin
+from kolena._utils.pydantic_v1 import validate_arguments
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.validators import ValidatorConfig
 from kolena.workflow import GroundTruth
 from kolena.workflow import Inference
@@ -165,7 +164,7 @@ class Evaluator(metaclass=ABCMeta):
     configurations: List[EvaluatorConfiguration]
     """The configurations with which to perform evaluation, provided on instantiation."""
 
-    @validate_call(config=ValidatorConfig)
+    @validate_arguments(config=ValidatorConfig)
     def __init__(self, configurations: Optional[List[EvaluatorConfiguration]] = None):
         if configurations is not None and len(configurations) == 0:
             raise ValueError("empty configuration list provided, at least one configuration required or 'None'")
@@ -221,7 +220,7 @@ class Evaluator(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    @validate_call(config=ValidatorConfig)
+    @validate_arguments(config=ValidatorConfig)
     def compute_test_case_plots(
         self,
         test_case: TestCase,
@@ -242,7 +241,7 @@ class Evaluator(metaclass=ABCMeta):
         """
         return None  # not required
 
-    @validate_call(config=ValidatorConfig)
+    @validate_arguments(config=ValidatorConfig)
     def compute_test_suite_metrics(
         self,
         test_suite: TestSuite,
@@ -304,7 +303,7 @@ def _maybe_display_name(configuration: Optional[EvaluatorConfiguration]) -> Opti
     return configuration.display_name()
 
 
-@validate_call(config=ValidatorConfig)
+@validate_arguments(config=ValidatorConfig)
 def _configuration_description(configuration: Optional[EvaluatorConfiguration]) -> str:
     display_name = _maybe_display_name(configuration)
     return f"(configuration: {display_name})" if display_name is not None else ""

--- a/kolena/workflow/evaluator_function.py
+++ b/kolena/workflow/evaluator_function.py
@@ -28,11 +28,10 @@ from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
-from pydantic.dataclasses import dataclass
-
 from kolena._api.v1.generic import TestRun as API
 from kolena._utils import krequests
 from kolena._utils import log
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.state import is_client_uninitialized
 from kolena._utils.validators import ValidatorConfig
 from kolena.workflow import EvaluatorConfiguration

--- a/kolena/workflow/ground_truth.py
+++ b/kolena/workflow/ground_truth.py
@@ -34,9 +34,8 @@ A [`TestCase`][kolena.workflow.TestCase] holds a list of test samples (model inp
 """
 from typing import Type
 
-from pydantic.dataclasses import dataclass
-
 from kolena._utils.datatypes import DataObject
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.validators import ValidatorConfig
 from kolena.workflow import Composite
 from kolena.workflow import TestSample

--- a/kolena/workflow/inference.py
+++ b/kolena/workflow/inference.py
@@ -30,9 +30,8 @@ class PoseEstimate(Inference):
 """
 from typing import Type
 
-from pydantic.dataclasses import dataclass
-
 from kolena._utils.datatypes import DataObject
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.validators import ValidatorConfig
 from kolena.workflow import Composite
 from kolena.workflow import TestSample

--- a/kolena/workflow/model.py
+++ b/kolena/workflow/model.py
@@ -24,8 +24,6 @@ from typing import Set
 from typing import Tuple
 from typing import TypeVar
 
-from pydantic import validate_call
-
 from kolena._api.v1.core import Model as CoreAPI
 from kolena._api.v1.event import EventAPI
 from kolena._api.v1.generic import Model as API
@@ -37,6 +35,7 @@ from kolena._utils.consts import FieldName
 from kolena._utils.endpoints import get_model_url
 from kolena._utils.frozen import Frozen
 from kolena._utils.instrumentation import with_event
+from kolena._utils.pydantic_v1 import validate_arguments
 from kolena._utils.serde import from_dict
 from kolena._utils.validators import validate_name
 from kolena._utils.validators import ValidatorConfig
@@ -91,7 +90,7 @@ class Model(Frozen, metaclass=ABCMeta):
             raise NotImplementedError(f"{cls.__name__} must implement class attribute 'workflow'")
         super().__init_subclass__()
 
-    @validate_call(config=ValidatorConfig)
+    @validate_arguments(config=ValidatorConfig)
     def __init__(
         self,
         name: str,
@@ -186,7 +185,7 @@ class Model(Frozen, metaclass=ABCMeta):
         log.info(f"loaded {len(models)} '{cls.workflow.name}' models{tags_message}")
         return models
 
-    @validate_call(config=ValidatorConfig)
+    @validate_arguments(config=ValidatorConfig)
     def load_inferences(self, test_case: TestCase) -> List[Tuple[TestSample, GroundTruth, Inference]]:
         """
         Load all inferences stored for this model on the provided test case.
@@ -196,7 +195,7 @@ class Model(Frozen, metaclass=ABCMeta):
         """
         return list(self.iter_inferences(test_case))
 
-    @validate_call(config=ValidatorConfig)
+    @validate_arguments(config=ValidatorConfig)
     def iter_inferences(self, test_case: TestCase) -> Iterator[Tuple[TestSample, GroundTruth, Inference]]:
         """
         Iterate over all inferences stored for this model on the provided test case.

--- a/kolena/workflow/plot.py
+++ b/kolena/workflow/plot.py
@@ -94,7 +94,7 @@ class Curve(DataObject):
     value at which a given precision-recall point occurs.
     """
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         if len(self.x) != len(self.y):
             raise ValueError(
                 f"Series 'x' (length: {len(self.x)}) and 'y' (length: {len(self.y)}) have different lengths",
@@ -198,7 +198,7 @@ class Histogram(Plot):
     [`AxisConfig`][kolena.workflow.AxisConfig] for details.
     """
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         n_buckets = len(self.buckets)
         if n_buckets < 2:
             raise ValueError(f"Minimum 2 entries required in 'buckets' series (length: {n_buckets})")
@@ -243,7 +243,7 @@ class BarPlot(Plot):
     config: Optional[AxisConfig] = None
     """Custom format options to allow for control over the display of the numerical plot axis (`values`)."""
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         n_labels, n_values = len(self.labels), len(self.values)
         if n_labels == 0 or n_values == 0 or n_labels != n_values:
             raise ValueError(
@@ -298,7 +298,7 @@ class ConfusionMatrix(Plot):
     y_label: str = "Actual"
     """The label for the `y` axis of the confusion matrix."""
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         n_labels = len(self.labels)
         if n_labels < 2:
             raise ValueError(f"At least two labels required: got {n_labels}")

--- a/kolena/workflow/plot.py
+++ b/kolena/workflow/plot.py
@@ -32,12 +32,12 @@ from typing import Sequence
 from typing import Union
 
 import numpy as np
-from pydantic.dataclasses import dataclass
 
 from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataObject
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.validators import ValidatorConfig
 
 NumberSeries = Sequence[Union[float, int]]

--- a/kolena/workflow/plot.py
+++ b/kolena/workflow/plot.py
@@ -94,7 +94,7 @@ class Curve(DataObject):
     value at which a given precision-recall point occurs.
     """
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         if len(self.x) != len(self.y):
             raise ValueError(
                 f"Series 'x' (length: {len(self.x)}) and 'y' (length: {len(self.y)}) have different lengths",
@@ -198,7 +198,7 @@ class Histogram(Plot):
     [`AxisConfig`][kolena.workflow.AxisConfig] for details.
     """
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         n_buckets = len(self.buckets)
         if n_buckets < 2:
             raise ValueError(f"Minimum 2 entries required in 'buckets' series (length: {n_buckets})")
@@ -243,7 +243,7 @@ class BarPlot(Plot):
     config: Optional[AxisConfig] = None
     """Custom format options to allow for control over the display of the numerical plot axis (`values`)."""
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         n_labels, n_values = len(self.labels), len(self.values)
         if n_labels == 0 or n_values == 0 or n_labels != n_values:
             raise ValueError(
@@ -298,7 +298,7 @@ class ConfusionMatrix(Plot):
     y_label: str = "Actual"
     """The label for the `y` axis of the confusion matrix."""
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         n_labels = len(self.labels)
         if n_labels < 2:
             raise ValueError(f"At least two labels required: got {n_labels}")

--- a/kolena/workflow/test_case.py
+++ b/kolena/workflow/test_case.py
@@ -24,8 +24,6 @@ from typing import Optional
 from typing import Tuple
 
 import pandas as pd
-from pydantic import validate_call
-from pydantic.dataclasses import dataclass
 
 from kolena._api.v1.core import BulkProcessStatus
 from kolena._api.v1.core import TestCase as CoreAPI
@@ -41,6 +39,8 @@ from kolena._utils.consts import FieldName
 from kolena._utils.dataframes.validators import validate_df_schema
 from kolena._utils.frozen import Frozen
 from kolena._utils.instrumentation import with_event
+from kolena._utils.pydantic_v1 import validate_arguments
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.serde import from_dict
 from kolena._utils.validators import validate_name
 from kolena._utils.validators import ValidatorConfig
@@ -115,7 +115,7 @@ class TestCase(Frozen, metaclass=ABCMeta):
             raise NotImplementedError(f"{cls.__name__} must implement class attribute 'workflow'")
         super().__init_subclass__()
 
-    @validate_call(config=ValidatorConfig)
+    @validate_arguments(config=ValidatorConfig)
     def __init__(
         self,
         name: str,
@@ -278,19 +278,19 @@ class TestCase(Frozen, metaclass=ABCMeta):
         _description: str
         _initial_description: str
 
-        @validate_call(config=ValidatorConfig)
+        @validate_arguments(config=ValidatorConfig)
         def __init__(self, description: str, reset: bool) -> None:
             self._edits = []
             self._reset = reset
             self._description = description
             self._initial_description = description
 
-        @validate_call(config=ValidatorConfig)
+        @validate_arguments(config=ValidatorConfig)
         def description(self, description: str) -> None:
             """Update the description of the test case."""
             self._description = description
 
-        @validate_call(config=ValidatorConfig)
+        @validate_arguments(config=ValidatorConfig)
         def add(self, test_sample: TestSample, ground_truth: GroundTruth) -> None:
             """
             Add a test sample to the test case. When the test sample already exists in the test case, its ground truth
@@ -301,7 +301,7 @@ class TestCase(Frozen, metaclass=ABCMeta):
             """
             self._edits.append(self._Edit(test_sample, ground_truth=ground_truth))
 
-        @validate_call(config=ValidatorConfig)
+        @validate_arguments(config=ValidatorConfig)
         def remove(self, test_sample: TestSample) -> None:
             """
             Remove a test sample from the test case. Does nothing if the test sample is not in the test case.

--- a/kolena/workflow/test_run.py
+++ b/kolena/workflow/test_run.py
@@ -28,7 +28,6 @@ from typing import Tuple
 from typing import Union
 
 import pandas as pd
-from pydantic import validate_call
 
 from kolena._api.v1.event import EventAPI
 from kolena._api.v1.generic import TestRun as API
@@ -43,6 +42,7 @@ from kolena._utils.endpoints import get_results_url
 from kolena._utils.frozen import Frozen
 from kolena._utils.instrumentation import report_crash
 from kolena._utils.instrumentation import with_event
+from kolena._utils.pydantic_v1 import validate_arguments
 from kolena._utils.serde import from_dict
 from kolena._utils.validators import ValidatorConfig
 from kolena.errors import IncorrectUsageError
@@ -96,7 +96,7 @@ class TestRun(Frozen, metaclass=ABCMeta):
     evaluator: Optional[Union[Evaluator, BasicEvaluatorFunction]]
     configurations: Optional[List[EvaluatorConfiguration]]
 
-    @validate_call(config=ValidatorConfig)
+    @validate_arguments(config=ValidatorConfig)
     def __init__(
         self,
         model: Model,
@@ -225,7 +225,7 @@ class TestRun(Frozen, metaclass=ABCMeta):
                 yield test_sample, ground_truth, inference
         log.info(f"loaded inferences from model '{self.model.name}' on test suite '{self.test_suite.name}'")
 
-    @validate_call(config=ValidatorConfig)
+    @validate_arguments(config=ValidatorConfig)
     def upload_inferences(self, inferences: List[Tuple[TestSample, Inference]]) -> None:
         """
         Upload inferences from a model.
@@ -441,7 +441,7 @@ class TestRun(Frozen, metaclass=ABCMeta):
 
         return standard_metrics, thresholded_metrics
 
-    @validate_call(config=ValidatorConfig)
+    @validate_arguments(config=ValidatorConfig)
     def _upload_test_sample_metrics(
         self,
         test_case: Optional[TestCase],
@@ -549,7 +549,7 @@ class TestRun(Frozen, metaclass=ABCMeta):
         krequests.raise_for_status(res)
 
 
-@validate_call(config=ValidatorConfig)
+@validate_arguments(config=ValidatorConfig)
 def test(
     model: Model,
     test_suite: TestSuite,

--- a/kolena/workflow/test_sample.py
+++ b/kolena/workflow/test_sample.py
@@ -51,14 +51,13 @@ from typing import Optional
 from typing import Type
 from typing import Union
 
-from pydantic import StrictBool
-from pydantic import StrictFloat
-from pydantic import StrictInt
-from pydantic import StrictStr
-
 from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
+from kolena._utils.pydantic_v1 import StrictBool
+from kolena._utils.pydantic_v1 import StrictFloat
+from kolena._utils.pydantic_v1 import StrictInt
+from kolena._utils.pydantic_v1 import StrictStr
 from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.validators import ValidatorConfig
 from kolena.workflow._validators import get_data_object_field_types

--- a/kolena/workflow/test_sample.py
+++ b/kolena/workflow/test_sample.py
@@ -262,7 +262,7 @@ class Video(BaseVideo):
     end: Optional[float] = None
     """Optionally specify end time of video snippet, in seconds."""
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         if self.start is not None and self.end is not None and self.start > self.end:
             raise ValueError(f"Specified start time '{self.start}' is after specified end time '{self.end}'")
         if self.start is not None and self.end is not None and (self.start < 0 or self.end < 0):

--- a/kolena/workflow/test_sample.py
+++ b/kolena/workflow/test_sample.py
@@ -262,7 +262,7 @@ class Video(BaseVideo):
     end: Optional[float] = None
     """Optionally specify end time of video snippet, in seconds."""
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         if self.start is not None and self.end is not None and self.start > self.end:
             raise ValueError(f"Specified start time '{self.start}' is after specified end time '{self.end}'")
         if self.start is not None and self.end is not None and (self.start < 0 or self.end < 0):

--- a/kolena/workflow/test_sample.py
+++ b/kolena/workflow/test_sample.py
@@ -55,11 +55,11 @@ from pydantic import StrictBool
 from pydantic import StrictFloat
 from pydantic import StrictInt
 from pydantic import StrictStr
-from pydantic.dataclasses import dataclass
 
 from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.validators import ValidatorConfig
 from kolena.workflow._validators import get_data_object_field_types
 from kolena.workflow._validators import safe_issubclass

--- a/kolena/workflow/test_suite.py
+++ b/kolena/workflow/test_suite.py
@@ -24,8 +24,6 @@ from typing import Set
 from typing import Tuple
 from typing import Type
 
-from pydantic import validate_call
-
 from kolena._api.v1.core import TestSuite as CoreAPI
 from kolena._api.v1.event import EventAPI
 from kolena._api.v1.generic import TestSuite as API
@@ -37,6 +35,7 @@ from kolena._utils.consts import FieldName
 from kolena._utils.endpoints import get_test_suite_url
 from kolena._utils.frozen import Frozen
 from kolena._utils.instrumentation import with_event
+from kolena._utils.pydantic_v1 import validate_arguments
 from kolena._utils.serde import from_dict
 from kolena._utils.validators import validate_name
 from kolena._utils.validators import ValidatorConfig
@@ -96,7 +95,7 @@ class TestSuite(Frozen, metaclass=ABCMeta):
             raise NotImplementedError(f"{cls.__name__} must implement class attribute '_test_case_type'")
         super().__init_subclass__()
 
-    @validate_call(config=ValidatorConfig)
+    @validate_arguments(config=ValidatorConfig)
     def __init__(
         self,
         name: str,
@@ -268,7 +267,7 @@ class TestSuite(Frozen, metaclass=ABCMeta):
         #: The tags associated with this test suite. Modify this list directly to edit this test suite's tags.
         tags: Set[str]
 
-        @validate_call(config=ValidatorConfig)
+        @validate_arguments(config=ValidatorConfig)
         def __init__(self, test_cases: List[TestCase], description: str, tags: Set[str], reset: bool):
             self._test_cases = test_cases if not reset else []
             self._reset = reset
@@ -278,12 +277,12 @@ class TestSuite(Frozen, metaclass=ABCMeta):
             self._initial_tags = tags
             self.tags = tags
 
-        @validate_call(config=ValidatorConfig)
+        @validate_arguments(config=ValidatorConfig)
         def description(self, description: str) -> None:
             """Update the description of the test suite."""
             self._description = description
 
-        @validate_call(config=ValidatorConfig)
+        @validate_arguments(config=ValidatorConfig)
         def add(self, test_case: TestCase) -> None:
             """
             Add a test case to this test suite. If a different version of the test case already exists in this test
@@ -293,7 +292,7 @@ class TestSuite(Frozen, metaclass=ABCMeta):
             """
             self._test_cases = [*(tc for tc in self._test_cases if tc.name != test_case.name), test_case]
 
-        @validate_call(config=ValidatorConfig)
+        @validate_arguments(config=ValidatorConfig)
         def remove(self, test_case: TestCase) -> None:
             """
             Remove a test case from this test suite. Does nothing if the test case is not in the test suite.

--- a/kolena/workflow/workflow.py
+++ b/kolena/workflow/workflow.py
@@ -17,11 +17,11 @@ from typing import Type
 from urllib.parse import quote
 
 import dacite
-from pydantic.dataclasses import dataclass
 
 from kolena._api.v1.generic import Workflow as API
 from kolena._utils import krequests
 from kolena._utils import log
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.state import kolena_initialized
 from kolena.workflow import GroundTruth
 from kolena.workflow import Inference

--- a/kolena/workflow/workflow.py
+++ b/kolena/workflow/workflow.py
@@ -105,7 +105,7 @@ class Workflow:
     inference_type: Type[Inference]
     """The custom [`Inference`][kolena.workflow.Inference] type for the workflow."""
 
-    def __post_init_post_parse__(self) -> None:
+    def __post_init__(self) -> None:
         object.__setattr__(self, "name", self.name.strip())
         if self.name == "":
             raise ValueError("invalid zero-length name provided")

--- a/kolena/workflow/workflow.py
+++ b/kolena/workflow/workflow.py
@@ -105,7 +105,7 @@ class Workflow:
     inference_type: Type[Inference]
     """The custom [`Inference`][kolena.workflow.Inference] type for the workflow."""
 
-    def __post_init__(self) -> None:
+    def __post_init_post_parse__(self) -> None:
         object.__setattr__(self, "name", self.name.strip())
         if self.name == "":
             raise ValueError("invalid zero-length name provided")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pandas = [
     { version = ">=2.1.1,<3", python = ">=3.12" },
 ]
 pandera = ">=0.9,<1"
-pydantic = ">=2,<3"
+pydantic = ">=1.10,<3"
 dacite = ">=1.6,<2"
 requests = ">=2.20,<3"
 requests-toolbelt = "*"

--- a/tests/integration/workflow/conftest.py
+++ b/tests/integration/workflow/conftest.py
@@ -20,8 +20,8 @@ from typing import Optional
 from typing import Tuple
 
 import pytest
-from pydantic.dataclasses import dataclass
 
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena.workflow import Curve
 from kolena.workflow import CurvePlot
 from kolena.workflow import Evaluator

--- a/tests/integration/workflow/dummy.py
+++ b/tests/integration/workflow/dummy.py
@@ -15,8 +15,8 @@ from dataclasses import field
 from typing import Dict
 
 from pydantic import Extra
-from pydantic.dataclasses import dataclass
 
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena.workflow import define_workflow
 from kolena.workflow import GroundTruth
 from kolena.workflow import Image

--- a/tests/integration/workflow/dummy.py
+++ b/tests/integration/workflow/dummy.py
@@ -14,8 +14,7 @@
 from dataclasses import field
 from typing import Dict
 
-from pydantic import Extra
-
+from kolena._utils.pydantic_v1 import Extra
 from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena.workflow import define_workflow
 from kolena.workflow import GroundTruth

--- a/tests/integration/workflow/test_test_run.py
+++ b/tests/integration/workflow/test_test_run.py
@@ -22,10 +22,10 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
-from pydantic.dataclasses import dataclass
 
 from kolena._api.v1.generic import TestRun as TestRunAPI
 from kolena._utils import krequests
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena.errors import RemoteError
 from kolena.workflow import define_workflow
 from kolena.workflow import EvaluationResults

--- a/tests/unit/_experimental/object_detection/test_dataset.py
+++ b/tests/unit/_experimental/object_detection/test_dataset.py
@@ -214,7 +214,6 @@ def test__upload_object_detection_ignore_field() -> None:
             threshold_strategy="F1-Optimal",
             min_confidence_score=0.222,
         )
-    df.to_csv("test.csv", index=False)
     assert df["TP"][0] == [
         {
             "top_left": [2.0, 2.0],

--- a/tests/unit/_experimental/object_detection/test_dataset.py
+++ b/tests/unit/_experimental/object_detection/test_dataset.py
@@ -30,6 +30,10 @@ from kolena.metrics._geometry import MulticlassInferenceMatches
 object_detection = pytest.importorskip("kolena._experimental.object_detection", reason="requires kolena[metrics] extra")
 
 
+def convert_tuples_to_lists(d: dict) -> dict:
+    return {k: list(v) if isinstance(v, tuple) else v for k, v in d.items()}
+
+
 @pytest.mark.metrics
 @pytest.mark.parametrize(
     "ground_truths,inferences,expected",
@@ -210,9 +214,31 @@ def test__upload_object_detection_ignore_field() -> None:
             threshold_strategy="F1-Optimal",
             min_confidence_score=0.222,
         )
-    assert [ScoredBoundingBox(**elem) for elem in df["TP"][0]] == [
-        ScoredBoundingBox(top_left=(2, 2), bottom_right=(3, 3), score=1, ignore_flag=False),
-        ScoredBoundingBox(top_left=(4, 4), bottom_right=(5, 5), score=1),
+    df.to_csv("test.csv", index=False)
+    assert df["TP"][0] == [
+        {
+            "top_left": [2.0, 2.0],
+            "bottom_right": [3.0, 3.0],
+            "width": 1.0,
+            "height": 1.0,
+            "area": 1.0,
+            "aspect_ratio": 1.0,
+            "ignore_flag": False,
+            "data_type": "ANNOTATION/BOUNDING_BOX",
+            "score": 1.0,
+            "iou": 1.0,
+        },
+        {
+            "top_left": [4.0, 4.0],
+            "bottom_right": [5.0, 5.0],
+            "width": 1.0,
+            "height": 1.0,
+            "area": 1.0,
+            "aspect_ratio": 1.0,
+            "data_type": "ANNOTATION/BOUNDING_BOX",
+            "score": 1.0,
+            "iou": 1.0,
+        },
     ]
     assert df["FN"][0] == [
         BoundingBox(top_left=(3, 3), bottom_right=(4, 4), ignore_flag=False),

--- a/tests/unit/_experimental/object_detection/test_dataset.py
+++ b/tests/unit/_experimental/object_detection/test_dataset.py
@@ -30,10 +30,6 @@ from kolena.metrics._geometry import MulticlassInferenceMatches
 object_detection = pytest.importorskip("kolena._experimental.object_detection", reason="requires kolena[metrics] extra")
 
 
-def convert_tuples_to_lists(d: dict) -> dict:
-    return {k: list(v) if isinstance(v, tuple) else v for k, v in d.items()}
-
-
 @pytest.mark.metrics
 @pytest.mark.parametrize(
     "ground_truths,inferences,expected",

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -20,9 +20,9 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-import pydantic
 import pytest
 
+import kolena._utils.pydantic_v1 as pydantic
 from kolena._utils.datatypes import DATA_TYPE_FIELD
 from kolena._utils.datatypes import DataObject
 from kolena.annotation import _AnnotationType

--- a/tests/unit/test_asset.py
+++ b/tests/unit/test_asset.py
@@ -15,9 +15,9 @@ import dataclasses
 from typing import Callable
 from typing import Type
 
-import pydantic
 import pytest
 
+import kolena._utils.pydantic_v1 as pydantic
 from kolena._utils.datatypes import DATA_TYPE_FIELD
 from kolena.asset import _AssetType
 from kolena.asset import Asset

--- a/tests/unit/workflow/test_data_object.py
+++ b/tests/unit/workflow/test_data_object.py
@@ -14,10 +14,11 @@
 import dataclasses
 import sys
 
-import pydantic
 import pytest
-from pydantic.dataclasses import dataclass
 
+import kolena._utils.pydantic_v1 as pydantic
+from kolena._utils.pydantic_v1 import Extra
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena.workflow import BaseVideo
 from kolena.workflow import Composite
 from kolena.workflow import DataObject
@@ -123,7 +124,10 @@ def test__data_object__extras_allow() -> None:
 
 
 def test__data_object__extras_allow_invalid() -> None:
-    @dataclass(frozen=True, config=dict(extra="allow"))
+    class Config:
+        extra = Extra.allow
+
+    @dataclass(frozen=True, config=Config)
     class DataclassesTester(DataObject):
         b: float
         a: str

--- a/tests/unit/workflow/test_evaluator.py
+++ b/tests/unit/workflow/test_evaluator.py
@@ -19,9 +19,9 @@ from typing import Optional
 from typing import Type
 from typing import Union
 
-import pydantic
 import pytest
 
+import kolena._utils.pydantic_v1 as pydantic
 from kolena._experimental.workflow.thresholded import ThresholdedMetrics
 from kolena._utils.datatypes import DataObject
 from kolena.workflow.annotation import BoundingBox

--- a/tests/unit/workflow/test_test_sample.py
+++ b/tests/unit/workflow/test_test_sample.py
@@ -25,9 +25,9 @@ from typing import Union
 
 import dacite
 import numpy as np
-import pydantic
 import pytest
 
+import kolena._utils.pydantic_v1 as pydantic
 from kolena._utils.datatypes import DataObject
 from kolena._utils.serde import as_deserialized_json
 from kolena._utils.serde import as_serialized_json


### PR DESCRIPTION
### Linked issue(s)

### What change does this PR introduce and why?

- create the pydantic_v1 namespace in the kolena._utils
- revert the changes in [this pr](https://github.com/kolenaIO/kolena/pull/486) and use the v1 feature only
- relax the pydantic requirement to support v1


#### testing
- verified it works locally as expected

```tmol
[project]
name = "pydantic-v1"
version = "0.1.0"
description = "Default template for PDM package"
authors = [
    {name = "Yifan Wu", email = "yifan@kolena.io"},
]
dependencies = [
    "pydantic==1.10.5",
    "kolena @ git+https://github.com/kolenaIO/kolena@yifan/kol-6982-kolena-client-support-for-pydantic-v1",
    "scikit-learn>=1.5.1",
    "scipy>=1.14.0",
]
requires-python = "==3.10.*"
readme = "README.md"
license = {text = "MIT"}


[tool.pdm]
distribution = false
```

```sh
pdm run python                                                                                                                                                                                                                                            (base) 16:49:00
Python 3.10.9 (main, Aug 10 2023, 15:09:36) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pydantic
>>> pydantic.__version__
'1.10.5'
>>> from kolena._experimental.object_detection import upload_object_detection_results
>>> upload_object_detection_results
<function upload_object_detection_results at 0x168b652d0>
```

- tested `dataset/object_detection_2d` example works

##### pydantic v1

```tmol
[tool.poetry]
name = "object_detection_2d"
version = "0.1.0"
description = "Example Kolena integration for Object Detection 2D"
authors = ["Kolena Engineering <eng@kolena.com>"]
license = "Apache-2.0"

[tool.poetry.dependencies]
python = ">=3.9,<3.12"
kolena = { path = "../../..", extras = ["metrics"]}
s3fs = "^2023.5.0"
fsspec = "^2023.5.0"
pandera = ">=0.9.0,<0.16"
numpy = "^1.19"
pydantic = ">=1.10,<2"

[tool.poetry.group.dev.dependencies]
pre-commit = "^2.17"
pytest = "^7"
pytest-depends = "^1.0.1"

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
``` 

```sh
poetry update                                                                                                                                                                                                                                   (base) 17:38:37
Configuration file exists at /Users/yifanwu/Library/Preferences/pypoetry, reusing this directory.

Consider moving TOML configuration files to /Users/yifanwu/Library/Application Support/pypoetry, as support for the legacy directory will be removed in an upcoming release.
Updating dependencies
Resolving dependencies... (158.3s)

Package operations: 0 installs, 6 updates, 2 removals

  - Removing annotated-types (0.7.0)
  - Removing pydantic-core (2.20.1)
  - Updating exceptiongroup (1.2.1 -> 1.2.2)
  - Downgrading pydantic (2.8.2 -> 1.10.17)
  - Updating pandera (0.15.1 -> 0.15.2)
  - Updating pyarrow (16.1.0 -> 17.0.0)
  - Updating shapely (2.0.4 -> 2.0.5)
  - Downgrading kolena (1.25.0 -> 0.999.0 /Users/yifanwu/Documents/kolena-repos/kolena)
```

[here](https://trunk.kolena.io/yifan/dataset?datasetId=111&offset=0) is the result 

##### pydantic v2's v1


```tmol
[tool.poetry]
name = "object_detection_2d"
version = "0.1.0"
description = "Example Kolena integration for Object Detection 2D"
authors = ["Kolena Engineering <eng@kolena.com>"]
license = "Apache-2.0"

[tool.poetry.dependencies]
python = ">=3.9,<3.12"
kolena = { path = "../../..", extras = ["metrics"]}
s3fs = "^2023.5.0"
fsspec = "^2023.5.0"
pandera = ">=0.9.0,<0.16"
numpy = "^1.19"
pydantic = ">=1.10,<3"

[tool.poetry.group.dev.dependencies]
pre-commit = "^2.17"
pytest = "^7"
pytest-depends = "^1.0.1"

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
``` 

```sh
poetry update                                                                                                                                                                                                                                   (base) 17:44:11
Configuration file exists at /Users/yifanwu/Library/Preferences/pypoetry, reusing this directory.

Consider moving TOML configuration files to /Users/yifanwu/Library/Application Support/pypoetry, as support for the legacy directory will be removed in an upcoming release.
Updating dependencies
Resolving dependencies... (160.9s)

Package operations: 2 installs, 2 updates, 0 removals

  - Installing annotated-types (0.7.0)
  - Installing pydantic-core (2.20.1)
  - Updating pydantic (1.10.17 -> 2.8.2)
  - Downgrading pandera (0.15.2 -> 0.15.1)

```

[here](https://trunk.kolena.io/yifan/dataset?datasetId=112) is the result

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
