### PR TITLE
bugfix: fix module name for exp special data type

### DIFF
--- a/kolena/_utils/datatypes.py
+++ b/kolena/_utils/datatypes.py
@@ -99,7 +99,7 @@ class DataCategory(str, Enum):
         if self == DataCategory.ANNOTATION:
             return "kolena.annotation"
         if self == DataCategory.SPECIAL:
-            return "kolena._experimental.data_type.special"
+            return "kolena._experimental.special_data_type"
         raise ValueError(f"Must specify module name for data category: {self}")
 
 


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?
See https://github.com/kolenaIO/kolena/pull/742#discussion_r1917322648

Bug from finding the module for special datatypes. Downloading a dataset that has timestamp classes will lead to:
` Failed to import module for data type 'SPECIAL/TIMESTAMP'`

This originates from [this commit](https://github.com/kolenaIO/kolena/pull/730/commits/34cabb2b403bfecc43a339b096898f61fc72629a#diff-5374b7a61484fb5a856021e2ec070f14e0f36fe7127813aadb954310530b3a4e) that moved the module but the refactoring did not find this literal string match.


Testing:

Using the following code on my trunk workspace:
```
from kolena.dataset import download_dataset

df = download_dataset("financebench", include_extracted_properties=True)
```

On trunk, I see `kolena> Failed to import module for data type 'SPECIAL/TIMESTAMP'`

With the change, df download is successful. Example data:
```
print(df["labeling_task"].tail(1))


149    {'answer': 'The three main companies acquired by Pfizer mentioned in this 10-K report are:

1. Medivation, Inc.
2. Hospira, Inc.
3. Anacor Pharmaceuticals, Inc.', 'labeler': 'nan@kolena.com', 'task_name': 'hgfsfdsaadfs', 'timestamp': Timestamp(epoch_time=1736887455.0, value=None, format=None)}
Name: labeling_task, dtype: object

```

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
