### PR TITLE
chore: update doc on video annotation, revert circle CI instance size

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -450,7 +450,7 @@ workflows:
           matrix:
             parameters:
               subproject: [ age_estimation, automatic_speech_recognition, classification, keypoint_detection, question_answering, rain_forecast, semantic_segmentation, speaker_diarization, object_detection_2d, semantic_textual_similarity, person_detection, crossing_pedestrian_detection, named_entity_recognition ]
-              resource-class: [ medium ]    # TODO: revert after KOL-7307 is resolved [KOL-7444]
+              resource-class: [ small ]
               python-version: [ "3.9.18" ]
       - example-test-workflow:
           matrix:

--- a/docs/dataset/advanced-usage/dataset-formatting/computer-vision.md
+++ b/docs/dataset/advanced-usage/dataset-formatting/computer-vision.md
@@ -243,8 +243,9 @@ correctly.
 Kolena supports `mov`, `mp4`, `mpeg` and other web browser supported video types.
 
 !!! Note
-    Bounding box visualization only works for videos with `5`, `15`, `29.97` and `59.94` frame rates.
-    Please let us know if you are working with a frame rate outside of the ones mentioned.
+    [Annotation](../../../reference/annotation.md) visualization over videos only works on videos with constant frame rates.
+    For the best experience, include a `frame_rate` field on your video datapoints in frames per second as a `float`
+    or `int` number.
 
 #### Setting up bounding box annotations on videos
 


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-7448
Resolves KOL-7444

### What change does this PR introduce and why?
Update documentation related to annotation over videos. Revert increasing CI instance size for running example after uv migration.

Updated doc:
<img width="1019" alt="image" src="https://github.com/user-attachments/assets/72d030c9-23a9-47e4-9a23-50707d750a3a">


### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
