### PR TITLE
chore: fixed threshold typo in doc thresholded results

### DIFF
--- a/docs/dataset/advanced-usage/thresholded-results.md
+++ b/docs/dataset/advanced-usage/thresholded-results.md
@@ -49,7 +49,7 @@ For instance, in a semantic segmentation problem:
 
 !!! note
     The thresholded object should be added to a model result dataframe with at least one column other
-    than the `thresholded` column that contains the threhoslded object.
+    than the `thresholded` column that contains the thresholded object.
 
 ### Uploading Thresholded Results
 


### PR DESCRIPTION
### Linked issue(s)
Fixes [KOL-7684](https://linear.app/kolena/issue/KOL-7684/update-typo-on-public-docs-thresholded-results)
### What change does this PR introduce and why?
Quick fix to the typo on thresholded object
### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
