### PR TITLE
give the user an option to choose whether to use the intersection or union of datapoint when calculating metrics with quality standard

### DIFF
--- a/tests/integration/_experimental/test_quality_standard.py
+++ b/tests/integration/_experimental/test_quality_standard.py
@@ -62,18 +62,11 @@ def test__download_quality_standard_result(
 ) -> None:
     dataset_name = with_test_prefix("test__download_quality_standard_result__dataset")
     model_name = with_test_prefix("test__download_quality_standard_result__model")
-    model_name2 = with_test_prefix("test__download_quality_standard_result__model_2")
     eval_configs = [eval_config for eval_config, _ in results]
     upload_dataset(dataset_name, datapoints, id_fields=ID_FIELDS)
     _upload_results(
         dataset_name,
         model_name,
-        results,
-    )
-
-    _upload_results(
-        dataset_name,
-        model_name2,
         results,
     )
 
@@ -110,11 +103,6 @@ def test__download_quality_standard_result(
     assert_frame_equal(
         quality_standard_df,
         download_quality_standard_result(dataset_name, [model_name], [metric_group_name]),
-    )
-    assert_frame_equal(
-        download_quality_standard_result(dataset_name, [model_name, model_name2]),
-        download_quality_standard_result(dataset_name, [model_name, model_name2], intersect_results=False),
-        check_like=True,
     )
 
     df_columns: pd.MultiIndex = quality_standard_df.columns
@@ -176,3 +164,115 @@ def test__download_quality_standard_result(
             ]
             == waterloo_minimum
         )
+
+
+def test__download_quality_standard_result__union(
+    datapoints: pd.DataFrame,
+    results: List[Tuple[EvalConfig, pd.DataFrame]],
+) -> None:
+    dataset_name = with_test_prefix("test__download_quality_standard_result__union")
+    model_name = with_test_prefix("test__download_quality_standard_result__union_model")
+    model_name2 = with_test_prefix("test__download_quality_standard_result__union_model_2")
+    eval_config, model1_results = results[0]
+    upload_dataset(dataset_name, datapoints, id_fields=ID_FIELDS)
+    _upload_results(
+        dataset_name,
+        model_name,
+        model1_results,
+    )
+    model_2_results = model1_results[2:]
+    _upload_results(
+        dataset_name,
+        model_name2,
+        model_2_results,
+    )
+
+    test_case_name = "city"
+    metric_group_name = "test group"
+    min_metric_label = "Min Score"
+    quality_standard = dict(
+        name=with_test_prefix("test__download_quality_standard_result__union"),
+        stratifications=[
+            dict(
+                name=test_case_name,
+                stratify_fields=[dict(source="datapoint", field="city", values=["new york", "waterloo"])],
+                test_cases=[
+                    dict(name="new york", stratification=[dict(value="new york")]),
+                    dict(name="waterloo", stratification=[dict(value="waterloo")]),
+                ],
+            ),
+        ],
+        metric_groups=[
+            dict(
+                name=metric_group_name,
+                metrics=[
+                    dict(label="Min Score", source="result", aggregator="min", params=dict(key="score")),
+                ],
+            ),
+        ],
+        version="1.0",
+    )
+    create_quality_standard(dataset_name, quality_standard)
+
+    quality_standard_df_intersection = download_quality_standard_result(dataset_name, [model_name, model_name2])
+    assert_frame_equal(
+        quality_standard_df_intersection,
+        download_quality_standard_result(dataset_name, [model_name, model_name2], [metric_group_name]),
+    )
+    quality_standard_df_union = download_quality_standard_result(
+        dataset_name,
+        [model_name, model_name2],
+        intersect_results=False,
+    )
+
+    json_config = json.dumps(eval_config)
+
+    newyork_minimum = 0.2
+    waterloo_minimum = 0.3
+    dataset_minimum = min(newyork_minimum, waterloo_minimum)
+    assert (
+        quality_standard_df_intersection.loc[
+            ("Dataset", np.nan),
+            (model_name, json_config, metric_group_name, min_metric_label),
+        ]
+        == dataset_minimum
+    )
+    assert (
+        quality_standard_df_intersection.loc[
+            ("city", "new york"),
+            (model_name, json_config, metric_group_name, min_metric_label),
+        ]
+        == newyork_minimum
+    )
+    assert (
+        quality_standard_df_intersection.loc[
+            ("city", "waterloo"),
+            (model_name, json_config, metric_group_name, min_metric_label),
+        ]
+        == waterloo_minimum
+    )
+
+    newyork_minimum = 0.0
+    waterloo_minimum = 0.1
+    dataset_minimum = min(newyork_minimum, waterloo_minimum)
+    assert (
+        quality_standard_df_union.loc[
+            ("Dataset", np.nan),
+            (model_name, json_config, metric_group_name, min_metric_label),
+        ]
+        == dataset_minimum
+    )
+    assert (
+        quality_standard_df_union.loc[
+            ("city", "new york"),
+            (model_name, json_config, metric_group_name, min_metric_label),
+        ]
+        == newyork_minimum
+    )
+    assert (
+        quality_standard_df_union.loc[
+            ("city", "waterloo"),
+            (model_name, json_config, metric_group_name, min_metric_label),
+        ]
+        == waterloo_minimum
+    )

--- a/tests/integration/_experimental/test_quality_standard.py
+++ b/tests/integration/_experimental/test_quality_standard.py
@@ -173,14 +173,14 @@ def test__download_quality_standard_result__union(
     dataset_name = with_test_prefix("test__download_quality_standard_result__union")
     model_name = with_test_prefix("test__download_quality_standard_result__union_model")
     model_name2 = with_test_prefix("test__download_quality_standard_result__union_model_2")
-    eval_config, model1_results = results[0]
+    eval_config, model_1_results = results[0]
     upload_dataset(dataset_name, datapoints, id_fields=ID_FIELDS)
     _upload_results(
         dataset_name,
         model_name,
-        model1_results,
+        model_1_results,
     )
-    model_2_results = model1_results[2:]
+    model_2_results = model_1_results[2:]
     _upload_results(
         dataset_name,
         model_name2,

--- a/tests/integration/_experimental/test_quality_standard.py
+++ b/tests/integration/_experimental/test_quality_standard.py
@@ -62,11 +62,18 @@ def test__download_quality_standard_result(
 ) -> None:
     dataset_name = with_test_prefix("test__download_quality_standard_result__dataset")
     model_name = with_test_prefix("test__download_quality_standard_result__model")
+    model_name2 = with_test_prefix("test__download_quality_standard_result__model_2")
     eval_configs = [eval_config for eval_config, _ in results]
     upload_dataset(dataset_name, datapoints, id_fields=ID_FIELDS)
     _upload_results(
         dataset_name,
         model_name,
+        results,
+    )
+
+    _upload_results(
+        dataset_name,
+        model_name2,
         results,
     )
 
@@ -103,6 +110,11 @@ def test__download_quality_standard_result(
     assert_frame_equal(
         quality_standard_df,
         download_quality_standard_result(dataset_name, [model_name], [metric_group_name]),
+    )
+    assert_frame_equal(
+        download_quality_standard_result(dataset_name, [model_name, model_name2]),
+        download_quality_standard_result(dataset_name, [model_name, model_name2], intersect_results=False),
+        check_like=True,
     )
 
     df_columns: pd.MultiIndex = quality_standard_df.columns


### PR DESCRIPTION
### Linked issue(s)

### What change does this PR introduce and why?
This is to address Mehrad's comment [here](https://linear.app/kolena/issue/KOL-6996/[kodiak]-[voxel]-ability-to-see-qs-metrics-for-the-portion-of-the#comment-5e5a74df), we want the user to select whether to use the intersection or union of datapoint when calculating metrics with quality standard.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
