### PR TITLE
chore: Improved  logging on upload_results func for clarificaition

### DIFF
--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -339,8 +339,12 @@ def _upload_results(
 
     link = f"{get_platform_url()}/dataset/standards?datasetId={dataset_id}&{models_str}"
     log.info(
-        f"uploaded test results for model '{model}' on dataset '{dataset}': "
-        f"{total_rows} uploaded, {response.n_inserted} inserted, {response.n_updated} updated ({link})",
+        f"Upload Summary for Model '{model}' on Dataset '{dataset}': \n"
+        f"Total Rows Attempted: {total_rows}\n"
+        f"Rows Successfully Inserted: {response.n_inserted}\n"
+        f"Rows Successfully Updated: {response.n_updated}\n"
+        f"Rows Failed to Insert/Update: {total_rows - response.n_inserted - response.n_updated}\n"
+        f"Details: ({link})",
     )
     return response
 

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -343,8 +343,9 @@ def _upload_results(
         f"Total Rows Attempted: {total_rows}\n"
         f"Rows Successfully Inserted: {response.n_inserted}\n"
         f"Rows Successfully Updated: {response.n_updated}\n"
-        f"Rows Failed to Insert/Update: {total_rows - response.n_inserted - response.n_updated}\n"
-        f"Details: ({link})",
+        f"Rows Failed to Insert/Update: {total_rows - response.n_inserted - response.n_updated}"
+        f"Verify the id fields matches. Unchanged datapoints won't be modified. \n"
+        f"Details: {link}",
     )
     return response
 


### PR DESCRIPTION
### Linked issue(s)
Fixes KOL-7700
### What change does this PR introduce and why?
More detail to data being uploaded to Kolena. It would show successfully inserted/updated datapoints and failed.
Example:
```
Upload Summary for Model 'whisper-1-translate' on Dataset 'LibriSpeech':
Total Rows Attempted: 11126
Rows Successfully Inserted: 11126
Rows Successfully Updated: 0
Rows Failed to Insert/Update: 0
```
Tested locally on examples
![Screenshot 2024-10-30 at 12 48 42 PM](https://github.com/user-attachments/assets/c51b1e0e-826c-42c0-a5c2-f31ac8ce154a)
![Screenshot 2024-10-30 at 12 50 43 PM](https://github.com/user-attachments/assets/3301fd71-ed45-45b0-97ac-bbdb5d630f5c)

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
