### PR TITLE
Unclamp minimum version on requests-toolbelt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pydantic>=1.10,<3",
     "dacite>=1.6,<2",
     "requests>=2.20,<3",
-    "requests-toolbelt>=1.0.0,<2",
+    "requests-toolbelt<2",
     "tqdm>=4,<5",
     "Pillow>=10.0.1,<11",
     "retrying>=1.3.3,<2",


### PR DESCRIPTION
### Linked issue(s)
Fixes: KOL-7838

### What change does this PR introduce and why?
Unclamp minimum version on requests-toolbelt

This was previous added in the migration to use uv, but it doesn't seem to have been driven by any particular need. Unclamping the version because we've been asked to.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
