### PR TITLE
Fix release CI workflow uv build commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: sed -i "s/0.999.0/$(git describe --tags --abbrev=0)/g" pyproject.toml
 
       - name: Build 'kolena' Python package
-        run: uv build --format=sdist
+        run: uv build --sdist
 
       - name: Publish 'kolena' documentation to production (S3)
         run: |
@@ -94,7 +94,7 @@ jobs:
           sed -i '0,/kolena/{s/kolena/kolena-client/}' pyproject.toml kolena/__init__.py
 
           uv pip install --all-extras -r pyproject.toml
-          uv build --format=sdist
+          uv build --sdist
 
       - name: "[backcompat] Install twine for package distribution on CodeArtifact"
         run: pip install twine


### PR DESCRIPTION
### Linked issue(s)

### What change does this PR introduce and why?
The `uv build` commands in the release workflow are incorrect. The syntax is `uv build --sdist`, not `uv build --format=sdist`. See docs [here](https://docs.astral.sh/uv/reference/cli/#uv-build). I have verified that `uv build --sdist` produces the same output file as `poetry build --format=sdist` used to.

I believe with this the `uv` commands in the workflow should be OK. The [only other one](https://github.com/kolenaIO/kolena/blob/miller/fix-more-uv-release-workflow-commands/.github/workflows/release.yml#L57) also exists in the `docs` workflow, and passes.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
