### PR TITLE
fix: workflow prebuild OD ref

### DIFF
--- a/docs/reference/pre-built/object-detection-2d.md
+++ b/docs/reference/pre-built/object-detection-2d.md
@@ -27,3 +27,5 @@ on the COCO dataset.
 </div>
 
 ::: kolena._experimental.object_detection
+    options:
+        members: ["TestSample", "GroundTruth", "Inference", "ThresholdConfiguration", "ObjectDetectionEvaluator"]


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?
Resolving [error in build](https://github.com/kolenaIO/kolena/actions/runs/10475685005/job/29012889300):
```
WARNING -  mkdocs_autorefs: Multiple URLs found for 'kolena._experimental.object_detection.compute_object_detection_results': ['reference/experimental/#kolena._experimental.object_detection.compute_object_detection_results', 'reference/pre-built/object-detection-2d/#kolena._experimental.object_detection.compute_object_detection_results']. Make sure to use unique headings, identifiers, or Markdown anchors (see our docs).
```

We do have this reference duplicated:
- https://docs.kolena.com/reference/pre-built/object-detection-2d/#kolena._experimental.object_detection.upload_object_detection_results
- https://docs.kolena.com/reference/experimental/#kolena._experimental.object_detection.upload_object_detection_results

This seems to pass the check before but failing with `mkdocs-autoref 1.1`. This PR excludes [those that were referenced in the dataset doc](https://github.com/kolenaIO/kolena/blob/e31223f32d39350af6d3b13a410ba48ae82a95dc/docs/reference/experimental/index.md?plain=1#L13)

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
