### PR TITLE
chore: Added license to pyproject to fix doc license tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,13 @@ documentation = "https://docs.kolena.com"
 readme = "README.md"
 license = "Apache-2.0"
 keywords = ["Kolena", "ML", "testing"]
-classifiers = [# classifiers for license, versions set automatically during Poetry build
+classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: Apache Software License",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ readme = "README.md"
 license = "Apache-2.0"
 keywords = ["Kolena", "ML", "testing"]
 classifiers = [# classifiers for license, versions set automatically during Poetry build
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
### Linked issue(s)
Fixes KOL-7643
### What change does this PR introduce and why?
Added license and python to the `pyproject.toml`. This should fix the license icon on the docs [as per Gordon](https://kolena-io.slack.com/archives/C028JB96WQL/p1729088393675539?thread_ts=1729087268.962609&cid=C028JB96WQL).
### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
