### PR TITLE
fix: avoid parsing scientific notation with e

### DIFF
--- a/kolena/_utils/dataframes/transformers.py
+++ b/kolena/_utils/dataframes/transformers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import json
 import math
+import re
 import warnings
 from collections.abc import Callable
 from typing import Any
@@ -107,6 +108,11 @@ def _try_parse(value: Any) -> Any:
     # Convert strings "true" and "false" to boolean values
     if value.lower() in ["true", "false"]:
         return value.lower() == "true"
+
+    # some string id could look like a scientific notation with e
+    scientific_notation_pattern = re.compile(r"[+-]?\d+(\.\d+)?[eE][+-]?\d+")
+    if scientific_notation_pattern.match(value):
+        return value
 
     # Attempt to convert the string to a numeric type
     try:

--- a/tests/unit/utils/dataframes/test_transformers.py
+++ b/tests/unit/utils/dataframes/test_transformers.py
@@ -109,6 +109,7 @@ def test__json_normalize(nested_data: Dict):
         ("'world'", "world"),  # Test string with quotes
         ("null", None),  # Test string "null"
         ("3e2", "3e2"),  # Test scientific notation
+        ("3E2", "3E2"),  # Test scientific notation
         ("4E2573", "4E2573"),  # Test scientific notation
     ],
 )

--- a/tests/unit/utils/dataframes/test_transformers.py
+++ b/tests/unit/utils/dataframes/test_transformers.py
@@ -91,37 +91,26 @@ def test__json_normalize(nested_data: Dict):
     pd.testing.assert_frame_equal(df_post, df_expected, check_like=True)
 
 
-def test__try_parse() -> None:
-    # Test empty string
-    assert _try_parse("") is None
-
-    # Test numeric string
-    assert _try_parse("42") == 42
-    assert _try_parse("3.14") == 3.14
-
-    # Test JSON string
-    assert _try_parse("[1, 2, 3]") == [1, 2, 3]
-    assert _try_parse('{"key": "value"}') == {"key": "value"}
-
-    # Test boolean string
-    assert _try_parse("true") is True
-    assert _try_parse("false") is False
-
-    # Test NumPy array
-    assert _try_parse(np.array([1, 2, 3])) == [1, 2, 3]
-
-    # Test NaN value
-    assert _try_parse(float("nan")) is None
-
-    # Test string "NaN"
-    assert _try_parse("NaN") is None
-
-    # Test other string
-    assert _try_parse("hello") == "hello"
-
-    # Test string with quotes
-    assert _try_parse('"hello"') == "hello"
-    assert _try_parse("'world'") == "world"
-
-    # Test string "null"
-    assert _try_parse("null") is None
+@pytest.mark.parametrize(
+    "input_value, expected",
+    [
+        ("", None),  # Test empty string
+        ("42", 42),  # Test numeric string
+        ("3.14", 3.14),  # Test numeric string
+        ("[1, 2, 3]", [1, 2, 3]),  # Test JSON string
+        ('{"key": "value"}', {"key": "value"}),  # Test JSON string
+        ("true", True),  # Test boolean string
+        ("false", False),  # Test boolean string
+        (np.array([1, 2, 3]), [1, 2, 3]),  # Test NumPy array
+        (float("nan"), None),  # Test NaN value
+        ("NaN", None),  # Test string "NaN"
+        ("hello", "hello"),  # Test other string
+        ('"hello"', "hello"),  # Test string with quotes
+        ("'world'", "world"),  # Test string with quotes
+        ("null", None),  # Test string "null"
+        ("3e2", "3e2"),  # Test scientific notation
+        ("4E2573", "4E2573"),  # Test scientific notation
+    ],
+)
+def test__try_parse(input_value: Any, expected: Any) -> None:
+    assert _try_parse(input_value) == expected


### PR DESCRIPTION
### Linked issue(s)

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
