### PR TITLE
chore: better support for uploading custom embeddings

### DIFF
--- a/kolena/_experimental/search/_internal/datatypes.py
+++ b/kolena/_experimental/search/_internal/datatypes.py
@@ -33,8 +33,11 @@ class LocatorEmbeddingsDataFrameSchema(pa.DataFrameModel):
 
 
 class DatasetEmbeddingsDataFrameSchema(pa.DataFrameModel):
-    key: Series[pa.typing.String] = pa.Field(coerce=True, _validate_locator=())
-    """Unique key corresponding to model used for embeddings extraction. This is typically a locator."""
+    key: Series[pa.typing.String] = pa.Field(coerce=True)
+    """
+    Unique key corresponding  to the embedding vectors. This can be, for example, the name of the embedding model along
+    with the column with which the embedding was extracted, such as "resnet50-image_locator".
+    """
 
     datapoint_id_object: Series[pa.typing.String] = pa.Field(coerce=True)
     """

--- a/kolena/_experimental/search/embeddings.py
+++ b/kolena/_experimental/search/embeddings.py
@@ -137,8 +137,8 @@ def upload_dataset_embeddings(dataset_name: str, key: str, df_embedding: pd.Data
     Upload a list of search embeddings for a dataset.
 
     :param dataset_name: String value indicating the name of the dataset for which the embeddings will be uploaded.
-    :param key: String value uniquely corresponding to the embedding vectors. This can be, for example, the name of the
-        embedding model along with the column with which the embedding was extracted, such as "resnet50-image_locator".
+    :param key: String value uniquely corresponding to the embedding vectors. For example, this can be the name of the
+        embedding model along with the column with which the embedding was extracted, such as `resnet50-image_locator`.
     :param df_embedding: Dataframe containing id fields for identifying datapoints in the dataset and the associated
         embeddings as `numpy.typing.ArrayLike` of numeric values.
     :raises NotFoundError: The given dataset does not exist.

--- a/kolena/_experimental/search/embeddings.py
+++ b/kolena/_experimental/search/embeddings.py
@@ -137,8 +137,8 @@ def upload_dataset_embeddings(dataset_name: str, key: str, df_embedding: pd.Data
     Upload a list of search embeddings for a dataset.
 
     :param dataset_name: String value indicating the name of the dataset for which the embeddings will be uploaded.
-    :param key: String value uniquely corresponding to the model used to extract the embedding vectors.
-        This is typically a locator.
+    :param key: String value uniquely corresponding to the embedding vectors. This can be, for example, the name of the
+        embedding model along with the column with which the embedding was extracted, such as "resnet50-image_locator".
     :param df_embedding: Dataframe containing id fields for identifying datapoints in the dataset and the associated
         embeddings as `numpy.typing.ArrayLike` of numeric values.
     :raises NotFoundError: The given dataset does not exist.

--- a/tests/integration/_experimental/search/test_embeddings.py
+++ b/tests/integration/_experimental/search/test_embeddings.py
@@ -108,6 +108,22 @@ def test__upload_dataset_embeddings(embedding: np.ndarray, dataset_name: str) ->
         ),
         run_embedding_reduction_pipeline=False,
     )
+    _upload_dataset_embeddings(
+        dataset_name,
+        key="my_model-left_image",
+        df_embedding=pd.DataFrame(
+            {"locator": [f"locator-{i}" for i in range(N_DATAPOINTS)], "embedding": [embedding * 2] * N_DATAPOINTS},
+        ),
+        run_embedding_reduction_pipeline=False,
+    )
+    _upload_dataset_embeddings(
+        dataset_name,
+        key="my_model-right_image",
+        df_embedding=pd.DataFrame(
+            {"locator": [f"locator-{i}" for i in range(N_DATAPOINTS)], "embedding": [embedding * 3] * N_DATAPOINTS},
+        ),
+        run_embedding_reduction_pipeline=False,
+    )
 
 
 def test__upload_dataset_embeddings__partial_dataset(dataset_name: str) -> None:


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-7537

### What change does this PR introduce and why?

To better support customers who will be uploading their own embeddings:
- Remove validation that the `key` in `upload_dataset_embeddings` must be a locator. Now it can be any free-from string such as `resnet50-image_locator`. We will use this to toggle which embeddings to use to search/visualize.
- Add integration tests to validate that multiple embeddings can be uploaded on the same datapoints.


Updated doc:
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/02f4907b-9ffa-4e86-b10b-2d028a9f596f">


### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
