### PR TITLE
feat: copy qs from another dataset

### DIFF
--- a/kolena/_api/v1/event.py
+++ b/kolena/_api/v1/event.py
@@ -67,6 +67,7 @@ class EventAPI:
 
         # quality-standard
         FETCH_QUALITY_STANDARD_RESULT = "sdk-quality-standard-result-fetched"
+        COPY_QUALITY_STANDARD_FROM_DATASET = "sdk-quality-standard-copied-from-dataset"
 
     @dataclass(frozen=True)
     class RecordEventRequest:

--- a/kolena/_api/v2/quality_standard.py
+++ b/kolena/_api/v2/quality_standard.py
@@ -13,8 +13,18 @@
 # limitations under the License.
 from enum import Enum
 
+from kolena._utils.pydantic_v1.dataclasses import dataclass
+
 
 class Path(str, Enum):
     QUALITY_STANDARD = "quality-standard"
     RESULT = "quality-standard/result"
-    COPY_QUALITY_STANDARD_FROM_DATASET = "quality-standard/copy-from-dataset"
+    COPY_FROM_DATASET = "quality-standard/copy-from-dataset"
+
+
+@dataclass(frozen=True)
+class CopyQualityStandardRequest:
+    dataset_id: int
+    source_dataset_id: int
+    include_metric_groups: bool = True
+    include_test_cases: bool = True

--- a/kolena/_api/v2/quality_standard.py
+++ b/kolena/_api/v2/quality_standard.py
@@ -17,3 +17,4 @@ from enum import Enum
 class Path(str, Enum):
     QUALITY_STANDARD = "quality-standard"
     RESULT = "quality-standard/result"
+    COPY_QUALITY_STANDARD_FROM_DATASET = "quality-standard/copy-from-dataset"

--- a/kolena/_experimental/__init__.py
+++ b/kolena/_experimental/__init__.py
@@ -11,4 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from kolena._experimental.quality_standard import copy_quality_standards_from_dataset
 from kolena._experimental.quality_standard import download_quality_standard_result

--- a/kolena/_experimental/quality_standard.py
+++ b/kolena/_experimental/quality_standard.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from dataclasses import asdict
+from typing import Any
+from typing import Dict
 from typing import List
+from typing import Tuple
 from typing import Union
 
 import pandas as pd
@@ -22,6 +26,9 @@ from kolena._api.v2.quality_standard import Path
 from kolena._utils import krequests_v2 as krequests
 from kolena._utils import log
 from kolena._utils.instrumentation import with_event
+from kolena._utils.pydantic_v1.dataclasses import dataclass
+from kolena.dataset.dataset import _load_dataset_metadata
+from kolena.errors import IncorrectUsageError
 
 
 def _format_quality_standard_result_df(quality_standard_result: dict) -> pd.DataFrame:
@@ -91,3 +98,58 @@ def download_quality_standard_result(
         for model in models:
             result_dfs.append(_download_quality_standard_result(dataset, [model], metric_groups, intersect_results))
         return pd.concat(result_dfs, axis=1)
+
+
+@dataclass(frozen=True)
+class CopyQualityStandardRequest:
+    dataset_id: int
+    source_dataset_id: int
+    include_metric_groups: bool = True
+    include_test_cases: bool = True
+
+
+@with_event(event_name=EventAPI.Event.COPY_QUALITY_STANDARD_FROM_DATASET)
+def copy_quality_standards_from_dataset(
+    dataset: str,
+    source_dataset: str,
+    include_metric_groups: bool = True,
+    include_test_cases: bool = True,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """
+    Create quality standards on a dataset by copying from a source dataset. Note that this operation will overwrite the
+    existing quality standards on the dataset if they exist.
+
+    :param dataset: The name of the dataset.
+    :param source_dataset: The name of the dataset from which the quality standards should be copied.
+    :param include_metric_groups: Optional flag to indicate whether to copy the metric groups from the source dataset.
+    :param include_test_cases: Optional flag to indicate whether to copy the test cases from the source dataset.
+    :return: A tuple of the created metric groups and test cases.
+    """
+    if dataset == source_dataset:
+        raise IncorrectUsageError("source dataset and target dataset are the same")
+
+    if not include_test_cases and not include_metric_groups:
+        raise IncorrectUsageError("should include at least one of metric groups or test cases")
+
+    dataset_metadata = _load_dataset_metadata(dataset)
+    assert dataset_metadata
+    source_dataset_metadata = _load_dataset_metadata(source_dataset)
+    assert source_dataset_metadata
+
+    request = CopyQualityStandardRequest(
+        dataset_metadata.id,
+        source_dataset_metadata.id,
+        include_metric_groups=include_metric_groups,
+        include_test_cases=include_test_cases,
+    )
+
+    response = krequests.put(
+        Path.COPY_QUALITY_STANDARD_FROM_DATASET,
+        json=asdict(request),
+        api_version="v2",
+    )
+    krequests.raise_for_status(response)
+
+    metric_groups = response.json().get("metric_groups", [])
+    test_cases = response.json().get("stratifications", [])
+    return metric_groups, test_cases


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-7304

### What change does this PR introduce and why?
Provide support to set up quality standards on a dataset by copying from another dataset that has QS set up. Note that this PR depends on [this backend PR](https://github.com/kolenaIO/shipyard/pull/2461), and CI is expected to fail unless the backend PR is in production. We are planning to cut a minor tag following the service release this week.

Also depends on https://github.com/kolenaIO/shipyard/pull/2462

Generated docs: 
<img width="1245" alt="image" src="https://github.com/user-attachments/assets/59d65470-ccf7-4606-a0a7-489cb40827f4">


### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
