### PR TITLE
chore: add color to bounding box example

### DIFF
--- a/examples/dataset/object_detection_2d/object_detection_2d/constants.py
+++ b/examples/dataset/object_detection_2d/object_detection_2d/constants.py
@@ -23,3 +23,14 @@ MODELS = [
     "faster_rcnn",
     "mask_rcnn",
 ]
+LABEL_TO_COLOR = {
+    "bicycle": "#f2f542",
+    "bus": "#f542bc",
+    "car": "#4260f5",
+    "truck": "#8b97a6",
+    "train": "#f0f1f2",
+    "fire hydrant": "#c542f5",
+    "motorcycle": "#66f542",
+    "stop sign": "#f54242",
+    "traffic light": "#f5aa42",
+}

--- a/examples/dataset/object_detection_2d/object_detection_2d/upload_dataset.py
+++ b/examples/dataset/object_detection_2d/object_detection_2d/upload_dataset.py
@@ -22,6 +22,7 @@ import pandas as pd
 from object_detection_2d.constants import BUCKET
 from object_detection_2d.constants import DATASET
 from object_detection_2d.constants import ID_FIELDS
+from object_detection_2d.constants import LABEL_TO_COLOR
 from object_detection_2d.constants import TASK
 
 from kolena.annotation import LabeledBoundingBox
@@ -38,6 +39,7 @@ def load_data(df_metadata_csv: pd.DataFrame) -> pd.DataFrame:
             *coords,
             record.label,
             supercategory=record.supercategory,  # type: ignore[call-arg]
+            color=LABEL_TO_COLOR[record.label],  # type: ignore[call-arg]
         )
         image_to_boxes[record.locator].append(bounding_box)
         metadata = {


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?

Add color to bboxes in the 2d OD example to make data visualization better. Otherwise all bboxes are showing as the same color.

<img width="1409" alt="image" src="https://github.com/user-attachments/assets/328cf3b4-52f5-433f-ab92-38f789653cec">


### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
