### PR TITLE
feat: experimental method to download results by model tag

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -494,7 +494,7 @@ workflows:
           matrix:
             parameters:
               subproject: [ age_estimation, automatic_speech_recognition, classification, keypoint_detection, question_answering, rain_forecast, semantic_segmentation, speaker_diarization, object_detection_2d, semantic_textual_similarity, person_detection, crossing_pedestrian_detection, named_entity_recognition ]
-              resource-class: [ medium ]
+              resource-class: [ medium ]    # TODO: revert after KOL-7307 is resolved [KOL-7444]
               python-version: [ "3.9.18" ]
       - example-test-workflow:
           matrix:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -447,6 +447,16 @@ workflows:
           enabled: true
           requires:
             - ci-base-<< matrix.python-version >>-<< matrix.extras >>
+      - integration-test:
+          name: integration-test-experimental-dataset-<< matrix.python-version >>-<< matrix.extras >>
+          matrix:
+            parameters:
+              python-version: [ "3.9.18" ]
+              extras: [ "none" ]
+          pytest-group: _experimental/dataset
+          enabled: true
+          requires:
+            - ci-base-<< matrix.python-version >>-<< matrix.extras >>
       - integration-test-dataset:
           name: integration-test-dataset-<< matrix.python-version >>-<< matrix.extras >>
           matrix:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -494,7 +494,7 @@ workflows:
           matrix:
             parameters:
               subproject: [ age_estimation, automatic_speech_recognition, classification, keypoint_detection, question_answering, rain_forecast, semantic_segmentation, speaker_diarization, object_detection_2d, semantic_textual_similarity, person_detection, crossing_pedestrian_detection, named_entity_recognition ]
-              resource-class: [ small ]
+              resource-class: [ medium ]
               python-version: [ "3.9.18" ]
       - example-test-workflow:
           matrix:

--- a/docs/reference/experimental/index.md
+++ b/docs/reference/experimental/index.md
@@ -20,3 +20,7 @@
     options:
         members: ["kolena_trace"]
         show_root_heading: true
+::: kolena._experimental.dataset
+    options:
+        members: ["download_results_by_tag"]
+        show_root_heading: true

--- a/kolena/_api/v1/event.py
+++ b/kolena/_api/v1/event.py
@@ -63,6 +63,7 @@ class EventAPI:
         # dataset evaluation
         FETCH_DATASET_MODEL_RESULT = "sdk-dataset-model-result-fetched"
         UPLOAD_DATASET_MODEL_RESULT = "sdk-dataset-model-result-uploaded"
+        FETCH_DATASET_MODEL_RESULT_BY_TAG = "sdk-dataset-model-result-fetched-by-tag"
 
         # quality-standard
         FETCH_QUALITY_STANDARD_RESULT = "sdk-quality-standard-result-fetched"

--- a/kolena/_api/v2/model.py
+++ b/kolena/_api/v2/model.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from dataclasses import field
 from enum import Enum
 from typing import Dict
 from typing import List
@@ -24,6 +25,7 @@ from kolena._utils.pydantic_v1.dataclasses import dataclass
 class Path(str, Enum):
     UPLOAD_RESULTS = "/model/upload-results"
     LOAD_RESULTS = "/model/load-results"
+    LOAD_BY_TAG = "/model/load-by-tag"
 
 
 @dataclass(frozen=True)
@@ -50,6 +52,7 @@ class UploadResultsRequest:
     uuid: str
     dataset_id: int
     sources: Optional[List[Dict[str, str]]]
+    tags: List[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -64,3 +67,13 @@ class UploadResultsResponse:
 class EntityData:
     id: int
     name: str
+
+
+@dataclass(frozen=True)
+class LoadByTagRequest:
+    tag: str
+
+
+@dataclass(frozen=True)
+class LoadByTagResponse:
+    models: list[EntityData]

--- a/kolena/_api/v2/model.py
+++ b/kolena/_api/v2/model.py
@@ -76,4 +76,4 @@ class LoadByTagRequest:
 
 @dataclass(frozen=True)
 class LoadByTagResponse:
-    models: list[EntityData]
+    models: List[EntityData]

--- a/kolena/_experimental/dataset/__init__.py
+++ b/kolena/_experimental/dataset/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kolena/_experimental/dataset/__init__.py
+++ b/kolena/_experimental/dataset/__init__.py
@@ -11,3 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from kolena._experimental.dataset.evaluation import download_results_by_tag
+
+__all__ = [
+    "download_results_by_tag",
+]

--- a/kolena/_experimental/dataset/evaluation.py
+++ b/kolena/_experimental/dataset/evaluation.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import asdict
+from typing import List
 from typing import Optional
 
 import pandas as pd
@@ -29,7 +30,7 @@ from kolena.errors import IncorrectUsageError
 from kolena.errors import NotFoundError
 
 
-def _get_models_by_tag(tag: str) -> list[str]:
+def _get_models_by_tag(tag: str) -> List[str]:
     """
     Get model names by a given tag.
 

--- a/kolena/_experimental/dataset/evaluation.py
+++ b/kolena/_experimental/dataset/evaluation.py
@@ -42,7 +42,7 @@ def _get_models_by_tag(tag: str) -> list[str]:
     )
     response.raise_for_status()
 
-    load_by_tag_response = from_dict(LoadByTagResponse, response)
+    load_by_tag_response = from_dict(LoadByTagResponse, response.json())
     return [model.name for model in load_by_tag_response.models]
 
 

--- a/kolena/_experimental/dataset/evaluation.py
+++ b/kolena/_experimental/dataset/evaluation.py
@@ -14,6 +14,7 @@
 from dataclasses import asdict
 from typing import List
 from typing import Optional
+from typing import Tuple
 
 import pandas as pd
 
@@ -53,9 +54,9 @@ def download_results_by_tag(
     model_tag: str,
     commit: Optional[str] = None,
     include_extracted_properties: bool = False,
-) -> tuple[pd.DataFrame, list[EvalConfigResults]]:
+) -> Tuple[pd.DataFrame, List[EvalConfigResults]]:
     """
-    Download results given dataset name and model tag.
+    Download results given dataset name and model tag. Currently restricted to if the model tag is unique to the model.
 
     Concat dataset with results:
 

--- a/kolena/_experimental/dataset/evaluation.py
+++ b/kolena/_experimental/dataset/evaluation.py
@@ -1,0 +1,80 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import asdict
+from typing import Optional
+
+import pandas as pd
+
+from kolena._api.v1.event import EventAPI
+from kolena._api.v2.model import LoadByTagRequest
+from kolena._api.v2.model import LoadByTagResponse
+from kolena._api.v2.model import Path
+from kolena._utils import krequests_v2 as krequests
+from kolena._utils.instrumentation import with_event
+from kolena._utils.serde import from_dict
+from kolena.dataset.evaluation import download_results
+from kolena.dataset.evaluation import EvalConfigResults
+from kolena.errors import IncorrectUsageError
+from kolena.errors import NotFoundError
+
+
+def _get_models_by_tag(tag: str) -> list[str]:
+    """
+    Get model names by a given tag.
+
+    :param tag: The tag on the model.
+    :return: A list of model names associated with the provided tag.
+    """
+    response = krequests.put(
+        Path.LOAD_BY_TAG,
+        json=asdict(LoadByTagRequest(tag=tag)),
+    )
+    response.raise_for_status()
+
+    load_by_tag_response = from_dict(LoadByTagResponse, response)
+    return [model.name for model in load_by_tag_response.models]
+
+
+@with_event(EventAPI.Event.FETCH_DATASET_MODEL_RESULT_BY_TAG)
+def download_results_by_tag(
+    dataset: str,
+    model_tag: str,
+    commit: Optional[str] = None,
+    include_extracted_properties: bool = False,
+) -> tuple[pd.DataFrame, list[EvalConfigResults]]:
+    """
+    Download results given dataset name and model tag.
+
+    Concat dataset with results:
+
+    ```python
+    df_dp, results = download_results_by_tag("dataset name", "model tag")
+    for eval_config, df_result in results:
+        df_combined = pd.concat([df_dp, df_result], axis=1)
+    ```
+
+    :param dataset: The name of the dataset.
+    :param model_tag: The tag associated with the model.
+    :param commit: The commit hash for version control. Get the latest commit when this value is `None`.
+    :param include_extracted_properties: If True, include kolena extracted properties from automated extractions
+    in the datapoints and results as separate columns
+    :return: Tuple of DataFrame of datapoints and list of [`EvalConfigResults`][kolena.dataset.EvalConfigResults].
+    """
+    model_names = _get_models_by_tag(model_tag)
+    if not model_names:
+        raise NotFoundError(f"no models with tag '{model_tag}' were found")
+    elif len(model_names) > 1:
+        raise IncorrectUsageError(f"multiple models with tag '{model_tag}' were found: {model_names}")
+    else:
+        return download_results(dataset, model_names[0], commit, include_extracted_properties)

--- a/kolena/dataset/_common.py
+++ b/kolena/dataset/_common.py
@@ -26,7 +26,6 @@ COL_DATAPOINT_ID_OBJECT = "datapoint_id_object"
 COL_EVAL_CONFIG = "eval_config"
 COL_RESULT = "result"
 COL_THRESHOLDED_OBJECT = "thresholded_object"
-COL_MODEL = "model"
 _MAX_DUPLICATE_ID_REPORT = 10
 
 DEFAULT_SOURCES = [dict(type="sdk")]

--- a/kolena/dataset/_common.py
+++ b/kolena/dataset/_common.py
@@ -26,6 +26,7 @@ COL_DATAPOINT_ID_OBJECT = "datapoint_id_object"
 COL_EVAL_CONFIG = "eval_config"
 COL_RESULT = "result"
 COL_THRESHOLDED_OBJECT = "thresholded_object"
+COL_MODEL = "model"
 _MAX_DUPLICATE_ID_REPORT = 10
 
 DEFAULT_SOURCES = [dict(type="sdk")]

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -153,12 +153,14 @@ def _send_upload_results_request(
     load_uuid: str,
     dataset_id: int,
     sources: Optional[List[Dict[str, str]]],
+    tags: List[str] = [],
 ) -> UploadResultsResponse:
     request = UploadResultsRequest(
         model=model,
         uuid=load_uuid,
         dataset_id=dataset_id,
         sources=sources,
+        tags=tags,
     )
     response = krequests.post(Path.UPLOAD_RESULTS, json=asdict(request))
     krequests.raise_for_status(response)
@@ -235,11 +237,19 @@ def _validate_configs(configs: List[EvalConfig]) -> None:
                 raise IncorrectUsageError("duplicate eval configs are invalid")
 
 
+def _validate_tags(tags: list[str]) -> None:
+    for tag in tags:
+        if not tag.strip():
+            raise IncorrectUsageError("at least one of the tags is empty")
+
+
 def _prepare_upload_results_request(
     dataset: str,
     results: Union[DataFrame, List[Tuple[EvalConfig, DataFrame]]],
     thresholded_fields: Optional[List[str]] = None,
+    tags: list[str] = [],
 ) -> Tuple[str, int, int]:
+    _validate_tags(tags)
     existing_dataset = _load_dataset_metadata(dataset)
     assert existing_dataset
 
@@ -280,10 +290,11 @@ def _upload_results(
     results: Union[DataFrame, List[Tuple[EvalConfig, DataFrame]]],
     sources: Optional[List[Dict[str, str]]] = DEFAULT_SOURCES,
     thresholded_fields: Optional[List[str]] = None,
+    tags: list[str] = [],
 ) -> UploadResultsResponse:
-    load_uuid, dataset_id, total_rows = _prepare_upload_results_request(dataset, results, thresholded_fields)
+    load_uuid, dataset_id, total_rows = _prepare_upload_results_request(dataset, results, thresholded_fields, tags)
 
-    response = _send_upload_results_request(model, load_uuid, dataset_id, sources=sources)
+    response = _send_upload_results_request(model, load_uuid, dataset_id, sources=sources, tags=tags)
     if isinstance(response.eval_config_id, list):
         models = [serialize_models_url(response.model_id, eval_config_id) for eval_config_id in response.eval_config_id]
     else:
@@ -304,6 +315,7 @@ def upload_results(
     model: str,
     results: Union[DataFrame, List[EvalConfigResults]],
     thresholded_fields: Optional[List[str]] = None,
+    tags: list[str] = [],
 ) -> None:
     """
     This function is used for uploading the results from a specified model on a given dataset.
@@ -311,8 +323,10 @@ def upload_results(
     :param dataset: The name of the dataset.
     :param model: The name of the model.
     :param results: Either a DataFrame or a list of [`EvalConfigResults`][kolena.dataset.EvalConfigResults].
-    :param thresholded_fields: Columns in result DataFrame containing data associated with different thresholds.
+    :param thresholded_fields: Optional columns in result DataFrame containing data associated with different
+     thresholds.
+    :param tags: Optional list of tags to be associated with the model.
 
     :return: None
     """
-    _upload_results(dataset, model, results, thresholded_fields=thresholded_fields)
+    _upload_results(dataset, model, results, thresholded_fields=thresholded_fields, tags=tags)

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -247,7 +247,7 @@ def _prepare_upload_results_request(
     dataset: str,
     results: Union[DataFrame, List[Tuple[EvalConfig, DataFrame]]],
     thresholded_fields: Optional[List[str]] = None,
-    tags: list[str] = [],
+    tags: List[str] = [],
 ) -> Tuple[str, int, int]:
     _validate_tags(tags)
     existing_dataset = _load_dataset_metadata(dataset)
@@ -290,7 +290,7 @@ def _upload_results(
     results: Union[DataFrame, List[Tuple[EvalConfig, DataFrame]]],
     sources: Optional[List[Dict[str, str]]] = DEFAULT_SOURCES,
     thresholded_fields: Optional[List[str]] = None,
-    tags: list[str] = [],
+    tags: List[str] = [],
 ) -> UploadResultsResponse:
     load_uuid, dataset_id, total_rows = _prepare_upload_results_request(dataset, results, thresholded_fields, tags)
 
@@ -315,7 +315,7 @@ def upload_results(
     model: str,
     results: Union[DataFrame, List[EvalConfigResults]],
     thresholded_fields: Optional[List[str]] = None,
-    tags: list[str] = [],
+    tags: List[str] = [],
 ) -> None:
     """
     This function is used for uploading the results from a specified model on a given dataset.

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -237,7 +237,7 @@ def _validate_configs(configs: List[EvalConfig]) -> None:
                 raise IncorrectUsageError("duplicate eval configs are invalid")
 
 
-def _validate_tags(tags: list[str]) -> None:
+def _validate_tags(tags: List[str]) -> None:
     for tag in tags:
         if not tag.strip():
             raise IncorrectUsageError("at least one of the tags is empty")

--- a/tests/integration/_experimental/dataset/__init__.py
+++ b/tests/integration/_experimental/dataset/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integration/_experimental/dataset/test_evaluation.py
+++ b/tests/integration/_experimental/dataset/test_evaluation.py
@@ -127,3 +127,5 @@ def test__download_results_by_tag__multiple_model_with_same_tag() -> None:
         download_results_by_tag(dataset_name, model_tag)
     exc_info_value = str(exc_info.value)
     assert "multiple models with tag" in exc_info_value
+    assert model_name_1 in exc_info_value
+    assert model_name_2 in exc_info_value

--- a/tests/integration/_experimental/dataset/test_evaluation.py
+++ b/tests/integration/_experimental/dataset/test_evaluation.py
@@ -1,0 +1,129 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from kolena._experimental.dataset.evaluation import download_results_by_tag
+from kolena.dataset import EvalConfigResults
+from kolena.dataset import upload_dataset
+from kolena.dataset.evaluation import _upload_results
+from kolena.errors import IncorrectUsageError
+from kolena.errors import NotFoundError
+from tests.integration.dataset.test_evaluation import check_eval_config_result_tuples
+from tests.integration.dataset.test_evaluation import get_df_dp
+from tests.integration.dataset.test_evaluation import get_df_result
+from tests.integration.dataset.test_evaluation import ID_FIELDS
+from tests.integration.dataset.test_evaluation import JOIN_COLUMN
+from tests.integration.helper import assert_frame_equal
+from tests.integration.helper import with_test_prefix
+
+
+def test__download_results_by_tag__model_does_not_exist() -> None:
+    dataset_name = with_test_prefix(f"{__file__}::test__download_results_by_tag__model_does_not_exist")
+    model_tag = with_test_prefix(f"{__file__}::test__download_results_by_tag__model_does_not_exist")
+
+    with pytest.raises(NotFoundError) as exc_info:
+        download_results_by_tag(dataset_name, model_tag)
+    exc_info_value = str(exc_info.value)
+    assert "no models with tag" in exc_info_value
+
+
+def test__download_results_by_tag() -> None:
+    dataset_name = with_test_prefix(f"{__file__}::test__download_results_by_tag")
+    model_name = with_test_prefix(f"{__file__}::test__download_results_by_tag")
+    model_tags = [
+        with_test_prefix(f"{__file__}::test__download_results_by_tag-a"),
+        with_test_prefix(f"{__file__}::test__download_results_by_tag-b"),
+    ]
+
+    df_dp = get_df_dp()
+    dp_columns = [JOIN_COLUMN, "locator", "width", "height", "city"]
+    upload_dataset(dataset_name, df_dp[dp_columns], id_fields=ID_FIELDS)
+
+    df_result = get_df_result(10)
+    eval_config = dict(threshold=0.422)
+
+    response = _upload_results(
+        dataset_name,
+        model_name,
+        [EvalConfigResults(eval_config, df_result)],
+        tags=model_tags,
+    )
+    assert response.n_inserted == 10
+    assert response.n_updated == 0
+    assert response.model_id is not None
+    assert response.eval_config_id is not None
+
+    for tag in model_tags:
+        fetched_df_dp, df_results_by_eval = download_results_by_tag(dataset_name, tag)
+        check_eval_config_result_tuples(df_results_by_eval)
+        eval_cfg, fetched_df_result = df_results_by_eval[0]
+        assert not fetched_df_dp.empty
+        assert not fetched_df_result.empty
+        assert len(df_results_by_eval) == 1
+        assert eval_cfg == eval_config
+        assert_frame_equal(fetched_df_dp, fetched_df_result, ID_FIELDS)
+
+
+def test__download_results_by_tag__multiple_model_with_same_tag() -> None:
+    dataset_name = with_test_prefix(f"{__file__}::test__multiple_model_with_same_tag")
+    model_name_1 = with_test_prefix(f"{__file__}::test__multiple_model_with_same_tag_1")
+    model_name_2 = with_test_prefix(f"{__file__}::test__multiple_model_with_same_tag_2")
+    model_tag = with_test_prefix(f"{__file__}::test__multiple_model_with_same_tag")
+
+    df_dp = get_df_dp()
+    dp_columns = [JOIN_COLUMN, "locator", "width", "height", "city"]
+    upload_dataset(dataset_name, df_dp[dp_columns], id_fields=ID_FIELDS)
+
+    df_result = get_df_result(10)
+    eval_config = dict(threshold=0.422)
+
+    # with only 1 model associated with the tag
+    response = _upload_results(
+        dataset_name,
+        model_name_1,
+        [EvalConfigResults(eval_config, df_result)],
+        tags=[model_tag],
+    )
+    assert response.n_inserted == 10
+    assert response.n_updated == 0
+    assert response.model_id is not None
+    assert response.eval_config_id is not None
+    model_id_1 = response.model_id
+
+    fetched_df_dp, df_results_by_eval = download_results_by_tag(dataset_name, model_tag)
+    check_eval_config_result_tuples(df_results_by_eval)
+    eval_cfg, fetched_df_result = df_results_by_eval[0]
+    assert not fetched_df_dp.empty
+    assert not fetched_df_result.empty
+    assert len(df_results_by_eval) == 1
+    assert eval_cfg == eval_config
+    assert_frame_equal(fetched_df_dp, fetched_df_result, ID_FIELDS)
+
+    # with 2 models having the same tag
+    response = _upload_results(
+        dataset_name,
+        model_name_2,
+        [EvalConfigResults(eval_config, df_result)],
+        tags=[model_tag],
+    )
+    assert response.n_inserted == 10
+    assert response.n_updated == 0
+    assert response.model_id is not None
+    assert response.eval_config_id is not None
+    assert response.model_id != model_id_1
+
+    with pytest.raises(IncorrectUsageError) as exc_info:
+        download_results_by_tag(dataset_name, model_tag)
+    exc_info_value = str(exc_info.value)
+    assert "multiple models with tag" in exc_info_value

--- a/tests/unit/dataset/test_evaluation.py
+++ b/tests/unit/dataset/test_evaluation.py
@@ -1,0 +1,29 @@
+# Copyright 2021-2024 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from kolena.dataset.evaluation import _validate_tags
+from kolena.errors import IncorrectUsageError
+
+
+@pytest.mark.parametrize(
+    "tags, has_error",
+    [([], False), (["tag-a", "tag-b"], False), (["tag-a", " "], True), ([""], True)],
+)
+def test__validate_tags(tags: list[str], has_error: bool) -> None:
+    if has_error:
+        with pytest.raises(IncorrectUsageError):
+            _validate_tags(tags)
+    else:
+        _validate_tags(tags)

--- a/tests/unit/dataset/test_evaluation.py
+++ b/tests/unit/dataset/test_evaluation.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import List
+
 import pytest
 
 from kolena.dataset.evaluation import _validate_tags
@@ -21,7 +23,7 @@ from kolena.errors import IncorrectUsageError
     "tags, has_error",
     [([], False), (["tag-a", "tag-b"], False), (["tag-a", " "], True), ([""], True)],
 )
-def test__validate_tags(tags: list[str], has_error: bool) -> None:
+def test__validate_tags(tags: List[str], has_error: bool) -> None:
     if has_error:
         with pytest.raises(IncorrectUsageError):
             _validate_tags(tags)


### PR DESCRIPTION
### Linked issue(s)

Resolves KOL-6900
Corresponding backend change: https://github.com/kolenaIO/shipyard/pull/2450

CI is expected to fail before the above change is in production. Planning to cut a minor version after 1.36 release.


### What change does this PR introduce and why?

- During `upload_results`, allow optionally specifying a list of string tags to be associated with the model. A model can be associated with multiple tags, and a tag can by associated with multiple models.
- Creating a method under experimental folder to support downloading results by specifying the model tag. Technically speaking, the backend change supports directly downloading results even if a tag is associated with multiple models. That however will make the function signature nested and complicated. Given that the immediate use case we see is a one-to-one mapping between a model and its human-readable tag, limiting the function by inspecting that only 1 model is associated with the provided tag and keeping the same return type as `download_results`. In case multiple models share the same tag, the exception message will contain the model names to help users identify which ones to use.


Also verified docs update:
<img width="1152" alt="image" src="https://github.com/user-attachments/assets/25d00be7-3041-47fb-81f2-802e062ab2a7">


### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
