### PR TITLE
Add client side support for the DocumentAsset type

### DIFF
--- a/docs/dataset/core-concepts/index.md
+++ b/docs/dataset/core-concepts/index.md
@@ -81,6 +81,7 @@ Multiple assets can be attached to a single datapoint.
 | [`VideoAsset`](../../reference/asset.md#kolena.asset.VideoAsset)           | Useful if you want to attach a video file.                     | Same as above reference files |
 | [`PointCloudAsset`](../../reference/asset.md#kolena.asset.PointCloudAsset) | Useful for attaching 3D point cloud data.                      | `.pcd`, `.npy`, `.npz`        |
 | [`MeshAsset`](../../reference/asset.md#kolena.asset.MeshAsset)             | Useful for attaching and visualizing 3D mesh files.            | `.ply`                        |
+| [`DocumentAsset`](../../reference/asset.md#kolena.asset.DocumentAsset)     | Useful if you want to attach a document file.                  | `.txt`, `.pdf`                |
 
 **Annotations**: allow you to visualize overlays on top of datapoints through the use of[`annotation`](../../reference/annotation.md).
 We currently support 10 different types of annotations each enabling a specific modality.

--- a/docs/dataset/core-concepts/index.md
+++ b/docs/dataset/core-concepts/index.md
@@ -67,7 +67,7 @@ as text. Below table outlines what extensions are supported for optimal visualiz
 | Image          | `jpg`, `jpeg`, `png`, `gif`, `bmp` and other web browser supported image types.       |
 | Audio          | `flac`, `mp3`, `wav`, `acc`, `ogg`, `ra` and other web browser supported audio types. |
 | Video          | `mov`, `mp4`, `mpeg` and other web browser supported video types.                     |
-| Document       | `txt` and `pdf` files.                                                                |
+| Document       | `txt`, `pdf`, `log`, `md` files.                                                      |
 | Point Cloud    | `pcd` files.                                                                          |
 
 **Assets**: allow you to connect multiple referenced files to each datapoint for visualization and analysis.
@@ -81,7 +81,7 @@ Multiple assets can be attached to a single datapoint.
 | [`VideoAsset`](../../reference/asset.md#kolena.asset.VideoAsset)           | Useful if you want to attach a video file.                     | Same as above reference files |
 | [`PointCloudAsset`](../../reference/asset.md#kolena.asset.PointCloudAsset) | Useful for attaching 3D point cloud data.                      | `.pcd`, `.npy`, `.npz`        |
 | [`MeshAsset`](../../reference/asset.md#kolena.asset.MeshAsset)             | Useful for attaching and visualizing 3D mesh files.            | `.ply`                        |
-| [`DocumentAsset`](../../reference/asset.md#kolena.asset.DocumentAsset)     | Useful if you want to attach a document file.                  | `.txt`, `.pdf`                |
+| [`DocumentAsset`](../../reference/asset.md#kolena.asset.DocumentAsset)     | Useful if you want to attach a document file.                  | `.pdf`, `.txt`, `.log`, `.md` |
 
 **Annotations**: allow you to visualize overlays on top of datapoints through the use of[`annotation`](../../reference/annotation.md).
 We currently support 10 different types of annotations each enabling a specific modality.

--- a/kolena/asset.py
+++ b/kolena/asset.py
@@ -195,7 +195,7 @@ class DocumentAsset(Asset):
     """
     A document file in a cloud bucket or served at a URL.
 
-    Only `.txt` and `.pdf` file types are supported.
+    Supported extensions include `.pdf`, `.txt`, `.log`, and `.md`.
     """
 
     locator: str

--- a/kolena/asset.py
+++ b/kolena/asset.py
@@ -24,6 +24,7 @@ The following asset types are available:
 - [`VideoAsset`][kolena.asset.VideoAsset]
 - [`AudioAsset`][kolena.asset.AudioAsset]
 - [`MeshAsset`][kolena.asset.MeshAsset]
+- [`DocumentAsset`][kolena.asset.DocumentAsset]
 
 """
 from abc import ABCMeta
@@ -44,6 +45,7 @@ class _AssetType(DataType):
     VIDEO = "VIDEO"
     AUDIO = "AUDIO"
     MESH = "MESH"
+    DOCUMENT = "DOCUMENT"
 
     @staticmethod
     def _data_category() -> DataCategory:
@@ -188,6 +190,22 @@ class MeshAsset(Asset):
         return _AssetType.MESH
 
 
+@dataclass(frozen=True, config=ValidatorConfig)
+class DocumentAsset(Asset):
+    """
+    A document file in a cloud bucket or served at a URL.
+
+    Only `.txt` and `.pdf` file types are supported.
+    """
+
+    locator: str
+    """The location of this document file in a cloud bucket, e.g. `s3://my-bucket/path/to/my-document-asset.pdf`."""
+
+    @staticmethod
+    def _data_type() -> _AssetType:
+        return _AssetType.DOCUMENT
+
+
 _ASSET_TYPES = [
     ImageAsset,
     PlainTextAsset,
@@ -197,4 +215,5 @@ _ASSET_TYPES = [
     VideoAsset,
     AudioAsset,
     MeshAsset,
+    DocumentAsset,
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "numpy >=1.26,<2; python_version >= '3.12'",
     "pandas >=1.1,<3; python_version < '3.12'",
     "pandas >=2.1.1,<3; python_version >= '3.12'",
-    "pandera>=0.9,<1",
+    "pandera>=0.22.1,<1",
     "pydantic>=1.10,<3",
     "dacite>=1.6,<2",
     "requests>=2.20,<3",


### PR DESCRIPTION
### Linked issue(s)
Fixes: KOL-7840

### What change does this PR introduce and why?
Introduces client side support for the DocumentAsset type.

This allows users to attach TXT and PDF documents to their datapoints, without requiring it to be the primary data value.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
