### PR TITLE
feat: list models by dataset

### DIFF
--- a/kolena/_api/v1/event.py
+++ b/kolena/_api/v1/event.py
@@ -64,6 +64,7 @@ class EventAPI:
         FETCH_DATASET_MODEL_RESULT = "sdk-dataset-model-result-fetched"
         UPLOAD_DATASET_MODEL_RESULT = "sdk-dataset-model-result-uploaded"
         FETCH_DATASET_MODEL_RESULT_BY_TAG = "sdk-dataset-model-result-fetched-by-tag"
+        FETCH_DATASET_MODELS_BY_DATASET = "sdk-dataset-models-fetched-by-dataset"
 
         # quality-standard
         FETCH_QUALITY_STANDARD_RESULT = "sdk-quality-standard-result-fetched"

--- a/kolena/_api/v1/event.py
+++ b/kolena/_api/v1/event.py
@@ -64,7 +64,7 @@ class EventAPI:
         FETCH_DATASET_MODEL_RESULT = "sdk-dataset-model-result-fetched"
         UPLOAD_DATASET_MODEL_RESULT = "sdk-dataset-model-result-uploaded"
         FETCH_DATASET_MODEL_RESULT_BY_TAG = "sdk-dataset-model-result-fetched-by-tag"
-        FETCH_DATASET_MODELS_BY_DATASET = "sdk-dataset-models-fetched-by-dataset"
+        GET_MODELS_BY_DATASET = "sdk-dataset-models-fetched-by-dataset"
 
         # quality-standard
         FETCH_QUALITY_STANDARD_RESULT = "sdk-quality-standard-result-fetched"

--- a/kolena/_api/v2/model.py
+++ b/kolena/_api/v2/model.py
@@ -26,6 +26,7 @@ class Path(str, Enum):
     UPLOAD_RESULTS = "/model/upload-results"
     LOAD_RESULTS = "/model/load-results"
     LOAD_BY_TAG = "/model/load-by-tag"
+    LOAD_BY_DATASET = "/model/load-by-dataset"
 
 
 @dataclass(frozen=True)
@@ -77,3 +78,8 @@ class LoadByTagRequest:
 @dataclass(frozen=True)
 class LoadByTagResponse:
     models: List[EntityData]
+
+
+@dataclass(frozen=True)
+class LoadByDatasetRequest:
+    dataset_id: int

--- a/kolena/dataset/__init__.py
+++ b/kolena/dataset/__init__.py
@@ -18,6 +18,8 @@ from kolena.dataset.evaluation import upload_results
 from kolena.dataset.evaluation import download_results
 from kolena.dataset.evaluation import EvalConfigResults
 from kolena.dataset.dataset import list_datasets
+from kolena.dataset.evaluation import ModelEntity
+from kolena.dataset.evaluation import get_models
 
 __all__ = [
     "upload_dataset",
@@ -26,4 +28,6 @@ __all__ = [
     "download_results",
     "EvalConfigResults",
     "list_datasets",
+    "ModelEntity",
+    "get_models",
 ]

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -351,7 +351,7 @@ def upload_results(
     _upload_results(dataset, model, results, thresholded_fields=thresholded_fields, tags=tags)
 
 
-@with_event(EventAPI.Event.FETCH_DATASET_MODELS_BY_DATASET)
+@with_event(EventAPI.Event.GET_MODELS_BY_DATASET)
 def get_models(
     dataset: str,
 ) -> List[ModelEntity]:

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -25,6 +25,7 @@ from typing import Union
 import pandas as pd
 
 from kolena._api.v1.event import EventAPI
+from kolena._api.v2.model import LoadByDatasetRequest
 from kolena._api.v2.model import LoadResultsRequest
 from kolena._api.v2.model import Path
 from kolena._api.v2.model import UploadResultsRequest
@@ -38,6 +39,7 @@ from kolena._utils.consts import BatchSize
 from kolena._utils.endpoints import get_platform_url
 from kolena._utils.endpoints import serialize_models_url
 from kolena._utils.instrumentation import with_event
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.serde import from_dict
 from kolena._utils.state import API_V2
 from kolena.dataset._common import COL_DATAPOINT
@@ -73,6 +75,23 @@ class EvalConfigResults(NamedTuple):
 
     eval_config: EvalConfig
     results: pd.DataFrame
+
+
+@dataclass(frozen=True)
+class ModelEntity:
+    """
+    The descriptor of a model tested on Kolena.
+    """
+
+    name: str
+    """Unique name of the model."""
+    tags: List[str]
+    """Tags associated with the model."""
+
+
+@dataclass(frozen=True)
+class LoadByDatasetResponse:
+    models: List[ModelEntity]
 
 
 def _iter_result_raw(
@@ -330,3 +349,23 @@ def upload_results(
     :return: None
     """
     _upload_results(dataset, model, results, thresholded_fields=thresholded_fields, tags=tags)
+
+
+@with_event(EventAPI.Event.FETCH_DATASET_MODELS_BY_DATASET)
+def get_models(
+    dataset: str,
+) -> List[ModelEntity]:
+    """
+    Get all models with results on a given dataset.
+
+    :param dataset: The name of the dataset.
+
+    :return: A list of models tested on the given dataset.
+    """
+    existing_dataset = _load_dataset_metadata(dataset)
+    assert existing_dataset, f"dataset {dataset} not found"
+
+    request = LoadByDatasetRequest(dataset_id=existing_dataset.id)
+    response = krequests.put(Path.LOAD_BY_DATASET, json=asdict(request))
+    krequests.raise_for_status(response)
+    return from_dict(LoadByDatasetResponse, response.json()).models


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-7601

### What change does this PR introduce and why?
Allow users to get a list of models (name and tags) by a given dataset.

Related backend PR: https://github.com/kolenaIO/shipyard/pull/2475


Generated docs:
<img width="1122" alt="image" src="https://github.com/user-attachments/assets/05f38b89-35c2-44f0-88a6-261b7d7817f1">

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/4bd5b744-7816-4e3d-8271-0e211ed463e5">


### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
