### PR TITLE
fix: validate dataset is non-empty when uploading

### DIFF
--- a/kolena/dataset/_common.py
+++ b/kolena/dataset/_common.py
@@ -65,6 +65,11 @@ def _validate_dataframe_ids_uniqueness(df: pd.DataFrame, id_fields: List[str]) -
         raise InputValidationError("id fields must be hashable") from e
 
 
+def validate_dataframe_not_empty(df: pd.DataFrame) -> None:
+    if df.empty:
+        raise InputValidationError("dataframe is empty")
+
+
 def validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
     for id_field in id_fields:
         if id_field not in df.columns:

--- a/kolena/dataset/_common.py
+++ b/kolena/dataset/_common.py
@@ -71,7 +71,7 @@ def validate_dataframe_not_empty(df: pd.DataFrame) -> None:
 
 
 def validate_name_not_empty(name: str) -> None:
-    if not name.replace(" ", ""):
+    if not name.strip():
         raise InputValidationError("name is empty")
 
 

--- a/kolena/dataset/_common.py
+++ b/kolena/dataset/_common.py
@@ -70,6 +70,11 @@ def validate_dataframe_not_empty(df: pd.DataFrame) -> None:
         raise InputValidationError("dataframe is empty")
 
 
+def validate_name_not_empty(name: str) -> None:
+    if not name.replace(" ", ""):
+        raise InputValidationError("name is empty")
+
+
 def validate_dataframe_ids(df: pd.DataFrame, id_fields: List[str]) -> None:
     for id_field in id_fields:
         if id_field not in df.columns:

--- a/kolena/dataset/dataset.py
+++ b/kolena/dataset/dataset.py
@@ -58,6 +58,7 @@ from kolena.dataset._common import DEFAULT_SOURCES
 from kolena.dataset._common import validate_batch_size
 from kolena.dataset._common import validate_dataframe_ids
 from kolena.dataset._common import validate_dataframe_not_empty
+from kolena.dataset._common import validate_name_not_empty
 from kolena.errors import InputValidationError
 from kolena.errors import NotFoundError
 from kolena.io import _dataframe_object_serde
@@ -233,6 +234,7 @@ def _prepare_upload_dataset_request(
     *,
     id_fields: Optional[List[str]] = None,
 ) -> Tuple[List[str], str]:
+    validate_name_not_empty(name)
     load_uuid = init_upload().uuid
 
     existing_dataset = _load_dataset_metadata(name, raise_error_if_not_found=False)

--- a/tests/integration/dataset/test_dataset.py
+++ b/tests/integration/dataset/test_dataset.py
@@ -59,6 +59,12 @@ def test__upload_dataset__empty_iterator() -> None:
         upload_dataset(name, batch_iterator(pd.DataFrame(columns=["locator"])), id_fields=["locator"])
 
 
+def test__upload_dataset__empty_name() -> None:
+    name = " "
+    with pytest.raises(InputValidationError):
+        upload_dataset(name, pd.DataFrame([dict(locator="0.jpg")], columns=["locator"]), id_fields=["locator"])
+
+
 def test__list_datasets() -> None:
     name = with_test_prefix(f"{__file__}::test__list_datasets")
     upload_dataset(name, pd.DataFrame([dict(locator="0.jpg")], columns=["locator"]), id_fields=["locator"])

--- a/tests/integration/dataset/test_dataset.py
+++ b/tests/integration/dataset/test_dataset.py
@@ -26,6 +26,7 @@ from kolena.dataset import list_datasets
 from kolena.dataset import upload_dataset
 from kolena.dataset.dataset import _fetch_dataset_history
 from kolena.dataset.dataset import _load_dataset_metadata
+from kolena.errors import InputValidationError
 from kolena.errors import NotFoundError
 from kolena.workflow.annotation import BoundingBox
 from kolena.workflow.annotation import LabeledBoundingBox
@@ -48,14 +49,19 @@ def test__load_dataset_metadata_dataset__not_exist() -> None:
 
 def test__upload_dataset__empty() -> None:
     name = with_test_prefix(f"{__file__}::test__upload_dataset__empty")
-    upload_dataset(name, pd.DataFrame(columns=["locator"]), id_fields=["locator"])
+    with pytest.raises(InputValidationError):
+        upload_dataset(name, pd.DataFrame(columns=["locator"]), id_fields=["locator"])
 
-    assert download_dataset(name).empty
+
+def test__upload_dataset__empty_iterator() -> None:
+    name = with_test_prefix(f"{__file__}::test__upload_dataset__empty_iterator")
+    with pytest.raises(InputValidationError):
+        upload_dataset(name, batch_iterator(pd.DataFrame(columns=["locator"])), id_fields=["locator"])
 
 
 def test__list_datasets() -> None:
     name = with_test_prefix(f"{__file__}::test__list_datasets")
-    upload_dataset(name, pd.DataFrame(columns=["locator"]), id_fields=["locator"])
+    upload_dataset(name, pd.DataFrame([dict(locator="0.jpg")], columns=["locator"]), id_fields=["locator"])
     assert name in list_datasets()
 
 


### PR DESCRIPTION
### Linked issue(s)
Towards [KOL-7149](https://linear.app/kolena/issue/KOL-7149/improve-the-sdk-experience-with-dataset-upload), will also make a server-side change

### What change does this PR introduce and why?
To maintain parity with the frontend which does not allow creation of dataset that is empty of has empty names. Currently, empty datasets created via the SDK will not show in the frontend and users are not able to delete them.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
