### PR TITLE
fix: pin griffe to resolve doc build failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ mkdocs-material = ">=9.2,<10"  # insiders fork installed out-of-band in docs/set
 mkdocstrings = { version = ">0.20,<1", extras = ["python"] }
 mkdocs-git-committers-plugin-2 = "^1"
 mkdocs-git-revision-date-localized-plugin = "^1"
+griffe = "<1"
 
 [tool.poetry.scripts]
 kolena = 'kolena._utils.cli:run'


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?
Aiming to resolve build [error from last merge](https://github.com/kolenaIO/kolena/actions/runs/10459507658/job/28963823963):
```
  File "/home/runner/.cache/pypoetry/virtualenvs/kolena-f6eT86MR-py3.9/lib/python3.9/site-packages/mkdocstrings_handlers/python/handler.py", line 14, in <module>
    from griffe.collections import LinesCollection, ModulesCollection
ModuleNotFoundError: No module named 'griffe.collections'
```

While haven't been able to reproduce this locally as the import statement seems to be from [older version of mkdocstrings-python prior to 1.10.8](https://github.com/mkdocstrings/python/commit/eff10ccf0fa1b2e73df912048a15c2d6406a2c8b), this definitely has to to with [breaking changes from griffe >=1 releases](https://github.com/mkdocstrings/griffe/releases) while [no upper bound was given by mkdocstring-python](https://github.com/mkdocstrings/python/blob/main/pyproject.toml#L33). [Last successful build](https://github.com/kolenaIO/kolena/actions/runs/10394680004/job/28784998863) was using griffe 0.49.0. Pin `griffe` to <1 for now to ensure successful builds.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
