### PR TITLE
chore: remove video_id col from JAAD dataset

### DIFF
--- a/examples/dataset/crossing_pedestrian_detection/crossing_pedestrian_detection/upload_dataset.py
+++ b/examples/dataset/crossing_pedestrian_detection/crossing_pedestrian_detection/upload_dataset.py
@@ -55,7 +55,6 @@ def process_data() -> pd.DataFrame:
                 {
                     "locator": video_locator(video_file),
                     "frame_rate": VIDEO_FRAME_RATE,
-                    "video_id": int(filename.split("_")[-1]),
                     "filename": filename,
                     "thumbnail_locator": thumbnail_locator(filename),
                     "num_frames": gt_annotations[filename]["num_frames"],


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?
With `video_id` column in the csv, our web app will assume `video_id` is the id field instead of `locator`. This means that people manually importing datasets with the UI need to know to manually change the id field in order to upload results. Given that we are not using `video_id` elsewhere, removing it from the dataset to avoid this confusion.

Ref: https://kolena-io.slack.com/archives/C07E6AFUNQ5/p1725547562583959?thread_ts=1725393700.884029&cid=C07E6AFUNQ5

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
