### PR TITLE
Attempt to fix uv install issue in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@v2
 
+      - name: Setup environment
+        run: uv venv && source .venv/bin/activate
+
       - name: Fetch tags to enable autoversioning
         run: git fetch --prune --unshallow --tags
 


### PR DESCRIPTION
### Linked issue(s)

### What change does this PR introduce and why?
Attempting to fix our release CI workflow.

The workflows are failing with [this error](https://github.com/kolenaIO/kolena/actions/runs/11024053078/job/30617747236). This suggests we are missing a call to `uv venv`. I notice that the docs workflow, which passed, [has the step](https://github.com/kolenaIO/kolena/blob/trunk/.github/workflows/docs.yml#L43) that I've added in this PR, and [is passing](https://github.com/kolenaIO/kolena/actions/runs/11016411492/job/30591845680).

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
