### PR TITLE
Migrate to uv for package management

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -117,6 +117,8 @@ jobs:
             - run:
                 name: Install Dependencies
                 command: uv pip install -r pyproject.toml --verbose
+                env:
+                  UV_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cpu/"
       - when: &install_with_extras
           condition:
             equal: [ "metrics", << parameters.extras >> ]
@@ -124,6 +126,8 @@ jobs:
             - run:
                 name: Install Dependencies
                 command: uv pip install --all-extras -r pyproject.toml --verbose
+                env:
+                  UV_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cpu/"
       - run: uv run python3 -c 'import kolena'
       # TODO: fix underlying mypy issues with Python>3.9 rather than skipping
       - when:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -317,19 +317,19 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      - run: *install_uv
-      - run: *setup_env
-      - run: uv pip install -r pyproject.toml --verbose
+      - run: |
+          poetry config installer.max-workers 10
+          poetry install -vv --no-ansi
       - run:
           name: Run pre-commit checks
-          command: uvx pre-commit run -a
+          command: poetry run pre-commit run -a
       - run:
           name: Run << parameters.subproject >> (Python << parameters.python-version >>) integration tests
           command: |
             token=KOLENA_TOKEN_$((CIRCLE_BUILD_NUM % << pipeline.parameters.token_count >>))
             echo "Using $token"
             export KOLENA_TOKEN=${!token}
-            uv run pytest --cache-clear -vv tests
+            poetry run pytest --cache-clear -vv tests
 
   example-evaluator:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -35,8 +35,6 @@ executors:
     docker:
       - image: cimg/python:<< parameters.python-version >>
     resource_class: << parameters.resource-class >>
-    environment:
-      POETRY_CACHE_DIR: /home/circleci/project/.poetry
 
 jobs:
   ci-base:
@@ -52,31 +50,26 @@ jobs:
       python-version: << parameters.python-version >>
     steps:
       - checkout
-      - restore_cache:
-          key: &poetry-cache poetry-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Install uv
+          command: pip install uv
+      - run:
+          name: Setup environment
+          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
       - when:
           condition:
             equal: [ "none", << parameters.extras >> ]
           steps:
             - run:
                 name: Install Dependencies
-                command: |
-                  poetry config installer.max-workers 10
-                  poetry install -vv --no-ansi
+                command: uv pip install -r pyproject.toml --verbose
       - when:
           condition:
             equal: [ "metrics", << parameters.extras >> ]
           steps:
             - run:
                 name: Install Dependencies
-                command: |
-                  poetry config installer.max-workers 10
-                  poetry install -vv --all-extras --no-ansi
-      - save_cache:
-          key: *poetry-cache
-          paths:
-            - /home/circleci/project/.poetry/virtualenvs
-            - poetry.lock
+                command: uv pip install --all-extras -r pyproject.toml --verbose
 
   docs:
     parameters:
@@ -91,9 +84,12 @@ jobs:
       python-version: << parameters.python-version >>
     steps:
       - checkout
-      - restore_cache:
-          name: Restore Poetry cache
-          key: poetry-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Install uv
+          command: pip install uv
+      - run:
+          name: Setup environment
+          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
       - restore_cache:
           name: Restore MkDocs cache
           key: mkdocs-cache
@@ -107,14 +103,14 @@ jobs:
           command: git lfs pull
       - run:
           name: Build documentation without 'insiders' packages
-          command: poetry run mkdocs build
+          command: uv run mkdocs build
       - add_ssh_keys: # add github.com SSH key fingerprint to access private repo forks
           fingerprints: [ "15:8b:d4:ac:1f:cd:2f:d3:92:a7:4c:aa:46:81:0b:7d" ]
       - run:
           name: Build documentation with 'insiders' packages
           command: |
             ./docs/setup_insiders.sh
-            poetry run mkdocs build --config-file mkdocs.insiders.yml
+            uv run mkdocs build --config-file mkdocs.insiders.yml
       - save_cache:
           key: mkdocs-cache
           paths:
@@ -133,9 +129,13 @@ jobs:
       python-version: << parameters.python-version >>
     steps:
       - checkout
-      - restore_cache:
-          key: poetry-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
-      - run: poetry run python3 -c 'import kolena'
+      - run:
+          name: Install uv
+          command: pip install uv
+      - run:
+          name: Setup environment
+          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
+      - run: uv run python3 -c 'import kolena'
       # TODO: fix underlying mypy issues with Python>3.9 rather than skipping
       - when:
           condition:
@@ -144,21 +144,21 @@ jobs:
                 pattern: "^3\\.(10|11|12).*$"
                 value: << parameters.python-version >>
           steps:
-            - run: poetry run pre-commit run -a
+            - run: uvx pre-commit run -a
       - when:
           condition:
             equal: [ "none", << parameters.extras >> ]
           steps:
             - run:
                 name: Run unit tests
-                command: poetry run pytest --cache-clear -m 'not metrics' -vv --cov=kolena --cov-branch tests/unit
+                command: uv run pytest --cache-clear -m 'not metrics' -vv --cov=kolena --cov-branch tests/unit
       - when:
           condition:
             equal: [ "metrics", << parameters.extras >> ]
           steps:
             - run:
                 name: Run metrics unit tests
-                command: poetry run pytest --cache-clear -m 'metrics' -vv --cov=kolena --cov-branch tests/unit
+                command: uv run pytest --cache-clear -m 'metrics' -vv --cov=kolena --cov-branch tests/unit
       - when:
           # Generate coverage only from one Python version
           condition:
@@ -168,7 +168,7 @@ jobs:
           steps:
             - run:
                 name: Coverage
-                command: poetry run coverage xml --data-file .coverage
+                command: uv run coverage xml --data-file .coverage
             - codecov/upload:
                 file: coverage.xml
                 flags: integration
@@ -203,8 +203,12 @@ jobs:
                 name: skip job
                 command: circleci-agent step halt
       - checkout
-      - restore_cache:
-          key: poetry-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Install uv
+          command: pip install uv
+      - run:
+          name: Setup environment
+          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
       - run:
           name: Set KOLENA_TOKEN with round robin
           command: |
@@ -229,7 +233,7 @@ jobs:
                     TESTFILES=$(find tests/integration/$TEST_GROUP -name "test_*.py" |
                       circleci tests split --split-by=timings --timings-type=filename)
                   fi
-                  poetry run pytest --cache-clear -vv --durations=10 --cov=kolena --cov-branch --ignore=examples \
+                  uv run pytest --cache-clear -vv --durations=10 --cov=kolena --cov-branch --ignore=examples \
                     -o junit_family=legacy --junitxml=test-results/result.xml $TESTFILES
       - when:
           condition:
@@ -237,21 +241,7 @@ jobs:
           steps:
             - run:
                 name: Run experimental metrics integration tests
-                command: poetry run pytest --cache-clear -m 'metrics' -vv --cov=kolena --cov-branch tests/integration/
-      - when:
-          # Generate coverage only from one python version
-          condition:
-            matches:
-              pattern: "^3\\.9.*$"
-              value: << parameters.python-version >>
-          steps:
-            - run:
-                name: Coverage
-                command: poetry run coverage xml --data-file .coverage
-            - codecov/upload:
-                file: coverage.xml
-            - store_test_results:
-                path: test-results
+                command: uv run pytest --cache-clear -m 'metrics' -vv --cov=kolena --cov-branch tests/integration/
 
   integration-test-dataset:
     parameters:
@@ -287,8 +277,12 @@ jobs:
                 name: skip job
                 command: circleci-agent step halt
       - checkout
-      - restore_cache:
-          key: poetry-cache-<< parameters.python-version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Install uv
+          command: pip install uv
+      - run:
+          name: Setup environment
+          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
       - run:
           name: Set KOLENA_TOKEN with round robin
           command: |
@@ -300,22 +294,8 @@ jobs:
           command: |
             TESTFILES=$(circleci tests glob tests/integration/dataset/**/test_*.py |
                 circleci tests split --split-by=timings --timings-type=filename)
-            poetry run pytest --cache-clear -vv --durations=10 --cov=kolena --cov-branch --ignore=examples \
+            uv run pytest --cache-clear -vv --durations=10 --cov=kolena --cov-branch --ignore=examples \
               -o junit_family=legacy --junitxml=test-results/result.xml $TESTFILES
-      - when:
-          # Generate coverage only from one python version
-          condition:
-            matches:
-              pattern: "^3\\.9.*$"
-              value: << parameters.python-version >>
-          steps:
-            - run:
-                name: Coverage
-                command: poetry run coverage xml --data-file .coverage
-            - codecov/upload:
-                file: coverage.xml
-            - store_test_results:
-                path: test-results
 
   example-test-dataset:
     parameters:
@@ -334,19 +314,23 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      - run: |
-          poetry config installer.max-workers 10
-          poetry install -vv --no-ansi
+      - run:
+          name: Install uv
+          command: pip install uv
+      - run:
+          name: Setup environment
+          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
+      - run: uv pip install -r pyproject.toml --verbose
       - run:
           name: Run pre-commit checks
-          command: poetry run pre-commit run -a
+          command: uvx pre-commit run -a
       - run:
           name: Run << parameters.subproject >> (Python << parameters.python-version >>) integration tests
           command: |
             token=KOLENA_TOKEN_$((CIRCLE_BUILD_NUM % << pipeline.parameters.token_count >>))
             echo "Using $token"
             export KOLENA_TOKEN=${!token}
-            poetry run pytest -vv tests
+            uv run pytest -vv tests
 
   example-test-workflow:
     parameters:
@@ -365,19 +349,23 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      - run: |
-          poetry config installer.max-workers 10
-          poetry install -vv --no-ansi
+      - run:
+          name: Install uv
+          command: pip install uv
+      - run:
+          name: Setup environment
+          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
+      - run: uv pip install -r pyproject.toml --verbose
       - run:
           name: Run pre-commit checks
-          command: poetry run pre-commit run -a
+          command: uvx pre-commit run -a
       - run:
           name: Run << parameters.subproject >> (Python << parameters.python-version >>) integration tests
           command: |
             token=KOLENA_TOKEN_$((CIRCLE_BUILD_NUM % << pipeline.parameters.token_count >>))
             echo "Using $token"
             export KOLENA_TOKEN=${!token}
-            poetry run pytest --cache-clear -vv tests
+            uv run pytest --cache-clear -vv tests
 
   example-evaluator:
     docker:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  codecov: codecov/codecov@3.2.4
-
 parameters:
   workflow:
     type: boolean
@@ -50,26 +47,12 @@ jobs:
       python-version: << parameters.python-version >>
     steps:
       - checkout
-      - run:
+      - run: &install_uv
           name: Install uv
           command: pip install uv
-      - run:
+      - run: &setup_env
           name: Setup environment
           command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
-      - when:
-          condition:
-            equal: [ "none", << parameters.extras >> ]
-          steps:
-            - run:
-                name: Install Dependencies
-                command: uv pip install -r pyproject.toml --verbose
-      - when:
-          condition:
-            equal: [ "metrics", << parameters.extras >> ]
-          steps:
-            - run:
-                name: Install Dependencies
-                command: uv pip install --all-extras -r pyproject.toml --verbose
 
   docs:
     parameters:
@@ -84,12 +67,8 @@ jobs:
       python-version: << parameters.python-version >>
     steps:
       - checkout
-      - run:
-          name: Install uv
-          command: pip install uv
-      - run:
-          name: Setup environment
-          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
+      - run: *install_uv
+      - run: *setup_env
       - restore_cache:
           name: Restore MkDocs cache
           key: mkdocs-cache
@@ -129,12 +108,22 @@ jobs:
       python-version: << parameters.python-version >>
     steps:
       - checkout
-      - run:
-          name: Install uv
-          command: pip install uv
-      - run:
-          name: Setup environment
-          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
+      - run: *install_uv
+      - run: *setup_env
+      - when: &install_without_extras
+          condition:
+            equal: [ "none", << parameters.extras >> ]
+          steps:
+            - run:
+                name: Install Dependencies
+                command: uv pip install -r pyproject.toml --verbose
+      - when: &install_with_extras
+          condition:
+            equal: [ "metrics", << parameters.extras >> ]
+          steps:
+            - run:
+                name: Install Dependencies
+                command: uv pip install --all-extras -r pyproject.toml --verbose
       - run: uv run python3 -c 'import kolena'
       # TODO: fix underlying mypy issues with Python>3.9 rather than skipping
       - when:
@@ -159,19 +148,6 @@ jobs:
             - run:
                 name: Run metrics unit tests
                 command: uv run pytest --cache-clear -m 'metrics' -vv --cov=kolena --cov-branch tests/unit
-      - when:
-          # Generate coverage only from one Python version
-          condition:
-            matches:
-              pattern: "^3\\.9.*$"
-              value: << parameters.python-version >>
-          steps:
-            - run:
-                name: Coverage
-                command: uv run coverage xml --data-file .coverage
-            - codecov/upload:
-                file: coverage.xml
-                flags: integration
 
   integration-test:
     parameters:
@@ -203,12 +179,10 @@ jobs:
                 name: skip job
                 command: circleci-agent step halt
       - checkout
-      - run:
-          name: Install uv
-          command: pip install uv
-      - run:
-          name: Setup environment
-          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
+      - run: *install_uv
+      - run: *setup_env
+      - when: *install_without_extras
+      - when: *install_with_extras
       - run:
           name: Set KOLENA_TOKEN with round robin
           command: |
@@ -277,12 +251,10 @@ jobs:
                 name: skip job
                 command: circleci-agent step halt
       - checkout
-      - run:
-          name: Install uv
-          command: pip install uv
-      - run:
-          name: Setup environment
-          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
+      - run: *install_uv
+      - run: *setup_env
+      - when: *install_without_extras
+      - when: *install_with_extras
       - run:
           name: Set KOLENA_TOKEN with round robin
           command: |
@@ -314,12 +286,8 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      - run:
-          name: Install uv
-          command: pip install uv
-      - run:
-          name: Setup environment
-          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
+      - run: *install_uv
+      - run: *setup_env
       - run: uv pip install -r pyproject.toml --verbose
       - run:
           name: Run pre-commit checks
@@ -349,12 +317,8 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      - run:
-          name: Install uv
-          command: pip install uv
-      - run:
-          name: Setup environment
-          command: uv venv --python << parameters.python-version >> && source .venv/bin/activate
+      - run: *install_uv
+      - run: *setup_env
       - run: uv pip install -r pyproject.toml --verbose
       - run:
           name: Run pre-commit checks

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,17 +38,16 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: Install Poetry
-        run: pip install poetry==1.5.1
+      - uses: astral-sh/setup-uv@v2
+
+      - name: Setup environment
+        run: uv venv && source .venv/bin/activate
 
       - name: Fetch tags to enable autoversioning
         run: git fetch --prune --unshallow --tags
 
-      - name: Update package version to PEP 440-compliant production release tag
-        run: poetry version $(git describe --tags --abbrev=0)
-
-      - name: Install Poetry dependencies
-        run: poetry install
+      - name: Install dependencies
+        run: uv pip install --all-extras -r pyproject.toml
 
       - name: Install docs 'insiders' dependencies
         run: ./docs/setup_insiders.sh
@@ -56,7 +55,7 @@ jobs:
       - name: Publish 'kolena' documentation to trunk (S3)
         if: inputs.environment != 'production'
         run: |
-          poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
+          uv run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://trunk-docs.kolena.io" --delete
           aws cloudfront create-invalidation --no-cli-pager --distribution-id ${{ secrets.TRUNK_DOC_DISTRIBUTION_ID }} --paths "/*"
           aws s3 sync ./site "s3://trunk-docs.kolena.com" --delete
@@ -65,7 +64,7 @@ jobs:
       - name: Publish 'kolena' documentation to production (S3)
         if: inputs.environment == 'production'
         run: |
-          poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
+          uv run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io" --delete
           aws cloudfront create-invalidation --no-cli-pager --distribution-id ${{ secrets.DOC_DISTRIBUTION_ID }} --paths "/*"
           aws s3 sync ./site "s3://docs.kolena.com" --delete

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Run pre-commit checks
         run: uvx pre-commit run -a
 
+      - name: Update package version to PEP 440-compliant release tag
+        run: sed -i "s/0.999.0/$(git describe --tags --abbrev=0)/g" pyproject.toml
+
       - name: Build 'kolena' Python package
         run: uv build --format=sdist
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,28 +31,24 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: Install Poetry
-        run: pip install poetry==1.5.1
+      - uses: astral-sh/setup-uv@v2
 
       - name: Fetch tags to enable autoversioning
         run: git fetch --prune --unshallow --tags
 
-      - name: Update package version to PEP 440-compliant production release tag
-        run: poetry version $(git describe --tags --abbrev=0)
-
       - name: Install dependencies
-        run: poetry install
+        run: uv pip install --all-extras -r pyproject.toml
 
       - name: Run pre-commit checks
-        run: poetry run pre-commit run -a
+        run: uvx pre-commit run -a
 
       - name: Build 'kolena' Python package
-        run: poetry build --format=sdist
+        run: uv build --format=sdist
 
       - name: Publish 'kolena' documentation to production (S3)
         run: |
           ./docs/setup_insiders.sh
-          poetry run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
+          uv run mkdocs build --verbose --strict --config-file mkdocs.insiders.yml
           aws s3 sync ./site "s3://docs.kolena.io" --delete
           aws cloudfront create-invalidation --no-cli-pager --distribution-id ${{ secrets.DOC_DISTRIBUTION_ID }} --paths "/*"
           aws s3 sync ./site "s3://docs.kolena.com" --delete
@@ -91,8 +87,8 @@ jobs:
           # update first instance of 'kolena' to 'kolena-client' in pyproject.toml, kolena/__init__.py (package name)
           sed -i '0,/kolena/{s/kolena/kolena-client/}' pyproject.toml kolena/__init__.py
 
-          poetry install
-          poetry build --format=sdist
+          uv pip install --all-extras -r pyproject.toml
+          uv build --format=sdist
 
       - name: "[backcompat] Install twine for package distribution on CodeArtifact"
         run: pip install twine

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.code-workspace
 
 .DS_Store
+.venv/
 
 __pycache__/
 .ipynb_checkpoints/
@@ -22,3 +23,4 @@ dist/
 site
 
 poetry.lock
+uv.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,32 +2,41 @@
 
 ## Development environment setup
 
+`kolena` uses [uv](https://github.com/astral-sh/uv) to manage dependencies. To set up this repository for development,
+run:
+
+```shell
+uv venv && source .venv/bin/activate
+uv pip install --all-extras -r pyproject.toml
+uv tool run pre-commit install
+```
+
 ### Install pre-commit checks
 
 Pre-commit is used for static analysis and to ensure code style consistency. Please install it so warnings and
 errors can be caught before committing code.
 
 ```
-poetry run pre-commit install
+uv tool run pre-commit install
 ```
 
 ## Documentation
 
 The documentation for `kolena`, hosted at [docs.kolena.com](https://docs.kolena.com/), is built out of this repo using
 [MkDocs](https://www.mkdocs.org/).
-Building the documentation locally requires installing the Poetry dependencies for `kolena` as well as additional
+Building the documentation locally requires installing the dependencies for `kolena` as well as additional
 [OS-level dependencies for mkdocs-material](https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/#cairo-graphics).
 
 To run the documentation server locally, run:
 
 ```
-poetry run mkdocs serve -a localhost:8999
+uv run mkdocs serve -a localhost:8999
 ```
 
 To build static documentation:
 
 ```
-poetry run mkdocs build
+uv run mkdocs build
 ```
 
 Note that any OSError unable to find "cairo-2, "cairo", or "libcairo-2" can be solved with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,9 @@ To build the documentation with "insider" features, run the [`setup_insiders.sh`
 ```
 
 Note that this script requires an SSH key in your environment with access to the [kolenaIO](https://github.com/kolenaIO)
-organization.
+organization. Additionally, this script modifies the `pyproject.toml` to reference the "insider" versions of the mkdocs
+projects. Please take care to avoid merging these updates, as it will prevent contributors without insiders access from
+running `kolena`.
 
 After running `setup_insiders.sh`, add `--config-file mkdocs.insiders.yml` to the `serve` and `build` invocations above
 to build documentation with all "insider" features enabled.

--- a/docs/automations/set-up-natural-language-search.md
+++ b/docs/automations/set-up-natural-language-search.md
@@ -53,7 +53,7 @@ Uploading embeddings to Kolena can be done in four simple steps:
 
 ### Step 1: Install `kolena-embeddings` Package
 
-The package can be installed via `pip` or `poetry` and requires use of your kolena token which can be created
+The package can be installed via `pip` or `uv` and requires use of your kolena token which can be created
 on the [:kolena-developer-16: Developer](https://app.kolena.com/redirect/developer) page.
 
 We first [retrieve and set](../installing-kolena.md#initialization) our `KOLENA_TOKEN` environment variable.
@@ -70,16 +70,11 @@ export KOLENA_TOKEN="********"
     pip install --extra-index-url="https://<KOLENA_TOKEN>@gateway.kolena.cloud/repositories" kolena-embeddings
     ```
 
-=== "`poetry`"
+=== "`uv`"
 
-    Configure an additional poetry source:
+    Run the following command, making sure to replace <KOLENA_TOKEN> with the token retrieved from the developer page:
     ```shell
-    poetry source add --priority=supplemental kolena-embeddings "https://gateway.kolena.cloud/repositories"
-    ```
-
-    Then run the following command, making sure to replace <KOLENA_TOKEN> with the token retrieved from the developer page:
-    ```shell
-    poetry config http-basic.kolena-embeddings <KOLENA_TOKEN> ""
+    uv add --extra-index-url="https://<KOLENA_TOKEN>@gateway.kolena.cloud/repositories" kolena-embeddings
     ```
 
 This package provides the `kembed.util.extract_embeddings` method that generates

--- a/docs/dataset/quickstart.md
+++ b/docs/dataset/quickstart.md
@@ -22,10 +22,10 @@ the `kolena` Python SDK.
         pip install kolena
         ```
 
-    === "`poetry`"
+    === "`uv`"
 
         ```shell
-        poetry add kolena
+        uv add kolena
         ```
 
     Then, clone the example code:
@@ -40,7 +40,8 @@ the `kolena` Python SDK.
 
     ```shell
     cd kolena/examples/dataset/keypoint_detection
-    poetry update && poetry install
+    uv venv && source .venv/bin/activate
+    uv pip install --all-extras -r pyproject.toml
     ```
 
 ## Step 1: Upload Dataset
@@ -92,7 +93,7 @@ model testing and evaluation.
     We can now register a new dataset using the provided script:
 
     ```shell
-    poetry run python3 keypoint_detection/upload_dataset.py
+    uv run python3 keypoint_detection/upload_dataset.py
     ```
 
     After this script has completed, a new dataset named `300-W` will be created, which you can
@@ -133,8 +134,8 @@ keypoint detection model and a random keypoint model.
     which will compute metrics on a CSV of model results and upload them to Kolena.
 
     ```shell
-    poetry run python3 keypoint_detection/upload_results.py RetinaFace
-    poetry run python3 keypoint_detection/upload_results.py random
+    uv run python3 keypoint_detection/upload_results.py RetinaFace
+    uv run python3 keypoint_detection/upload_results.py random
     ```
 
     Results for two models named `RetinaFace` and `random` should now appear <somewhere>

--- a/docs/installing-kolena.md
+++ b/docs/installing-kolena.md
@@ -14,7 +14,7 @@ preferred Python package manager.
 
 SDK builds can be installed directly from
 [PyPI](https://pypi.org/project/kolena/) using any Python package manager such as [pip](https://pypi.org/project/pip/)
-or [Poetry](https://python-poetry.org/):
+or [uv](https://docs.astral.sh/uv/):
 
 === "`pip`"
 
@@ -22,10 +22,10 @@ or [Poetry](https://python-poetry.org/):
     pip install kolena
     ```
 
-=== "`poetry`"
+=== "`uv`"
 
     ```shell
-    poetry add kolena
+    uv add kolena
     ```
 
 #### Extra Dependency Groups
@@ -39,10 +39,10 @@ Certain metrics computation functionality depends on additional packages like
     pip install 'kolena[metrics]'
     ```
 
-=== "`poetry`"
+=== "`uv`"
 
     ```shell
-    poetry add 'kolena[metrics]'
+    uv add 'kolena[metrics]'
     ```
 
 ## Initialization

--- a/docs/setup_insiders.sh
+++ b/docs/setup_insiders.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-uv pip install git+ssh://git@github.com/kolenaIO/mkdocs-material-insiders.git
-uv pip install git+ssh://git@github.com/kolenaIO/mkdocstrings-python.git
+uv add git+ssh://git@github.com/kolenaIO/mkdocs-material-insiders.git --dev
+uv add git+ssh://git@github.com/kolenaIO/mkdocstrings-python.git --dev

--- a/docs/setup_insiders.sh
+++ b/docs/setup_insiders.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-poetry run pip install git+ssh://git@github.com/kolenaIO/mkdocs-material-insiders.git
-poetry run pip install git+ssh://git@github.com/kolenaIO/mkdocstrings-python.git
+uv pip install git+ssh://git@github.com/kolenaIO/mkdocs-material-insiders.git
+uv pip install git+ssh://git@github.com/kolenaIO/mkdocstrings-python.git

--- a/docs/workflow/advanced-usage/packaging-for-automated-evaluation.md
+++ b/docs/workflow/advanced-usage/packaging-for-automated-evaluation.md
@@ -180,7 +180,7 @@ ORGANIZATION=<organization>
 TARGET_IMAGE_TAG="$DOCKER_REGISTRY/$ORGANIZATION/$IMAGE_TAG"
 
 # create repository if not exist
-poetry run kolena repository create --name "$ORGANIZATION/$IMAGE_NAME"
+uv run kolena repository create --name "$ORGANIZATION/$IMAGE_NAME"
 
 echo $KOLENA_TOKEN | docker login -u "$ORGANIZATION" --password-stdin $DOCKER_REGISTRY
 
@@ -191,7 +191,7 @@ docker push $TARGET_IMAGE_TAG
 
 echo "registering image $TARGET_IMAGE_TAG for evaluator $EVALUATOR_NAME of workflow $WORKFLOW..."
 
-poetry run kolena evaluator register \
+uv run kolena evaluator register \
   --workflow "$WORKFLOW" \
   --evaluator-name "$EVALUATOR_NAME" \
   --image $TARGET_IMAGE_TAG
@@ -273,7 +273,7 @@ If you're building Docker images for a new workflow, use the `kolena` command-li
 repository must be prefixed with your organization's name.
 
 ```shell
-poetry run kolena repository create -n my-organization/new-evaluator
+uv run kolena repository create -n my-organization/new-evaluator
 ```
 
 After the repository is created, we can use the Docker CLI to publish a newly built Docker image to `docker.kolena.io`:
@@ -290,7 +290,7 @@ and pass it as the environment variable `KOLENA_EVALUATOR_SECRET` at runtime.
 Update the evaluator register command in `docker/publish.sh` to pass in sensitive data for the evaluator:
 
 ```shell
-poetry run kolena evaluator register --workflow "$WORKFLOW" \
+uv run kolena evaluator register --workflow "$WORKFLOW" \
   --evaluator-name "$EVALUATOR_NAME" \
   --image $TARGET_IMAGE_TAG \
   --secret '<your secret>'
@@ -302,7 +302,7 @@ If your evaluator requires access to AWS APIs, specify the full AWS role ARN it 
 command.
 
 ```shell
-poetry run kolena evaluator register --workflow "$WORKFLOW" \
+uv run kolena evaluator register --workflow "$WORKFLOW" \
   --evaluator-name "$EVALUATOR_NAME" \
   --image $TARGET_IMAGE_TAG \
   --aws-assume-role <target_role_arn>

--- a/docs/workflow/advanced-usage/set-up-natural-language-search.md
+++ b/docs/workflow/advanced-usage/set-up-natural-language-search.md
@@ -31,7 +31,7 @@ Let's take a look at each step with example code snippets.
 
 ### Step 1: Install `kolena_embeddings` Package
 
-The package can be installed via `pip` or `poetry` and requires use of your kolena token which can be created
+The package can be installed via `pip` or `uv` and requires use of your kolena token which can be created
 on the [:kolena-developer-16: Developer](https://app.kolena.com/redirect/developer) page.
 
 === "`pip`"
@@ -40,22 +40,10 @@ on the [:kolena-developer-16: Developer](https://app.kolena.com/redirect/develop
     pip install --extra-index-url="https://MY_KOLENA_TOKEN@gateway.kolena.cloud/repositories" kolena-embeddings
     ```
 
-=== "`poetry`"
-
-    Configure an additional poetry source:
-    ```shell
-    poetry source add --priority=supplemental kolena-embeddings "https://gateway.kolena.cloud/repositories"
-    ```
-
-    Then run the following command, making sure to replace <KOLENA_TOKEN> with the token retrieved from the developer page:
-    ```shell
-    poetry config http-basic.kolena-embeddings <KOLENA_TOKEN> ""
-    ```
-
-    Run the following command:
+=== "`uv`"
 
     ```shell
-    poetry add --source kolena-embeddings kolena-embeddings
+    uv add --extra-index-url="https://MY_KOLENA_TOKEN@gateway.kolena.cloud/repositories" kolena-embeddings
     ```
 
 This package provides the `kembed.util.extract_and_upload_embeddings` method:

--- a/docs/workflow/quickstart.md
+++ b/docs/workflow/quickstart.md
@@ -26,10 +26,10 @@ Install the `kolena` Python package to programmatically interact with Kolena:
     pip install kolena
     ```
 
-=== "`poetry`"
+=== "`uv`"
 
     ```shell
-    poetry add kolena
+    uv add kolena
     ```
 
 ## Clone the Examples

--- a/examples/dataset/age_estimation/README.md
+++ b/examples/dataset/age_estimation/README.md
@@ -5,11 +5,11 @@ open-source age estimation models to demonstrate how to test regression problems
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -24,7 +24,7 @@ This project defines two scripts that perform the following operations:
 1. [`upload_dataset.py`](age_estimation/upload_dataset.py) creates the Labeled Faces in the Wild dataset on Kolena
 
 ```shell
-$ poetry run python3 age_estimation/upload_dataset.py --help
+$ uv run age_estimation/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET]
 
 options:
@@ -38,7 +38,7 @@ The `upload_results.py` script defines command line arguments to select which mo
 `--help` flag for more information:
 
 ```shell
-$ poetry run python3 age_estimation/upload_results.py --help
+$ uv run age_estimation/upload_results.py --help
 usage: upload_results.py [-h] [--model {ssrnet,deepface}] [--dataset DATASET]
 
 options:

--- a/examples/dataset/age_estimation/pyproject.toml
+++ b/examples/dataset/age_estimation/pyproject.toml
@@ -1,22 +1,27 @@
-[tool.poetry]
+[project]
 name = "age_estimation"
 version = "0.1.0"
 description = "Example Kolena integration for age estimation"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.9,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12"
-kolena = "^1.23.0"
-s3fs = "^2023.5.0"
-fsspec = "^2023.5.0"
-numpy = "^1.19"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "fsspec>=2023.5.0,<2024",
+    "numpy>=1.19,<2",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/automatic_speech_recognition/README.md
+++ b/examples/dataset/automatic_speech_recognition/README.md
@@ -7,11 +7,11 @@ to demonstrate how to test speech recognition problems on Kolena.
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -30,7 +30,7 @@ This project defines two scripts that perform the following operations:
     Run this command to upload the dataset:
 
     ```shell
-    poetry run python3 automatic_speech_recognition/upload_dataset.py
+    uv run automatic_speech_recognition/upload_dataset.py
     ```
 
 2. [`upload_results.py`](automatic_speech_recognition/upload_results.py) tests an ASR model, e.g. `whisper-default`.
@@ -38,14 +38,14 @@ This project defines two scripts that perform the following operations:
     Run this command to evaluate the default model on the `LibriSpeech` dataset:
 
     ```shell
-    poetry run python3 automatic_speech_recognition/upload_results.py
+    uv run automatic_speech_recognition/upload_results.py
     ```
 
 Command line arguments are defined within each script to specify what model to use.
 Run a script using the `--help` flag for more information:
 
 ```shell
-$ poetry run python3 automatic_speech_recognition/upload_results.py --help
+$ uv run automatic_speech_recognition/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET] [{whisper-translate,whisper-default,wav2vec2}]
 
 positional arguments:

--- a/examples/dataset/automatic_speech_recognition/pyproject.toml
+++ b/examples/dataset/automatic_speech_recognition/pyproject.toml
@@ -1,25 +1,30 @@
-[tool.poetry]
+[project]
 name = "automatic-speech-recognition"
 version = "0.1.0"
 description = "Example Kolena integration for automatic speech recognition"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.8,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.8,<3.12"
-kolena = "^1.23.0"
-s3fs = "^2023.5.0"
-jiwer = "^3.0.3"
-langid = "^1.1.6"
-langcodes = "^3.3.0"
-numwords-to-nums = "^1.2.0"
-language-data = "^1.1"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "jiwer>=3.0.3,<4",
+    "langid>=1.1.6,<2",
+    "langcodes>=3.3.0,<4",
+    "numwords-to-nums>=1.2.0,<2",
+    "language-data>=1.1,<2",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<8",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/classification/README.md
+++ b/examples/dataset/classification/README.md
@@ -10,11 +10,11 @@ The models used in this example are
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -38,14 +38,14 @@ Command line arguments are defined within each script to specify the dataset nam
 for. Run a script using the `--help` flag for more information:
 
 ```shell
-$ poetry run python3 classification/binary/upload_dataset.py --help
+$ uv run classification/binary/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET]
 
 optional arguments:
   -h, --help         show this help message and exit
   --dataset DATASET  Optionally specify a custom dataset name to upload.
 
-$ poetry run python3 classification/binary/upload_results.py --help
+$ uv run classification/binary/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET] {resnet50v2,inceptionv3}
 
 positional arguments:
@@ -71,14 +71,14 @@ Command line arguments are defined within each script to specify the dataset nam
 for. Run a script using the `--help` flag for more information:
 
 ```shell
-$ poetry run python3 classification/multiclass/upload_dataset.py --help
+$ uv run classification/multiclass/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET]
 
 optional arguments:
   -h, --help         show this help message and exit
   --dataset DATASET  Optionally specify a custom dataset name to upload.
 
-$ poetry run python3 classification/multiclass/upload_results.py --help
+$ uv run classification/multiclass/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET] {resnet50v2,inceptionv3}
 
 positional arguments:

--- a/examples/dataset/classification/classification/__init__.py
+++ b/examples/dataset/classification/classification/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/dataset/classification/pyproject.toml
+++ b/examples/dataset/classification/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.9,<3.12"
 
-
 dependencies = [
     "kolena>=1.23.0,<2",
     "s3fs>=2023.5.0,<2024",

--- a/examples/dataset/classification/pyproject.toml
+++ b/examples/dataset/classification/pyproject.toml
@@ -1,22 +1,28 @@
-[tool.poetry]
+[project]
 name = "classification"
 version = "0.1.0"
 description = "Example Kolena integration for binary and multiclass classification"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.9,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12"
-kolena = "^1.23.0"
-s3fs = "^2023.5.0"
-fsspec = "^2023.5.0"
-numpy = "^1.19"
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "fsspec>=2023.5.0,<2024",
+    "numpy>=1.19,<2",
+]
+
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/crossing_pedestrian_detection/README.md
+++ b/examples/dataset/crossing_pedestrian_detection/README.md
@@ -26,11 +26,11 @@ and [`static_deepsort`](https://arxiv.org/abs/1703.07402).
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -46,7 +46,7 @@ This project defines two scripts that perform the following operations:
    the [JAAD]((https://data.nvision2.eecs.yorku.ca/JAAD_dataset/) ) dataset.
 
 ```shell
-$ poetry run python3 crossing_pedestrian_detection/upload_dataset.py --help
+$ uv run crossing_pedestrian_detection/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET]
 
 optional arguments:
@@ -58,7 +58,7 @@ optional arguments:
    models: `c3d_sort`, `c3d_deepsort`, `static_sort` and `static_deepsort`
 
 ```shell
-$ poetry run python3 crossing_pedestrian_detection/upload_results.py --help
+$ uv run crossing_pedestrian_detection/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET] {c3d_sort,c3d_deepsort,static_sort,static_deepsort}
 
 positional arguments:

--- a/examples/dataset/crossing_pedestrian_detection/pyproject.toml
+++ b/examples/dataset/crossing_pedestrian_detection/pyproject.toml
@@ -1,22 +1,27 @@
-[tool.poetry]
+[project]
 name = "crossing_pedestrian_detection"
 version = "0.1.0"
 description = "Example Kolena integration for Crossing Pedestrian Detection"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 readme = "README.md"
+requires-python = ">=3.8,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.8,<3.12"
-kolena = {extras = ["metrics"], version = "^1.23.0"}
-s3fs = "^2023.5.0"
-smart-open = {extras = ["s3"], version = "^7.0.1"}
-numpy = "^1.19"
+dependencies = [
+    "kolena[metrics]>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "smart-open[s3]>=7.0.1,<8",
+    "numpy>=1.19,<2",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/face_recognition_11/README.md
+++ b/examples/dataset/face_recognition_11/README.md
@@ -16,11 +16,11 @@ these corresponding thresholds.
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -45,14 +45,14 @@ Command line arguments are defined within each script to specify the dataset nam
 for. Run a script using the `--help` flag for more information:
 
 ```shell
-$ poetry run python3 face_recognition_11/upload_dataset.py --help
+$ uv run face_recognition_11/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET]
 
 optional arguments:
   -h, --help         show this help message and exit
   --dataset DATASET  Optionally specify a custom dataset name to upload.
 
-$ poetry run python3 face_recognition_11/upload_results.py --help
+$ uv run face_recognition_11/upload_results.py --help
 usage: upload_results.py [-h] [--model {vgg-face,facenet512}] [--detector {mtcnn,dlib}] [--dataset DATASET]
 
 optional arguments:

--- a/examples/dataset/face_recognition_11/pyproject.toml
+++ b/examples/dataset/face_recognition_11/pyproject.toml
@@ -1,21 +1,27 @@
-[tool.poetry]
+[project]
 name = "face_recognition_11"
 version = "0.1.0"
 description = "Example Kolena integration for face recognition 1:1"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.9,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12"
-kolena = ">=1.23.0"
-s3fs = "^2023.5.0"
-numpy = "^1"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "fsspec>=2023.5.0,<2024",
+    "numpy>=1.19,<2",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/image_retrieval_by_text/README.md
+++ b/examples/dataset/image_retrieval_by_text/README.md
@@ -6,11 +6,11 @@ license are included.
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 Optionally download the COCO images from our s3 bucket to a directory if you want to run inference in real time
@@ -34,7 +34,7 @@ This project defines two scripts that perform the following operations:
 dataset.
 
 ```shell
-$ poetry run python3 image_retrieval_by_text/upload_dataset.py --help
+$ uv run image_retrieval_by_text/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET]
 
 optional arguments:
@@ -49,7 +49,7 @@ The `upload_results.py` script defines command line arguments to select which mo
 `--help` flag for more information:
 
 ```shell
-$ poetry run python3 image_retrieval_by_text/upload_results.py --help
+$ uv run image_retrieval_by_text/upload_results.py --help
 usage: upload_results.py [-h] [--model {kakaobrain/align-base,google/siglip-base-patch16-224,BAAI/AltCLIP,openai/clip-vit-base-patch32}]
                          [--dataset DATASET] [--run-inference RUN_INFERENCE] [--local-image-dir LOCAL_IMAGE_DIR]
 

--- a/examples/dataset/image_retrieval_by_text/pyproject.toml
+++ b/examples/dataset/image_retrieval_by_text/pyproject.toml
@@ -1,32 +1,32 @@
-[tool.poetry]
+[project]
 name = "image_retrieval_by_text"
 version = "0.1.0"
 description = "Example Kolena integration for Image Retrieval by Text"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.9,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.13"
-kolena = {extras = ["metrics"], version = "^1.23.0"}
-s3fs = "^2023.5.0"
-numpy = "^1.26.4"
-pillow = "^10.2.0"
-pre-commit = "^3.6.2"
-torch = "^2.2.1"
-transformers = "^4.38.1"
-boto3 = ">=1.34.41,<1.34.52"
-sentencepiece = "^0.2.0"
-protobuf = "^4.25.3"
-scipy = [  # transient dependency of scikit-learn, pin required to unbreak installs on specific Python versions
-    { version = ">=1,<1.11", python = ">=3.8,<3.9", optional = true },
-    { version = ">=1,<1.14", python = ">=3.9,<3.10", optional = true },
-    { version = ">=1.12,<2", python = ">=3.12", optional = true }
+dependencies = [
+    "kolena[metrics]>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "numpy>=1.26.4,<2",
+    "pillow>=10.2.0,<11",
+    "torch>=2.2.1,<3",
+    "transformers>=4.38.1,<5",
+    "boto3>=1.34.41,<1.34.52",
+    "sentencepiece>=0.2.0,<1",
+    "protobuf>=4.25.3,<5",
 ]
 
-[tool.poetry.group.dev.dependencies]
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/keypoint_detection/README.md
+++ b/examples/dataset/keypoint_detection/README.md
@@ -5,11 +5,11 @@ to demonstrate testing keypoint detection models on Kolena.
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -31,14 +31,14 @@ Command line arguments are defined within each script to specify the dataset nam
 for. Run a script using the `--help` flag for more information:
 
 ```shell
-$ poetry run python3 keypoint_detection/upload_dataset.py --help
+$ uv run keypoint_detection/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET]
 
 optional arguments:
   -h, --help         show this help message and exit
   --dataset DATASET  Optionally specify a custom dataset name to upload.
 
-$ poetry run python3 keypoint_detection/upload_results.py --help
+$ uv run keypoint_detection/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET] {retinaface,random}
 
 positional arguments:

--- a/examples/dataset/keypoint_detection/pyproject.toml
+++ b/examples/dataset/keypoint_detection/pyproject.toml
@@ -1,22 +1,26 @@
-[tool.poetry]
+[project]
 name = "keypoint_detection"
 version = "0.1.0"
 description = "Example Kolena integration for keypoint detection"
-authors = ["Kolena Engineering <eng@kolena.com>"]
-license = "Apache-2.0"
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
+requires-python = ">=3.9,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12"
-kolena = "^1.23.0"
-s3fs = "^2023.5.0"
-fsspec = "^2023.5.0"
-numpy = "^1.19"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "fsspec>=2023.5.0,<2024",
+    "numpy>=1.19,<2",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/named_entity_recognition/README.md
+++ b/examples/dataset/named_entity_recognition/README.md
@@ -5,11 +5,11 @@ dataset to demonstrate testing named entity recognition models on Kolena.
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 #### Data
@@ -35,14 +35,14 @@ Command line arguments are defined within each script to specify the dataset nam
 for. Run a script using the `--help` flag for more information:
 
 ```shell
-$ poetry run python3 named_entity_recognition/upload_dataset.py --help
+$ uv run named_entity_recognition/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET]
 
 optional arguments:
   -h, --help         show this help message and exit
   --dataset DATASET  Optionally specify a custom dataset name to upload.
 
-$ poetry run python3 named_entity_recognition/upload_results.py --help
+$ uv run named_entity_recognition/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET] {bert,roberta}
 
 positional arguments:

--- a/examples/dataset/named_entity_recognition/README.md
+++ b/examples/dataset/named_entity_recognition/README.md
@@ -9,6 +9,8 @@ This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python depe
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
+# Include if using torch on cpu
+export UV_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu/"
 uv sync
 ```
 

--- a/examples/dataset/named_entity_recognition/named_entity_recognition/__init__.py
+++ b/examples/dataset/named_entity_recognition/named_entity_recognition/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/dataset/named_entity_recognition/named_entity_recognition/constants.py
+++ b/examples/dataset/named_entity_recognition/named_entity_recognition/constants.py
@@ -11,9 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Any
+from typing import Dict
+
 DATASET = "n2c2-2014"
 MODELS = ["roberta", "bert"]
-MODEL_INFO = {
+MODEL_INFO: Dict[str, Dict[str, Any]] = {
     "roberta": {"name": "obi/deid_roberta_i2b2"},
     "bert": {"name": "obi/deid_bert_i2b2", "max_length": 512},
 }

--- a/examples/dataset/named_entity_recognition/pyproject.toml
+++ b/examples/dataset/named_entity_recognition/pyproject.toml
@@ -1,20 +1,26 @@
-[tool.poetry]
+[project]
 name = "named-entity-recognition"
 version = "0.1.0"
 description = "Example Kolena integration for a named entity recognition problem"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
+requires-python = ">=3.9,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12"
-kolena = "^1.29.0"
-pandas = "^2.2.2"
-transformers = "^4.43.3"
-torch = "^2.4.0"
+dependencies = [
+    "kolena>=1.29.0,<2",
+    "pandas>=2.2.2,<3",
+    "transformers>=4.43.3,<5",
+    "torch>=2.4.0,<3",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/object_detection_2d/README.md
+++ b/examples/dataset/object_detection_2d/README.md
@@ -6,11 +6,11 @@ object detection problems on Kolena. Only images with the
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -26,7 +26,7 @@ This project defines two scripts that perform the following operations:
 dataset - only transportation relevant object annotations are used in this example.
 
 ```shell
-$ poetry run python3 object_detection_2d/upload_dataset.py --help
+$ uv run object_detection_2d/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET]
 
 optional arguments:
@@ -41,7 +41,7 @@ The `upload_results.py` script defines command line arguments to select which mo
 `--help` flag for more information:
 
 ```shell
-$ poetry run python3 object_detection_2d/upload_results.py --help
+$ uv run object_detection_2d/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET] {yolo_r,yolo_x,mask_rcnn,faster_rcnn,yolo_v4s,yolo_v3}
 
 positional arguments:

--- a/examples/dataset/object_detection_2d/pyproject.toml
+++ b/examples/dataset/object_detection_2d/pyproject.toml
@@ -1,22 +1,27 @@
-[tool.poetry]
+[project]
 name = "object_detection_2d"
 version = "0.1.0"
 description = "Example Kolena integration for Object Detection 2D"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.9,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12"
-kolena = {extras = ["metrics"], version = "^1.23.0"}
-s3fs = "^2023.5.0"
-fsspec = "^2023.5.0"
-numpy = "^1.19"
+dependencies = [
+    "kolena[metrics]>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "fsspec>=2023.5.0,<2024",
+    "numpy>=1.19,<2",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/object_detection_3d/README.md
+++ b/examples/dataset/object_detection_3d/README.md
@@ -35,11 +35,11 @@ F1-optimal configurations for difficulty: `easy`,`moderate`, and `hard`.
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 This example integration will use pre-trained models provided by
@@ -60,7 +60,7 @@ This project defines two scripts that perform the following operations:
    the [KITTI](https://www.cvlibs.net/datasets/kitti/eval_object.php?obj_benchmark=3d) dataset.
 
 ```shell
-$ poetry run python3 object_detection_3d/upload_dataset.py --help
+$ uv run object_detection_3d/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET]
 
 optional arguments:
@@ -75,7 +75,7 @@ The `upload_results.py` script defines command line arguments to select which mo
 `--help` flag for more information:
 
 ```shell
-$ poetry run python3 object_detection_3d/upload_results.py --help
+$ uv run object_detection_3d/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET]
                          {parta2_hv_secfpn_8xb2-cyclic-80e_kitti-3d-3class,pointpillars_hv_secfpn_8xb6-160e_kitti-3d-3class}
 

--- a/examples/dataset/object_detection_3d/pyproject.toml
+++ b/examples/dataset/object_detection_3d/pyproject.toml
@@ -1,25 +1,32 @@
-[tool.poetry]
+[project]
 name = "object_detection_3d"
 version = "0.1.0"
 description = "Example Kolena integration for KITTI 3D object detection"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.8,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.8,<3.12"
-kolena = "^1.23.0"
-pydantic = ">=2,<3"
-openmim = "^0.3.9"
-mmcv-lite = ">=2.0.0rc4"
-mmdet = ">=3.0.0"
-mmdet3d = ">=1.1.0"
-s3fs = "^2024.2.0"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2024.2.0,<2025",
+    "fsspec>=2023.5.0,<2024",
+    "numpy>=1.19,<2",
+    "pydantic>=2,<3",
+    "openmim>=0.3.9,<1",
+    "mmcv-lite>=2.0.0rc4,<3",
+    "mmdet>=3.0.0,<4",
+    "mmdet3d>=1.1.0,<2",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/person_detection/README.md
+++ b/examples/dataset/person_detection/README.md
@@ -11,11 +11,11 @@ provide a `figure` field for pose reference.
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -32,7 +32,7 @@ dataset - only person relevant object annotations are used in this example. This
 the person keypoints provided with the coco-2014-val annotations.
 
 ```shell
-$ poetry run python3 person_detection/upload_dataset.py --help
+$ uv run person_detection/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET]
 
 optional arguments:
@@ -47,7 +47,7 @@ The `upload_results.py` script defines command line arguments to select which mo
 `--help` flag for more information:
 
 ```shell
-$ poetry run python3 person_detection/upload_results.py --help
+$ uv run person_detection/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET] {yolo_r,yolo_x,mask_rcnn,faster_rcnn,yolo_v4s,yolo_v3}
 
 positional arguments:

--- a/examples/dataset/person_detection/pyproject.toml
+++ b/examples/dataset/person_detection/pyproject.toml
@@ -1,21 +1,26 @@
-[tool.poetry]
+[project]
 name = "person-detection"
 version = "0.1.0"
 description = "Example Kolena integration for COCO Person Detection"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.9,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12"
-kolena = {extras = ["metrics"], version = "^1.23.0"}
-s3fs = "^2023.5.0"
-numpy = "^1.19"
+dependencies = [
+    "kolena[metrics]>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "numpy>=1.19,<2",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/question_answering/README.md
+++ b/examples/dataset/question_answering/README.md
@@ -6,11 +6,11 @@ to demonstrate the question answering workflow in Kolena.
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -42,7 +42,7 @@ Command line arguments are defined within each script to specify the dataset nam
 for. Run a script using the `--help` flag for more information:
 
 ```shell
-$ poetry run python3 question_answering/upload_dataset.py --help
+$ uv run question_answering/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--datasets {TruthfulQA,HaluEval-QA} [{TruthfulQA,HaluEval-QA} ...]]
 
 optional arguments:
@@ -50,7 +50,7 @@ optional arguments:
   --datasets {TruthfulQA,HaluEval-QA} [{TruthfulQA,HaluEval-QA} ...]
                         Name(s) of the dataset(s) to register.
 
-$ poetry run python3 question_answering/prepare_results.py --help
+$ uv run question_answering/prepare_results.py --help
 usage: upload_dataset.py [-h] [--datasets {TruthfulQA,HaluEval-QA} [{TruthfulQA,HaluEval-QA} ...]]
 
 optional arguments:
@@ -58,7 +58,7 @@ optional arguments:
   --datasets {TruthfulQA,HaluEval-QA} [{TruthfulQA,HaluEval-QA} ...]
                         Name(s) of the dataset(s) to register.
 
-$ poetry run python3 question_answering/upload_results.py --help
+$ uv run question_answering/upload_results.py --help
 usage: upload_results.py [-h] [--datasets {TruthfulQA,HaluEval-QA} [{TruthfulQA,HaluEval-QA} ...]]
                          [--models {gpt-3.5-turbo,gpt-4-1106-preview} [{gpt-3.5-turbo,gpt-4-1106-preview} ...]]
 

--- a/examples/dataset/question_answering/README.md
+++ b/examples/dataset/question_answering/README.md
@@ -10,6 +10,8 @@ This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python depe
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
+# Include if using torch on cpu
+export UV_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu/"
 uv sync
 ```
 

--- a/examples/dataset/question_answering/pyproject.toml
+++ b/examples/dataset/question_answering/pyproject.toml
@@ -1,34 +1,35 @@
-[tool.poetry]
+[project]
 name = "question_answering"
 version = "0.1.0"
 description = "Example Kolena integration for question answering"
-authors = ["Kolena Engineering <eng@kolena.com>"]
-license = "Apache-2.0"
-
-[tool.poetry.dependencies]
-python = ">=3.9,<3.11"
-kolena = "^1.23.0"
-s3fs = "^2022.7.1"
-torch = [
-  {markers = "sys_platform == 'darwin' and platform_machine == 'arm64'", url = "https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_11_0_arm64.whl"},
-  {markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", url = "https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_10_9_x86_64.whl"},
-  {markers = "sys_platform != 'darwin'", version = "2.1.2", source = "torch+cpu"}
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
 ]
-sentence-transformers = "^2.2.2"
-openai = "^1.6.0"
-protobuf = "^4.25.1"
-numpy = "^1.19"
+license = "Apache-2.0"
+requires-python = ">=3.9,<3.12"
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "sentence-transformers>=2.2.2,<3",
+    "openai>=1.6.0,<2",
+    "protobuf>=4.25.1,<5",
+    "numpy>=1.19,<2",
+    "torch @ https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_11_0_arm64.whl; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "torch @ https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_10_9_x86_64.whl; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "torch == 2.1.2 @ https://download.pytorch.org/whl/cpu/; sys_platform != 'darwin'",
+]
 
-[[tool.poetry.source]]
-name = "torch+cpu"
-url = "https://download.pytorch.org/whl/cpu/"
-priority = "explicit"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true # to allow the syntax 'pkg @ url' in dependencies

--- a/examples/dataset/question_answering/pyproject.toml
+++ b/examples/dataset/question_answering/pyproject.toml
@@ -10,14 +10,12 @@ requires-python = ">=3.9,<3.12"
 
 dependencies = [
     "kolena>=1.23.0,<2",
-    "s3fs>=2023.5.0,<2024",
+    "s3fs>=2023.5.0",
     "sentence-transformers>=2.2.2,<3",
     "openai>=1.6.0,<2",
     "protobuf>=4.25.1,<5",
     "numpy>=1.19,<2",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_11_0_arm64.whl; sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_10_9_x86_64.whl; sys_platform == 'darwin' and platform_machine == 'x86_64'",
-    "torch == 2.1.2 @ https://download.pytorch.org/whl/cpu/; sys_platform != 'darwin'",
+    "torch==2.1.2",
 ]
 
 [tool.uv]
@@ -30,6 +28,3 @@ dev-dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.hatch.metadata]
-allow-direct-references = true # to allow the syntax 'pkg @ url' in dependencies

--- a/examples/dataset/rain_forecast/README.md
+++ b/examples/dataset/rain_forecast/README.md
@@ -6,11 +6,11 @@ demonstrate testing rain forecast models on Kolena.
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -30,7 +30,7 @@ The `upload_results.py` script defines command line arguments to select which mo
 `--help` flag for more information:
 
 ```shell
-$ poetry run python3 rain_forecast/upload_results.py --help
+$ uv run rain_forecast/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET] {ann,logreg}
 
 positional arguments:

--- a/examples/dataset/rain_forecast/pyproject.toml
+++ b/examples/dataset/rain_forecast/pyproject.toml
@@ -1,20 +1,25 @@
-[tool.poetry]
+[project]
 name = "rain_forecast"
 version = "0.1.0"
 description = "Kolena Datasets Example integration for rain forecast"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.8,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.8,<3.11"
-kolena = "^1.23.0"
-s3fs = "^2022.7.1"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/search_embeddings/README.md
+++ b/examples/dataset/search_embeddings/README.md
@@ -9,12 +9,12 @@ this data has already been uploaded to your Kolena platform.
 
 1. Ensure that data for the [`semantic_segmentation`](../semantic_segmentation) dataset has been seeded through calling
 the [`upload_dataset.py`](../semantic_segmentation/semantic_segmentation/upload_dataset.py) script.
-2. Install the kolena-embeddings package via the natural language search [instructions](https://docs.kolena.com/dataset/advanced-usage/set-up-natural-language-search/#poetry)
-3. This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. Install project
+2. Install the kolena-embeddings package via the natural language search [instructions](https://docs.kolena.com/dataset/advanced-usage/set-up-natural-language-search/#uv)
+3. This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. Install project
 dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 4. [Recommended] Download test images to a local path for faster embedding extraction:
@@ -35,7 +35,7 @@ First, ensure that the `KOLENA_TOKEN` environment variable is populated in your 
 embeddings or uses pre-extracted embeddings, and uploads them to the Kolena platform.
 
 ```shell
-$ poetry run python3 search_embeddings/upload_embeddings.py --help
+$ uv run search_embeddings/upload_embeddings.py --help
 usage: upload_embeddings.py [-h] [--run-extraction {True,False}] [--dataset-name DATASET_NAME] [--local-path LOCAL_PATH]
 
 options:

--- a/examples/dataset/search_embeddings/pyproject.toml
+++ b/examples/dataset/search_embeddings/pyproject.toml
@@ -1,24 +1,30 @@
-[tool.poetry]
+[project]
 name = "search_embeddings"
 version = "0.1.0"
 description = "Example Kolena dataset embeddings extraction logic"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.8,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.8,<3.13"
-kolena = "^1.23.0"
-s3fs = "^2023.5.0"
-kolena-embeddings = {version = "^0.6.0", source = "kolena-embeddings"}
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "numpy>=1.19,<2",
+    "kolena-embeddings >= 0.6.0 @ https://gateway.kolena.cloud/repositories",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-
-[[tool.poetry.source]]
-name = "kolena-embeddings"
-url = "https://gateway.kolena.cloud/repositories"
-priority = "supplemental"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true # to allow the syntax 'pkg @ url' in dependencies

--- a/examples/dataset/semantic_segmentation/README.md
+++ b/examples/dataset/semantic_segmentation/README.md
@@ -8,11 +8,11 @@ images with the [Attribution License](http://creativecommons.org/licenses/by/2.0
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -47,7 +47,7 @@ upload.
 Run a script using the `--help` flag for more information:
 
 ```shell
-$ poetry run python3 semantic_segmentation/upload_results.py --help
+$ uv run semantic_segmentation/upload_results.py --help
 usage: upload_results.py [-h] --write-bucket WRITE_BUCKET [--dataset DATASET]
                          [{pspnet_r101,pspnet_r50}]
 

--- a/examples/dataset/semantic_segmentation/pyproject.toml
+++ b/examples/dataset/semantic_segmentation/pyproject.toml
@@ -1,26 +1,30 @@
-[tool.poetry]
+[project]
 name = "semantic_segmentation"
 version = "0.1.0"
 description = "Kolena Datasets Example integration for semantic segmentation"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.8,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.8,<3.12"
-opencv-python-headless = ">=4.6.0.66,<4.7"
-kolena = "^1.23.0"
-s3fs = "^2023.5.0"
-fsspec = "^2023.5.0"
-boto3 = "^1.25"
-scikit-learn = "^1.1.2"
-scikit-image = "^0.19.3"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "fsspec>=2023.5.0,<2024",
+    "opencv-python-headless>=4.6.0.66,<4.7",
+    "boto3>=1.25,<2",
+    "scikit-learn>=1.1.2,<2",
+    "scikit-image>=0.19.3,<1",
+]
 
-
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/semantic_textual_similarity/README.md
+++ b/examples/dataset/semantic_textual_similarity/README.md
@@ -5,11 +5,11 @@ open-source sentence transformer models to demonstrate how to test semantic text
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -30,7 +30,7 @@ Command line arguments are defined within each script to specify the dataset nam
 for. Run a script using the `--help` flag for more information:
 
 ```shell
-$ poetry run python3 semantic_textual_similarity/upload_dataset.py --help
+$ uv run semantic_textual_similarity/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset-csv DATASET_CSV] [--dataset DATASET]
 
 options:
@@ -40,7 +40,7 @@ options:
                         details
   --dataset DATASET     Optionally specify a name of the dataset to upload.
 
-$ poetry run python3 semantic_textual_similarity/upload_results.py --help
+$ uv run semantic_textual_similarity/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET]
                          {distilroberta,MiniLM-L12,mpnet-base}
 

--- a/examples/dataset/semantic_textual_similarity/pyproject.toml
+++ b/examples/dataset/semantic_textual_similarity/pyproject.toml
@@ -1,22 +1,27 @@
-[tool.poetry]
+[project]
 name = "semantic_textual_similarity"
 version = "0.1.0"
 description = "Example Kolena integration for semantic textual similarity"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.9,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12"
-kolena = "^1.23.0"
-s3fs = "^2023.5.0"
-fsspec = "^2023.5.0"
-numpy = "^1.19"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "fsspec>=2023.5.0,<2024",
+    "numpy>=1.19,<2",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/speaker_diarization/README.md
+++ b/examples/dataset/speaker_diarization/README.md
@@ -6,11 +6,11 @@ on Kolena.
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -30,7 +30,7 @@ This project defines two scripts that perform the following operations:
    Run this command to create the default dataset:
 
     ```shell
-    poetry run python3 speaker_diarization/upload_dataset.py
+    uv run speaker_diarization/upload_dataset.py
     ```
 
 2. [`upload_results.py`](speaker_diarization/upload_results.py) uploads the results of model
@@ -39,14 +39,14 @@ This project defines two scripts that perform the following operations:
    Run this command to upload results of model `gcp-stt-video` for the above dataset:
 
     ```shell
-    poetry run python3 speaker_diarization/upload_results.py
+    uv run speaker_diarization/upload_results.py
     ```
 
 Command line arguments are defined within each script to specify the dataset name to create or
 upload results for. Run a script using the `--help` flag for more information:
 
 ```shell
-$ poetry run python3 speaker_diarization/upload_dataset.py --help
+$ uv run speaker_diarization/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset DATASET] [--sample-count SAMPLE_COUNT]
 
 optional arguments:
@@ -55,7 +55,7 @@ optional arguments:
   --sample-count SAMPLE_COUNT
                         Number of samples to use. All samples are used by default.
 
-$ poetry run python3 speaker_diarization/upload_results.py --help
+$ uv run speaker_diarization/upload_results.py --help
 usage: upload_results.py [-h] [--dataset DATASET] [--align-speakers] [--sample-count SAMPLE_COUNT]
 
 optional arguments:

--- a/examples/dataset/speaker_diarization/pyproject.toml
+++ b/examples/dataset/speaker_diarization/pyproject.toml
@@ -1,24 +1,29 @@
-[tool.poetry]
+[project]
 name = "speaker-diarization"
 version = "0.1.0"
 description = "Example Kolena integration for speaker diarization"
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 license = "Apache-2.0"
+requires-python = ">=3.9,<3.12"
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12"
-kolena = "^1.23.0"
-pyannote-metrics = "^3.2.1"
-s3fs = "^2023.10.0"
-pyannote-core = "^5.0.0"
-jiwer = "^3.0.3"
-numpy = "^1.19"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.10.0,<2024",
+    "numpy>=1.19,<2",
+    "pyannote-metrics>=3.2.1,<4",
+    "pyannote-core>=5.0.0,<6",
+    "jiwer>=3.0.3,<4",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/text_summarization/README.md
+++ b/examples/dataset/text_summarization/README.md
@@ -7,11 +7,11 @@ problems on Kolena.
 
 ## Setup
 
-This project uses [Poetry](https://python-poetry.org/) for packaging and Python dependency management. To get started,
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
 install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
 
 ```shell
-poetry update && poetry install
+uv sync
 ```
 
 ## Usage
@@ -33,7 +33,7 @@ Command line arguments are defined within each script to specify the dataset nam
 for. Run a script using the `--help` flag for more information:
 
 ```shell
-$ poetry run python3 text_summarization/upload_dataset.py --help
+$ uv run text_summarization/upload_dataset.py --help
 usage: upload_dataset.py [-h] [--dataset-csv DATASET_CSV] [--dataset-name DATASET_NAME]
 
 optional arguments:
@@ -43,7 +43,7 @@ optional arguments:
   --dataset DATASET
                         Optionally specify a name of the dataset to upload.
 
-$ poetry run python3 text_summarization/upload_results.py --help
+$ uv run text_summarization/upload_results.py --help
 usage: upload_results.py [-h] [--models {ada,babbage,curie,davinci,turbo} [{ada,babbage,curie,davinci,turbo} ...]]
                          [--dataset DATASET]
 

--- a/examples/dataset/text_summarization/pyproject.toml
+++ b/examples/dataset/text_summarization/pyproject.toml
@@ -33,17 +33,3 @@ dev-dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# TODO Remove after validating that everything else works for CI
-# Transient dependency of `bert-score` -- pin to CPU-only to unbreak CI. This can be safely removed on GPU systems
-# Further reading: https://github.com/python-poetry/poetry/issues/6409#issuecomment-1310655479
-# torch = [
-#   {markers = "sys_platform == 'darwin' and platform_machine == 'arm64'", url = "https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_11_0_arm64.whl"},
-#   {markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", url = "https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_10_9_x86_64.whl"},
-#   {markers = "sys_platform != 'darwin'", version = "2.1.2", source = "torch+cpu"}
-# ]
-#
-# [[tool.poetry.source]]
-# name = "torch+cpu"
-# url = "https://download.pytorch.org/whl/cpu"
-# priority = "explicit"

--- a/examples/dataset/text_summarization/pyproject.toml
+++ b/examples/dataset/text_summarization/pyproject.toml
@@ -1,41 +1,49 @@
-[tool.poetry]
+[project]
 name = "text_summarization"
 version = "0.1.0"
 description = "Example Kolena integration for text summarization"
-authors = ["Kolena Engineering <eng@kolena.com>"]
-license = "Apache-2.0"
-
-[tool.poetry.dependencies]
-python = ">=3.8,<3.11"
-kolena = "^1.23.0"
-s3fs = "^2022.7.1"
-scikit-learn = "^1.1.2"
-numba = "^0.56.0"
-opencv-python-headless = "^4.6.0"
-# Transient dependency of `bert-score` -- pin to CPU-only to unbreak CI. This can be safely removed on GPU systems
-# Further reading: https://github.com/python-poetry/poetry/issues/6409#issuecomment-1310655479
-torch = [
-  {markers = "sys_platform == 'darwin' and platform_machine == 'arm64'", url = "https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_11_0_arm64.whl"},
-  {markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", url = "https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_10_9_x86_64.whl"},
-  {markers = "sys_platform != 'darwin'", version = "2.1.2", source = "torch+cpu"}
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
 ]
-evaluate = "^0.4.0"
-bert-score = "^0.3.13"
-absl-py = "^1.4.0"
-nltk = "^3.8.1"
-rouge-score = "^0.1.2"
-sacrebleu = "^2.3.1"
+license = "Apache-2.0"
+requires-python = ">=3.8,<3.12"
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-pytest = "^7"
-pytest-depends = "^1.0.1"
+dependencies = [
+    "kolena>=1.23.0,<2",
+    "s3fs>=2023.5.0,<2024",
+    "numpy>=1.19,<2",
+    "scikit-learn>=1.1.2,<2",
+    "numba>=0.56.0,<1",
+    "opencv-python-headless>=4.6.0,<5",
+    "evaluate>=0.4.0,<1",
+    "bert-score>=0.3.13,<1",
+    "absl-py>=1.4.0,<2",
+    "nltk>=3.8.1,<4",
+    "rouge-score>=0.1.2,<1",
+    "sacrebleu>=2.3.1,<3",
+]
 
-[[tool.poetry.source]]
-name = "torch+cpu"
-url = "https://download.pytorch.org/whl/cpu"
-priority = "explicit"
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+# TODO Remove after validating that everything else works for CI
+# Transient dependency of `bert-score` -- pin to CPU-only to unbreak CI. This can be safely removed on GPU systems
+# Further reading: https://github.com/python-poetry/poetry/issues/6409#issuecomment-1310655479
+# torch = [
+#   {markers = "sys_platform == 'darwin' and platform_machine == 'arm64'", url = "https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_11_0_arm64.whl"},
+#   {markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", url = "https://download.pytorch.org/whl/cpu/torch-2.1.2-cp39-none-macosx_10_9_x86_64.whl"},
+#   {markers = "sys_platform != 'darwin'", version = "2.1.2", source = "torch+cpu"}
+# ]
+#
+# [[tool.poetry.source]]
+# name = "torch+cpu"
+# url = "https://download.pytorch.org/whl/cpu"
+# priority = "explicit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ classifiers = [# classifiers for license, versions set automatically during Poet
 packages = [
     { include = "kolena" }
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.9,<3.13"
+# TODO BEFORE MERGE include 3.8 as a valid python version
+# requires-python = ">=3.8,<3.13"
 
 dependencies = [
     "numpy >=1.19,<2; python_version < '3.11'",
@@ -56,20 +58,6 @@ metrics = [
     "scipy >=1,<1.14; python_version >= '3.9' and python_version < '3.12'",
     "scipy >=1.12,<2; python_version >= '3.12'",
 ]
-# mkdocstrings = { version = ">0.20,<1", extras = ["python"] }
-# black = { version = "^22.1.0", allow-prereleases = true }
-dev = [
-    "pre-commit>=2.17,<3",
-    "pytest>=7,<8",
-    "pytest-cov>=4.0.0,<5",
-    "pytest-depends>=1.0.1,<2",
-    "mkdocs>=1.4.3,<2",
-    "cairosvg>=2.7.0,<3",
-    # insiders fork installed out-of-band in docs/setup_insiders.sh
-    "mkdocs-material>=9.2,<10",
-    "mkdocs-git-committers-plugin-2>=1,<2",
-    "mkdocs-git-revision-date-localized-plugin>=1,<2",
-]
 
 [tool.poetry.scripts]
 kolena = 'kolena._utils.cli:run'
@@ -87,4 +75,20 @@ python_classes = []
 python_functions = ["test__*"]
 markers = [
     "metrics: tests that require the metrics extra dependency such as sklearn",
+]
+
+[tool.uv]
+dev-dependencies = [
+    "black>=22.1.0,<23",
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-cov>=4.0.0,<5",
+    "pytest-depends>=1.0.1,<2",
+    "mkdocs>=1.4.3,<2",
+    "cairosvg>=2.7.0,<3",
+    # insiders fork installed out-of-band in docs/setup_insiders.sh
+    "mkdocs-material>=9.2,<10",
+    "mkdocstrings[python]>=0.20,<1",
+    "mkdocs-git-committers-plugin-2>=1,<2",
+    "mkdocs-git-revision-date-localized-plugin>=1,<2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,10 @@ packages = [
 requires-python = ">=3.8,<3.13"
 
 dependencies = [
-    "numpy >=1.19,<2",
-    "pandas >=1.1,<3",
+    "numpy >=1.19,<2; python_version < '3.12'",
+    "numpy >=1.26,<2; python_version >= '3.12'",
+    "pandas >=1.1,<3; python_version < '3.12'",
+    "pandas >=2.1.1,<3; python_version >= '3.12'",
     "pandera>=0.9,<1",
     "pydantic>=1.10,<3",
     "dacite>=1.6,<2",
@@ -67,6 +69,7 @@ markers = [
 ]
 
 [tool.uv]
+environments = ["python_version < '3.12'", "python_version >= '3.12' and python_version < '3.13'"]
 dev-dependencies = [
     "black>=22.1.0,<23",
     "pre-commit>=2.17,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dev-dependencies = [
     # insiders fork installed out-of-band in docs/setup_insiders.sh
     "mkdocs-material>=9.2,<10",
     "mkdocstrings>=0.25,<1",
-    "mkdocstrings-python>=0.5,<1",
+    "mkdocstrings-python>=1.11.1,<2",
     "mkdocs-git-committers-plugin-2>=1,<2",
     "mkdocs-git-revision-date-localized-plugin>=1,<2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ metrics = [
     "scipy >=1,<2",
 ]
 
+[project.scripts]
+kolena = 'kolena._utils.cli:run'
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,12 @@ dev-dependencies = [
     "cairosvg>=2.7.0,<3",
     # insiders fork installed out-of-band in docs/setup_insiders.sh
     "mkdocs-material>=9.2,<10",
-    "mkdocstrings[python]>=0.20,<1",
+    "mkdocstrings>=0.25,<1",
+    "mkdocstrings-python>=0.5,<1",
     "mkdocs-git-committers-plugin-2>=1,<2",
     "mkdocs-git-revision-date-localized-plugin>=1,<2",
 ]
+
+[tool.uv.sources]
+mkdocs-material = { git = "ssh://git@github.com/kolenaIO/mkdocs-material-insiders.git" }
+mkdocstrings-python = { git = "ssh://git@github.com/kolenaIO/mkdocstrings-python.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
-[tool.poetry]
+[project]
 name = "kolena"
 version = "0.999.0"  # version is automatically set to latest git tag during release process
 description = "Client for Kolena's machine learning testing platform."
-authors = ["Kolena Engineering <eng@kolena.com>"]
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
 homepage = "https://kolena.com"
 documentation = "https://docs.kolena.com"
 readme = "README.md"
@@ -23,61 +25,58 @@ classifiers = [# classifiers for license, versions set automatically during Poet
 packages = [
     { include = "kolena" }
 ]
+requires-python = ">=3.8,<3.13"
 
-[tool.poetry.dependencies]
-python = ">=3.8,<3.13"
-numpy = [
-    { version = ">=1.19,<2", python = ">=3.8,<3.11" },
-    { version = ">=1.23,<2", python = ">=3.11,<3.12" },
-    { version = ">=1.26,<2", python = ">=3.12" },
+dependencies = [
+    "numpy >=1.19,<2; python_version < '3.11'",
+    "numpy >=1.23,<2; python_version == '3.11'",
+    "numpy >=1.26,<2; python_version >= '3.12'",
+    "pandas >=1.1,<3; python_version < '3.11'",
+    "pandas >=1.5,<3; python_version == '3.11'",
+    "pandas >=2.1.1,<3; python_version >= '3.12'",
+    "pandera>=0.9,<1",
+    "pydantic>=1.10,<3",
+    "dacite>=1.6,<2",
+    "requests>=2.20,<3",
+    "requests-toolbelt>=1.0.0,<2",
+    "tqdm>=4,<5",
+    "Pillow>=10.0.1,<11",
+    "retrying>=1.3.3,<2",
+    "Shapely>=1.8.5,<3",
+    "termcolor>=1.1,<3",
+    "pyarrow>=8",
+    "click>=8",
+    "lzstring>=1.0.4,<2",
 ]
-pandas = [
-    { version = ">=1.1,<3", python = ">=3.8,<3.11" },
-    { version = ">=1.5,<3", python = ">=3.11,<3.12" },
-    { version = ">=2.1.1,<3", python = ">=3.12" },
-]
-pandera = ">=0.9,<1"
-pydantic = ">=1.10,<3"
-dacite = ">=1.6,<2"
-requests = ">=2.20,<3"
-requests-toolbelt = "*"
-tqdm = ">=4,<5"
-Pillow = ">=10.0.1,<11"
-retrying = ">=1.3.3,<2"
-Shapely = ">=1.8.5,<3"
-termcolor = ">=1.1,<3"
-pyarrow = ">=8"
-click = ">=8"
-scikit-learn = { version = ">=1.2,<2", optional = true }
-scipy = [  # transient dependency of scikit-learn, pin required to unbreak installs on specific Python versions
-    { version = ">=1,<1.11", python = ">=3.8,<3.9", optional = true },
-    { version = ">=1,<1.14", python = ">=3.9,<3.10", optional = true },
-    { version = ">=1.12,<2", python = ">=3.12", optional = true }
-]
-lzstring = "^1.0.4"
 
-[tool.poetry.extras]
-metrics = ["scikit-learn", "scipy"]
-
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.17"
-black = { version = "^22.1.0", allow-prereleases = true }
-pytest = "^7"
-pytest-cov = "^4.0.0"
-pytest-depends = "^1.0.1"
-mkdocs = "^1.4.3"
-cairosvg = "^2.7.0"
-mkdocs-material = ">=9.2,<10"  # insiders fork installed out-of-band in docs/setup_insiders.sh
-mkdocstrings = { version = ">0.20,<1", extras = ["python"] }
-mkdocs-git-committers-plugin-2 = "^1"
-mkdocs-git-revision-date-localized-plugin = "^1"
+[project.optional-dependencies]
+metrics = [
+    "scikit-learn>=1.2,<2",
+    "scipy >=1,<1.11; python_version < '3.9'",
+    "scipy >=1,<1.14; python_version >= '3.9' and python_version < '3.12'",
+    "scipy >=1.12,<2; python_version >= '3.12'",
+]
+# mkdocstrings = { version = ">0.20,<1", extras = ["python"] }
+# black = { version = "^22.1.0", allow-prereleases = true }
+dev = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-cov>=4.0.0,<5",
+    "pytest-depends>=1.0.1,<2",
+    "mkdocs>=1.4.3,<2",
+    "cairosvg>=2.7.0,<3",
+    # insiders fork installed out-of-band in docs/setup_insiders.sh
+    "mkdocs-material>=9.2,<10",
+    "mkdocs-git-committers-plugin-2>=1,<2",
+    "mkdocs-git-revision-date-localized-plugin>=1,<2",
+]
 
 [tool.poetry.scripts]
 kolena = 'kolena._utils.cli:run'
 
 [build-system]
-requires = ["poetry-core>=1.2"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
 # do not scan 'kolena' for tests, as there are many functions/classes that look like tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,17 +25,11 @@ classifiers = [# classifiers for license, versions set automatically during Poet
 packages = [
     { include = "kolena" }
 ]
-requires-python = ">=3.9,<3.13"
-# TODO BEFORE MERGE include 3.8 as a valid python version
-# requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8,<3.13"
 
 dependencies = [
-    "numpy >=1.19,<2; python_version < '3.11'",
-    "numpy >=1.23,<2; python_version == '3.11'",
-    "numpy >=1.26,<2; python_version >= '3.12'",
-    "pandas >=1.1,<3; python_version < '3.11'",
-    "pandas >=1.5,<3; python_version == '3.11'",
-    "pandas >=2.1.1,<3; python_version >= '3.12'",
+    "numpy >=1.19,<2",
+    "pandas >=1.1,<3",
     "pandera>=0.9,<1",
     "pydantic>=1.10,<3",
     "dacite>=1.6,<2",
@@ -54,9 +48,7 @@ dependencies = [
 [project.optional-dependencies]
 metrics = [
     "scikit-learn>=1.2,<2",
-    "scipy >=1,<1.11; python_version < '3.9'",
-    "scipy >=1,<1.14; python_version >= '3.9' and python_version < '3.12'",
-    "scipy >=1.12,<2; python_version >= '3.12'",
+    "scipy >=1,<2",
 ]
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,6 @@ metrics = [
     "scipy >=1,<2",
 ]
 
-[tool.poetry.scripts]
-kolena = 'kolena._utils.cli:run'
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,3 @@ dev-dependencies = [
     "mkdocs-git-committers-plugin-2>=1,<2",
     "mkdocs-git-revision-date-localized-plugin>=1,<2",
 ]
-
-[tool.uv.sources]
-mkdocs-material = { git = "ssh://git@github.com/kolenaIO/mkdocs-material-insiders.git" }
-mkdocstrings-python = { git = "ssh://git@github.com/kolenaIO/mkdocstrings-python.git" }


### PR DESCRIPTION
### Linked issue(s)

KOL-7307

### What change does this PR introduce and why?

Replace `poetry` with `uv` for dependency management and tooling.

Installing `kolena` is potentially a long process, and the dependency resolution time with `poetry` has crept up to the point of causing our workflow tests to flake. `uv` seems to offer a much faster interface for this, while preserving simplicity of development.

Also removes codecov for now, as it's something that hasn't been actively used / monitored.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
