### PR TITLE
chore: doc update for dataset upsert

### DIFF
--- a/kolena/dataset/dataset.py
+++ b/kolena/dataset/dataset.py
@@ -326,9 +326,10 @@ def upload_dataset(
         within a dataset. When unspecified, a suitable value is inferred from the columns of the provided `df`. Note
         that `id_fields` must be hashable.
     :param commit_tags: Optionally specify a list of tags to associate with the dataset commit.
-    :param append_only: If True, the existing datapoint in the dataset will not be modified,
-    and only new datapoints from the input dataframe will be added. If False, all datapoints in the dataset will
-    be replaced by the ones in the input dataframe
+    :param append_only: If `False`, all datapoints in the dataset will be replaced by the ones in the input dataframe,
+        and existing datapoints absent from the input dataframe will be removed from the dataset. If `True`, new
+        datapoints from the input dataframe will be added, and existing datapoints will be modified if present in the
+        input dataframe, but no datapoints will be deleted from the datasets. This behaves like an `UPSERT` operation.
     """
     _upload_dataset(name, df, id_fields=id_fields, commit_tags=commit_tags, append_only=append_only)
 


### PR DESCRIPTION
### Linked issue(s)
Towards KOL-7432

### What change does this PR introduce and why?
Docstring update for dataset upsert with `append_only=True`. Related to: https://github.com/kolenaIO/shipyard/pull/2473

<img width="1107" alt="image" src="https://github.com/user-attachments/assets/de189913-1dd2-4553-99f0-94c2b6866100">


### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
