### PR TITLE
bugfix: use pydantic v1 compatible imports

### DIFF
--- a/kolena/_api/v2/_api.py
+++ b/kolena/_api/v2/_api.py
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
-from typing import Any
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
 
-from pydantic import root_validator
-from pydantic import StrictFloat
-from pydantic import StrictInt
-from pydantic.dataclasses import dataclass
-from pydantic.types import StrictBool
-from pydantic.types import StrictStr
 from typing_extensions import Literal
+
+from kolena._utils.pydantic_v1 import StrictBool
+from kolena._utils.pydantic_v1 import StrictFloat
+from kolena._utils.pydantic_v1 import StrictInt
+from kolena._utils.pydantic_v1 import StrictStr
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 @dataclass(frozen=True)
@@ -33,13 +31,9 @@ class Range:
     max: float = math.inf
     modulo: Optional[int] = None
 
-    @classmethod
-    @root_validator(skip_on_failure=True)
-    def validate_min_max(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if values["min"] > values["max"]:
+    def __post_init__(self) -> None:
+        if self.min > self.max:
             raise ValueError("Invalid min/max range.")
-
-        return values
 
 
 @dataclass
@@ -86,14 +80,9 @@ class GeneralFieldFilter:
     array_contains: Optional[List[Union[StrictStr, StrictBool, StrictInt, StrictFloat]]] = None
     options: GeneralFieldFilterOptions = GeneralFieldFilterOptions()
 
-    @classmethod
-    @root_validator(skip_on_failure=True)
-    def validate_single_operation(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        # check exactly one filter operation is specified
-        if sum(1 for value in values.values() if value is not None) != 1:
+    def __post_init__(self) -> None:
+        if sum(1 for value in self.__dict__.values() if value is not None) != 1:
             raise ValueError("Must provide exactly one operation.")
-
-        return values
 
     def __hash__(self) -> int:
         return hash((tuple(self.value_in or []), self.number_range, self.contains, self.null_value))

--- a/kolena/_api/v2/_derived_field.py
+++ b/kolena/_api/v2/_derived_field.py
@@ -15,10 +15,8 @@ import re
 from typing import Literal
 from typing import Optional
 
-from pydantic import constr
-from pydantic import model_validator
-from pydantic.dataclasses import dataclass
-from typing_extensions import Self
+from kolena._utils.pydantic_v1 import constr
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 Source = Literal["datapoint", "result"]
 
@@ -33,12 +31,10 @@ class CreateRequest:
     # This field is intended for internal use and should be set by the system, not included in the request body
     source: Source = "datapoint"
 
-    @model_validator(mode="after")
-    def check_name(self) -> Self:
+    def __post_init__(self) -> None:
         name = self.name
         if not re.fullmatch(VALID_NAME_PATTERN, name):
             raise ValueError(f"Invalid name: {name}")
-        return self
 
 
 @dataclass(frozen=True)
@@ -48,21 +44,18 @@ class UpdateRequest:
     # This field is intended for internal use and should be set by the system, not included in the request body
     source: Optional[Source] = None
 
-    @model_validator(mode="after")
-    def check_name(self) -> Self:
+    def __post_init__(self) -> None:
+        self._check_name()
+        self._check_name_formula()
+
+    def _check_name(self) -> None:
         name = self.name
-        if name is None:
-            return self
-
-        if not re.fullmatch(VALID_NAME_PATTERN, name):
+        if name and not re.fullmatch(VALID_NAME_PATTERN, name):
             raise ValueError(f"Invalid name: {name}")
-        return self
 
-    @model_validator(mode="after")
-    def check_name_formula(self) -> Self:
+    def _check_name_formula(self) -> None:
         if self.name is None and self.formula is None:
             raise ValueError("Invalid request")
-        return self
 
 
 @dataclass(frozen=True)

--- a/kolena/_api/v2/_dsl.py
+++ b/kolena/_api/v2/_dsl.py
@@ -14,8 +14,8 @@
 from typing import Dict
 from typing import Literal
 
-from pydantic import constr
-from pydantic.dataclasses import dataclass
+from kolena._utils.pydantic_v1 import constr
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 @dataclass(frozen=True)

--- a/kolena/_api/v2/_filter.py
+++ b/kolena/_api/v2/_filter.py
@@ -17,15 +17,13 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from pydantic import conlist
-from pydantic import model_validator
-from pydantic.dataclasses import dataclass
-
 from kolena._api.v2._api import GeneralFieldFilter
 from kolena._api.v2._api import Range
 from kolena._api.v2._derived_field import DerivedField
 from kolena._api.v2._dsl import Dsl
 from kolena._api.v2._metric import MetricGroup
+from kolena._utils.pydantic_v1 import conlist
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena.errors import IncorrectUsageError
 
 
@@ -46,11 +44,9 @@ class ModelFilter:
             ),
         )
 
-    @model_validator(mode="after")
-    def validate_stratify_field_or_filter(self) -> "ModelFilter":
+    def __post_init__(self) -> None:
         if self.result and self.is_null:
             raise ValueError("Conflicting value filter and null filter.")
-        return self
 
 
 @dataclass(frozen=True)
@@ -116,12 +112,12 @@ class CompareFilter:
 
 @dataclass(frozen=True)
 class Filters:
-    dataset_ids: conlist(int, min_length=1)
-    datapoint_ids: Optional[conlist(int, min_length=0)] = None
+    dataset_ids: conlist(int, min_items=1)
+    datapoint_ids: Optional[conlist(int, min_items=0)] = None
     datapoint: Dict[str, GeneralFieldFilter] = field(default_factory=dict)
     models: List[ModelFilter] = field(default_factory=list)
     compare_filters: List[CompareFilter] = field(default_factory=list)
-    human_evaluations: conlist(HumanEvaluationFilter, max_length=1) = field(default_factory=list)
+    human_evaluations: conlist(HumanEvaluationFilter, max_items=1) = field(default_factory=list)
     difficulty_scores: Optional[DifficultyScoreFilter] = None
     dsl: Optional[Dsl] = None
     derived_fields: Optional[List[DerivedField]] = None

--- a/kolena/_api/v2/_metric.py
+++ b/kolena/_api/v2/_metric.py
@@ -16,10 +16,7 @@ from typing import Literal
 from typing import Optional
 from typing import Union
 
-from pydantic import Field
-from pydantic import field_validator
-from pydantic.dataclasses import dataclass
-from typing_extensions import Annotated
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 MetricFormat = Literal["default", "integer", "decimal", "percentage", "scientific", "dollars", "euros"]
 
@@ -77,12 +74,7 @@ class BinaryClassificationAggregator:
 @dataclass(frozen=True, order=True)
 class MulticlassClassificationAggregator:
     aggregator: Union[Literal["accuracy"], ClassifierAggregator]
-    averagingMethod: Annotated[Union[AveragingMethod, None], Field(validate_default=True)] = None
-
-    @field_validator("averagingMethod")
-    @classmethod
-    def set_null_averaging_method(cls, v: Union[str, None]) -> str:
-        return v or "macro"
+    averagingMethod: AveragingMethod = "macro"
 
 
 @dataclass(frozen=True, order=True)
@@ -109,12 +101,7 @@ class ClassificationMetric(BaseMetric):
 @dataclass(frozen=True, order=True)
 class ObjectDetectionAggregator:
     aggregator: Union[Literal["average_precision"], ClassifierAggregator]
-    averagingMethod: Annotated[Union[AveragingMethod, None], Field(validate_default=True)] = None
-
-    @field_validator("averagingMethod")
-    @classmethod
-    def set_null_averaging_method(cls, v: Union[str, None]) -> str:
-        return v or "macro"
+    averagingMethod: AveragingMethod = "macro"
 
 
 @dataclass(frozen=True, order=True)
@@ -279,12 +266,9 @@ class MetricGroup:
     name: str
     metrics: List[Metric]
 
-    @field_validator("metrics")
-    @classmethod
-    def metric_label_unique(cls, metrics: List[Metric]) -> List[Metric]:
-        if len(metrics) > len({metric.label for metric in metrics}):
+    def __post_init__(self) -> None:
+        if len(self.metrics) > len({metric.label for metric in self.metrics}):
             raise ValueError("Metric labels must be unique.")
-        return metrics
 
     def __hash__(self) -> int:
         return hash(

--- a/kolena/_api/v2/_scope.py
+++ b/kolena/_api/v2/_scope.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 from typing import Optional
 
-from pydantic import conlist
-from pydantic import constr
-from pydantic.dataclasses import dataclass
+from kolena._utils.pydantic_v1 import conlist
+from kolena._utils.pydantic_v1 import constr
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 @dataclass(frozen=True)

--- a/kolena/_api/v2/_stats.py
+++ b/kolena/_api/v2/_stats.py
@@ -17,9 +17,9 @@ from typing import List
 from typing import Literal
 from typing import Union
 
-from pydantic import StrictBool
-from pydantic import StrictStr
-from pydantic.dataclasses import dataclass
+from kolena._utils.pydantic_v1 import StrictBool
+from kolena._utils.pydantic_v1 import StrictStr
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 @dataclass(frozen=True)

--- a/kolena/_api/v2/_stratification.py
+++ b/kolena/_api/v2/_stratification.py
@@ -15,13 +15,10 @@ from typing import Dict
 from typing import List
 from typing import Union
 
-from pydantic import field_validator
-from pydantic import model_validator
-from pydantic.dataclasses import dataclass
-
 from kolena._api.v2._api import GeneralFieldFilter
 from kolena._api.v2._testing import SimpleRange
 from kolena._api.v2._testing import StratifyFieldSpec
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
 @dataclass(frozen=True)
@@ -55,15 +52,14 @@ class Stratification:
     test_cases: List[TestCase]
     filters: Union[Dict[str, GeneralFieldFilter], None] = None
 
-    @field_validator("test_cases")
-    @classmethod
-    def test_case_name_unique(cls, test_cases: List[TestCase]) -> List[TestCase]:
-        if len(test_cases) > len({test_case.name for test_case in test_cases}):
-            raise ValueError("Test case name must be unique.")
-        return test_cases
+    def __post_init__(self) -> None:
+        self._check_test_case_name_unique()
+        self._validate_stratify_field_or_filter()
 
-    @model_validator(mode="after")
-    def validate_stratify_field_or_filter(self) -> "Stratification":
+    def _check_test_case_name_unique(self) -> None:
+        if len(self.test_cases) > len({test_case.name for test_case in self.test_cases}):
+            raise ValueError("Test case name must be unique.")
+
+    def _validate_stratify_field_or_filter(self) -> None:
         if not self.stratify_fields and not self.filters:
             raise ValueError("Must provide one of 'stratify_fields' or 'filters'")
-        return self

--- a/kolena/_api/v2/_testing.py
+++ b/kolena/_api/v2/_testing.py
@@ -21,16 +21,15 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from pydantic import conint
-from pydantic import conlist
-from pydantic import constr
-from pydantic import StrictInt
-from pydantic import StrictStr
-from pydantic.dataclasses import dataclass
-
 from kolena._api.v2._filter import Filters
 from kolena._api.v2._scope import Scopes
 from kolena._api.v2._stats import SingleStatsResponse
+from kolena._utils.pydantic_v1 import conint
+from kolena._utils.pydantic_v1 import conlist
+from kolena._utils.pydantic_v1 import constr
+from kolena._utils.pydantic_v1 import StrictInt
+from kolena._utils.pydantic_v1 import StrictStr
+from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena.errors import IncorrectUsageError
 
 MAX_BIN_COUNT = 200
@@ -137,7 +136,7 @@ class TypedBucketSplit:
 class StratifyFieldSpec(DatasetField):
     values: Optional[List[Union[StrictStr, StrictInt, bool, None]]] = None
     buckets: Union[
-        conlist(float, min_length=1, max_length=MAX_STRATIFICATION_BUCKET_COUNT),
+        conlist(float, min_items=1, max_items=MAX_STRATIFICATION_BUCKET_COUNT),
         TypedBucketSplit,
         None,
     ] = None

--- a/kolena/_api/v2/quality_standard.py
+++ b/kolena/_api/v2/quality_standard.py
@@ -15,10 +15,9 @@ from datetime import datetime
 from enum import Enum
 from typing import List
 
-from pydantic.v1 import conint
-
 from kolena._api.v2._metric import MetricGroup
 from kolena._api.v2._stratification import Stratification
+from kolena._utils.pydantic_v1 import conint
 from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-7886

### What change does this PR introduce and why?
- Use `kolena._utils.pydantic_v1` for all pydantic imports. This ensures that we are using either the stuff from pydantic-v1, or pydantic-v1-compatible modules from pydantic v2. Otherwise pydantic v1 users may see error messages such as `ImportError: cannot import name 'model_validator' from 'pydantic'`
- Use the generic `__post_init__` to replace pydantic validators - this is because `model_validator` is new in v2 while `root_validator` is marked as deprecated in v2. Though we can possibly use the latter it feels a better options to not use it.
- Updated method arg names to those used in pydantic-v1 (`min_length` vs `min_items` for example)


Testing:
Using [this commit](https://github.com/kolenaIO/kolena/compare/trunk...nan/workflow-pydantic-v1-test), running `uv run python3 workflow_test/test.py` is successful after the change. While using trunk, I saw
```
Traceback (most recent call last):
  File "/Users/nanwei/Desktop/kolena_dev/kolena_client/examples/workflow/test_pydantic_v1/workflow_test/test.py", line 15, in <module>
    from kolena.workflow import TestSample
  File "/Users/nanwei/Desktop/kolena_dev/kolena_client/examples/workflow/test_pydantic_v1/.venv/lib/python3.9/site-packages/kolena/workflow/__init__.py", line 17, in <module>
    from .test_sample import Audio
  File "/Users/nanwei/Desktop/kolena_dev/kolena_client/examples/workflow/test_pydantic_v1/.venv/lib/python3.9/site-packages/kolena/workflow/test_sample.py", line 63, in <module>
    from kolena.workflow._validators import get_data_object_field_types
  File "/Users/nanwei/Desktop/kolena_dev/kolena_client/examples/workflow/test_pydantic_v1/.venv/lib/python3.9/site-packages/kolena/workflow/_validators.py", line 28, in <module>
    from kolena._experimental.workflow.thresholded import ThresholdedMetrics
  File "/Users/nanwei/Desktop/kolena_dev/kolena_client/examples/workflow/test_pydantic_v1/.venv/lib/python3.9/site-packages/kolena/_experimental/__init__.py", line 14, in <module>
    from kolena._experimental.quality_standard import copy_quality_standards_from_dataset
  File "/Users/nanwei/Desktop/kolena_dev/kolena_client/examples/workflow/test_pydantic_v1/.venv/lib/python3.9/site-packages/kolena/_experimental/quality_standard.py", line 30, in <module>
    from kolena._api.v2._filter import Filters
  File "/Users/nanwei/Desktop/kolena_dev/kolena_client/examples/workflow/test_pydantic_v1/.venv/lib/python3.9/site-packages/kolena/_api/v2/_filter.py", line 21, in <module>
    from pydantic import model_validator
ImportError: cannot import name 'model_validator' from 'pydantic'
```

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
