### PR TITLE
feat: support iso format timestamp parsing by default

### DIFF
--- a/kolena/_experimental/special_data_type.py
+++ b/kolena/_experimental/special_data_type.py
@@ -19,6 +19,8 @@ from abc import ABCMeta
 from datetime import datetime
 from typing import Optional
 
+import pytz
+
 from kolena._utils.datatypes import DataCategory
 from kolena._utils.datatypes import DataType
 from kolena._utils.datatypes import TypedDataObject
@@ -53,14 +55,16 @@ class Timestamp(SpecialDataType):
 
     value: Optional[str] = None
     """
-    The timestamp in a string representation. If present, the corresponding `format` must be specified too.
-    Note that GMT timezone is assumed unless the offset is specified in the string.
+    The timestamp in a string representation. Note that GMT timezone is assumed unless the offset is specified in the
+    string.
     """
 
     format: Optional[str] = None
     """
     The format of the `value` string following the
-    [python format codes](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).
+    [python format codes](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes). If not
+    provided, the `value` will be parsed using
+    [python's `fromisoformat()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).
     """
 
     @staticmethod
@@ -70,16 +74,10 @@ class Timestamp(SpecialDataType):
     def __post_init__(self) -> None:
         if self.value:
             if not self.format:
-                raise ValueError("format needs to be specified for string timestamp")
-            if "%z" in self.format:
-                time_value = self.value
-                time_format = self.format
+                time_obj = datetime.fromisoformat(self.value)
             else:
-                time_value = self.value + " +0000"
-                time_format = self.format + " %z"
-
-            object.__setattr__(
-                self,
-                "epoch_time",
-                datetime.strptime(time_value, time_format).timestamp(),
-            )
+                time_obj = datetime.strptime(self.value, self.format)
+            # assume GMT if timezone is not provided
+            if not time_obj.tzinfo:
+                time_obj = pytz.utc.localize(time_obj)
+            object.__setattr__(self, "epoch_time", time_obj.timestamp())

--- a/tests/unit/_experimental/test_special_data_type.py
+++ b/tests/unit/_experimental/test_special_data_type.py
@@ -64,15 +64,31 @@ def test__serde__timestamp(object: Timestamp, json_data: Dict[str, Any]) -> None
         ("Tuesday, December 31, 2024 00:00:00 AM UTC-05:00", "%A, %B %d, %Y %H:%M:%S %p %Z%z", 1735621200),
     ],
 )
-def test__timestamp_epoch_conversion(value: str, format: str, epoch_time: float) -> None:
+def test__timestamp_epoch_conversion_with_format(value: str, format: str, epoch_time: float) -> None:
     timestamp_object = Timestamp(value=value, format=format)
+    assert epoch_time == timestamp_object.epoch_time
+
+
+@pytest.mark.parametrize(
+    "value, epoch_time",
+    [
+        ("2024-12-31", 1735603200),
+        ("2024-12-31 00:00:00", 1735603200),
+        ("2024-12-31 12:00:00+00:00", 1735646400),
+        ("2024-12-31 12:00:00-00:00", 1735646400),
+        ("2024-12-31 12:00:00+05:00", 1735628400),
+        ("2024-12-31 12:00:00-05:00", 1735664400),
+    ],
+)
+def test__timestamp_epoch_conversion_iso(value: str, epoch_time: float) -> None:
+    timestamp_object = Timestamp(value=value)
     assert epoch_time == timestamp_object.epoch_time
 
 
 @pytest.mark.parametrize(
     "value, format",
     [
-        # value without format
+        # value without format and not following ISO 8601 format
         ("12/31/2024, 00:00:00", None),
         # format inconsistent with value
         ("12/31/2024, 00:00:00", "%m/%d/%Y, %s"),


### PR DESCRIPTION
### Linked issue(s)
Towards KOL-3547

### What change does this PR introduce and why?
Assume the time string is of [ISO 8601 format](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) for parsing when the `format` is not specified.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
