### PR TITLE
Update build steps to exclude examples, docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: sed -i "s/0.999.0/$(git describe --tags --abbrev=0)/g" pyproject.toml
 
       - name: Build 'kolena' Python package
-        run: uv build --sdist
+        run: uvx hatch build -t sdist
 
       - name: Publish 'kolena' documentation to production (S3)
         run: |
@@ -94,7 +94,7 @@ jobs:
           sed -i '0,/kolena/{s/kolena/kolena-client/}' pyproject.toml kolena/__init__.py
 
           uv pip install --all-extras -r pyproject.toml
-          uv build --sdist
+          uvx hatch build -t sdist
 
       - name: "[backcompat] Install twine for package distribution on CodeArtifact"
         run: pip install twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-exclude = ["docs", "examples"]
+exclude = ["docs", "examples", "tests"]
 
 [tool.pytest.ini_options]
 # do not scan 'kolena' for tests, as there are many functions/classes that look like tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-exclude = ["docs", "examples", "tests"]
+include = ["kolena"]
+exclude = ["docs"]
 
 [tool.pytest.ini_options]
 # do not scan 'kolena' for tests, as there are many functions/classes that look like tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ kolena = 'kolena._utils.cli:run'
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+exclude = ["docs", "examples"]
+
 [tool.pytest.ini_options]
 # do not scan 'kolena' for tests, as there are many functions/classes that look like tests
 norecursedirs = "kolena"
@@ -88,3 +91,7 @@ dev-dependencies = [
     "mkdocs-git-committers-plugin-2>=1,<2",
     "mkdocs-git-revision-date-localized-plugin>=1,<2",
 ]
+
+[tool.uv.sources]
+mkdocs-material = { git = "ssh://git@github.com/kolenaIO/mkdocs-material-insiders.git" }
+mkdocstrings-python = { git = "ssh://git@github.com/kolenaIO/mkdocstrings-python.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,3 @@ dev-dependencies = [
     "mkdocs-git-committers-plugin-2>=1,<2",
     "mkdocs-git-revision-date-localized-plugin>=1,<2",
 ]
-
-[tool.uv.sources]
-mkdocs-material = { git = "ssh://git@github.com/kolenaIO/mkdocs-material-insiders.git" }
-mkdocstrings-python = { git = "ssh://git@github.com/kolenaIO/mkdocstrings-python.git" }


### PR DESCRIPTION
Should fix the [failed builds](https://github.com/kolenaIO/kolena/actions/runs/11025258075) during last night's release.
