### PR TITLE
feat: add support for 3d mesh assets + add optional `frame_rate` to video assets

### DIFF
--- a/examples/dataset/crossing_pedestrian_detection/crossing_pedestrian_detection/constants.py
+++ b/examples/dataset/crossing_pedestrian_detection/crossing_pedestrian_detection/constants.py
@@ -22,3 +22,4 @@ MODELS = [
     "static_deepsort",
 ]
 DEFAULT_DATASET_NAME = "JAAD [crossing-pedestrian-detection]"
+VIDEO_FRAME_RATE = 29.97

--- a/examples/dataset/crossing_pedestrian_detection/crossing_pedestrian_detection/upload_dataset.py
+++ b/examples/dataset/crossing_pedestrian_detection/crossing_pedestrian_detection/upload_dataset.py
@@ -22,6 +22,7 @@ from crossing_pedestrian_detection.constants import BUCKET
 from crossing_pedestrian_detection.constants import DATASET
 from crossing_pedestrian_detection.constants import DEFAULT_DATASET_NAME
 from crossing_pedestrian_detection.constants import ID_FIELDS
+from crossing_pedestrian_detection.constants import VIDEO_FRAME_RATE
 from crossing_pedestrian_detection.utils import process_gt_bboxes
 from smart_open import open as smart_open
 from tqdm import tqdm
@@ -53,6 +54,7 @@ def process_data() -> pd.DataFrame:
             datapoints.append(
                 {
                     "locator": video_locator(video_file),
+                    "frame_rate": VIDEO_FRAME_RATE,
                     "video_id": int(filename.split("_")[-1]),
                     "filename": filename,
                     "thumbnail_locator": thumbnail_locator(filename),

--- a/kolena/asset.py
+++ b/kolena/asset.py
@@ -23,7 +23,7 @@ The following asset types are available:
 - [`PointCloudAsset`][kolena.asset.PointCloudAsset]
 - [`VideoAsset`][kolena.asset.VideoAsset]
 - [`AudioAsset`][kolena.asset.AudioAsset]
-- [`Mesh3dAsset`][kolena.asset.Mesh3dAsset]
+- [`MeshAsset`][kolena.asset.MeshAsset]
 
 """
 from abc import ABCMeta
@@ -43,7 +43,7 @@ class _AssetType(DataType):
     POINT_CLOUD = "POINT_CLOUD"
     VIDEO = "VIDEO"
     AUDIO = "AUDIO"
-    MESH_3D = "MESH_3D"
+    MESH = "MESH"
 
     @staticmethod
     def _data_category() -> DataCategory:
@@ -165,7 +165,7 @@ class AudioAsset(Asset):
 
 
 @dataclass(frozen=True, config=ValidatorConfig)
-class Mesh3dAsset(Asset):
+class MeshAsset(Asset):
     """
     A 3d mesh file in a cloud bucket or served at a URL.
 
@@ -177,7 +177,7 @@ class Mesh3dAsset(Asset):
 
     @staticmethod
     def _data_type() -> _AssetType:
-        return _AssetType.MESH_3D
+        return _AssetType.MESH
 
 
 _ASSET_TYPES = [
@@ -188,5 +188,5 @@ _ASSET_TYPES = [
     BaseVideoAsset,
     VideoAsset,
     AudioAsset,
-    Mesh3dAsset,
+    MeshAsset,
 ]

--- a/kolena/asset.py
+++ b/kolena/asset.py
@@ -23,6 +23,7 @@ The following asset types are available:
 - [`PointCloudAsset`][kolena.asset.PointCloudAsset]
 - [`VideoAsset`][kolena.asset.VideoAsset]
 - [`AudioAsset`][kolena.asset.AudioAsset]
+- [`Mesh3dAsset`][kolena.asset.Mesh3dAsset]
 
 """
 from abc import ABCMeta
@@ -42,6 +43,7 @@ class _AssetType(DataType):
     POINT_CLOUD = "POINT_CLOUD"
     VIDEO = "VIDEO"
     AUDIO = "AUDIO"
+    MESH_3D = "MESH_3D"
 
     @staticmethod
     def _data_category() -> DataCategory:
@@ -134,11 +136,16 @@ class VideoAsset(BaseVideoAsset):
     end: Optional[float] = None
     """Optionally specify end time of video snippet, in seconds."""
 
+    frame_rate: Optional[float] = None
+    """Optionally specify the frame rate of video snippet, in frames per second."""
+
     def __post_init__(self) -> None:
         if self.start is not None and self.end is not None and self.start > self.end:
             raise ValueError(f"Specified start time '{self.start}' is after specified end time '{self.end}'")
         if self.start is not None and self.end is not None and (self.start < 0 or self.end < 0):
             raise ValueError(f"Specified start time '{self.start}' and end time '{self.end}' must be non-negative")
+        if self.frame_rate is not None and self.frame_rate <= 0:
+            raise ValueError(f"Specified frame rate '{self.frame_rate}' must be positive")
 
 
 @dataclass(frozen=True, config=ValidatorConfig)
@@ -157,4 +164,29 @@ class AudioAsset(Asset):
         return _AssetType.AUDIO
 
 
-_ASSET_TYPES = [ImageAsset, PlainTextAsset, BinaryAsset, PointCloudAsset, BaseVideoAsset, VideoAsset, AudioAsset]
+@dataclass(frozen=True, config=ValidatorConfig)
+class Mesh3dAsset(Asset):
+    """
+    A 3d mesh file in a cloud bucket or served at a URL.
+
+    Only `.ply` file type is supported.
+    """
+
+    locator: str
+    """The location of this 3d mesh file in a cloud bucket, e.g. `s3://my-bucket/path/to/my-mesh-asset.ply`."""
+
+    @staticmethod
+    def _data_type() -> _AssetType:
+        return _AssetType.MESH_3D
+
+
+_ASSET_TYPES = [
+    ImageAsset,
+    PlainTextAsset,
+    BinaryAsset,
+    PointCloudAsset,
+    BaseVideoAsset,
+    VideoAsset,
+    AudioAsset,
+    Mesh3dAsset,
+]

--- a/tests/unit/test_asset.py
+++ b/tests/unit/test_asset.py
@@ -60,6 +60,7 @@ def test__serialize__video() -> None:
         "thumbnail": None,
         "start": 0,
         "end": 1,
+        "frame_rate": None,
     }
     assert asset == VideoAsset._from_dict(asset_dict)
 
@@ -72,9 +73,10 @@ def test__instantiate__video(dataclass: Callable) -> None:
 
     locator = "s3://test-bucket/video.mp4"
     thumbnail = ImageAsset(locator="https://example.com/test.png")
-    Tester(locator=locator, thumbnail=thumbnail, start=0, end=1, a=1)
+    Tester(locator=locator, thumbnail=thumbnail, start=0, end=1, a=1, frame_rate=5)
     Tester(locator=locator)
     Tester(locator=locator, start=1, end=1.5)
+    Tester(locator=locator, frame_rate=1)
     Tester(locator=locator, a=1)
 
     with pytest.raises(ValueError):
@@ -85,3 +87,9 @@ def test__instantiate__video(dataclass: Callable) -> None:
 
     with pytest.raises(ValueError):
         Tester(locator=locator, start=-2, end=-1)
+
+    with pytest.raises(ValueError):
+        Tester(locator=locator, frame_rate=0)
+
+    with pytest.raises(ValueError):
+        Tester(locator=locator, frame_rate=-1)


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-7209
Resolves KOL-7208

### What change does this PR introduce and why?
- Add support for 3d mesh asset type ~~(depends on https://github.com/kolenaIO/marina/pull/3960)~~
- Add `frame_rate` for video assets (related to https://github.com/kolenaIO/marina/pull/3953)

Verified documentation generated:
![Aug-20-2024 12-32-35](https://github.com/user-attachments/assets/e9678f10-2b36-4809-8f57-945a49d8b998)


### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
