### PR TITLE
Add client implementation for uploading multilabel classification results

### DIFF
--- a/docs/reference/experimental/index.md
+++ b/docs/reference/experimental/index.md
@@ -8,6 +8,10 @@
     options:
         show_root_heading: true
         members: ["upload_dataset_embeddings"]
+::: kolena._experimental.classification
+    options:
+        members: ["upload_multilabel_classification_results"]
+        show_root_heading: true
 ::: kolena._experimental.object_detection
     options:
         members: ["compute_object_detection_results", "upload_object_detection_results"]

--- a/kolena/_experimental/classification/__init__.py
+++ b/kolena/_experimental/classification/__init__.py
@@ -11,3 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from .dataset import upload_multilabel_classification_results
+
+__all__ = [
+    "upload_multilabel_classification_results",
+]

--- a/kolena/_experimental/classification/_matching.py
+++ b/kolena/_experimental/classification/_matching.py
@@ -43,8 +43,7 @@ class InferenceMatches(Generic[GT, Inf]):
 
     matched: List[Tuple[GT, Inf]]
     """
-    Pairs of matched ground truth and inference objects above the IoU threshold, along with the calculated IoU.
-    Considered as true positive classifications after applying some confidence threshold.
+    Pairs of matched ground truth and inference objects. Considered as true positives.
     """
 
     unmatched_gt: List[GT]
@@ -52,7 +51,7 @@ class InferenceMatches(Generic[GT, Inf]):
 
     unmatched_inf: List[Inf]
     """
-    Unmatched inference objects. Considered as false positives after applying some confidence threshold.
+    Unmatched inference objects. Considered as false positives.
     """
 
 
@@ -74,7 +73,6 @@ def match_inferences(
     ignored_ground_truths: Optional[List[GT]] = None,
     required_match_fields: Optional[List[str]] = None,
 ) -> InferenceMatches[GT, Inf]:
-    inferences = sorted(inferences, key=lambda inf: inf.score if hasattr(inf, "score") else 0, reverse=True)
     if required_match_fields is None or len(required_match_fields) == 0:
         return _match_inferences(
             ground_truths,
@@ -116,6 +114,7 @@ def _match_inferences(
     *,
     ignored_ground_truths: Optional[List[GT]] = None,
 ) -> InferenceMatches[GT, Inf]:
+    inferences = sorted(inferences, key=lambda inf: inf.score if hasattr(inf, "score") else 0, reverse=True)
     matched: List[Tuple[GT, Inf]] = []
     unmatched_inf: List[Inf] = []
     taken_gts: Set[int] = set()
@@ -145,18 +144,3 @@ def get_label(classification: Union[str, Label, ScoredLabel]) -> str:
     if isinstance(classification, str):
         return classification
     return classification.label
-
-
-def filter_inferences(
-    inferences: List[Union[str, Label, ScoredLabel]],
-    confidence_score: Optional[float] = None,
-    labels: Optional[Set[str]] = None,
-) -> List[Union[str, Label, ScoredLabel]]:
-    filtered_by_confidence = (
-        [inf for inf in inferences if hasattr(inf, "score") and inf.score >= confidence_score]
-        if confidence_score
-        else inferences
-    )
-    if labels is None:
-        return filtered_by_confidence
-    return [inf for inf in filtered_by_confidence if get_label(inf) in labels]

--- a/kolena/_experimental/classification/_matching.py
+++ b/kolena/_experimental/classification/_matching.py
@@ -1,0 +1,162 @@
+# Copyright 2021-2025 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import defaultdict
+from typing import Dict
+from typing import Generic
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import TypeVar
+from typing import Union
+
+from pydantic.dataclasses import dataclass
+
+from kolena.annotation import Label
+from kolena.annotation import ScoredLabel
+
+GT = TypeVar("GT", bound=Union[str, Label])
+Inf = TypeVar("Inf", bound=Union[str, Label, ScoredLabel])
+
+
+@dataclass(frozen=True)
+class InferenceMatches(Generic[GT, Inf]):
+    """
+    The result of [`match_inferences`][kolena.metrics.match_inferences], providing lists of matches between
+    ground truth and inference objects, unmatched ground truths, and unmatched inferences. After applying some
+    confidence threshold on returned inference objects, `InferenceMatches` can be used to calculate metrics such as
+    precision and recall.
+
+    Objects are of type [`BoundingBox`][kolena.annotation.BoundingBox] or
+    [`Polygon`][kolena.annotation.Polygon], depending on the type of inputs provided to
+    [`match_inferences`][kolena.metrics.match_inferences].
+    """
+
+    matched: List[Tuple[GT, Inf]]
+    """
+    Pairs of matched ground truth and inference objects above the IoU threshold, along with the calculated IoU.
+    Considered as true positive classifications after applying some confidence threshold.
+    """
+
+    unmatched_gt: List[GT]
+    """Unmatched ground truth objects. Considered as false negatives."""
+
+    unmatched_inf: List[Inf]
+    """
+    Unmatched inference objects. Considered as false positives after applying some confidence threshold.
+    """
+
+
+def _get_keyed_items(
+    items: List,
+    required_match_fields: List[str],
+) -> Dict[Tuple, List]:
+    keyed_items = defaultdict(list)
+    for item in items:
+        key = tuple(getattr(item, field, None) for field in required_match_fields)
+        keyed_items[key].append(item)
+    return keyed_items
+
+
+def match_inferences(
+    ground_truths: List[GT],
+    inferences: List[Inf],
+    *,
+    ignored_ground_truths: Optional[List[GT]] = None,
+    required_match_fields: Optional[List[str]] = None,
+) -> InferenceMatches[GT, Inf]:
+    inferences = sorted(inferences, key=lambda inf: inf.score if hasattr(inf, "score") else 0, reverse=True)
+    if required_match_fields is None or len(required_match_fields) == 0:
+        return _match_inferences(
+            ground_truths,
+            inferences,
+            ignored_ground_truths=ignored_ground_truths,
+        )
+
+    keyed_inferences = _get_keyed_items(inferences, required_match_fields)
+    keyed_ground_truths = _get_keyed_items(ground_truths, required_match_fields)
+    keyed_ignore_ground_truths = (
+        _get_keyed_items(ignored_ground_truths, required_match_fields) if ignored_ground_truths else defaultdict(list)
+    )
+    keys = {*keyed_inferences.keys(), *keyed_ground_truths.keys(), *keyed_ignore_ground_truths.keys()}
+    inf_matches = [
+        _match_inferences(
+            keyed_ground_truths[key],
+            keyed_inferences[key],
+            ignored_ground_truths=keyed_ignore_ground_truths[key],
+        )
+        for key in keys
+    ]
+    flattened_matched: List[Tuple[GT, Inf]] = []
+    flattened_unmatched_gt: List[GT] = []
+    flattened_unmatched_inf: List[Inf] = []
+    for inf_match in inf_matches:
+        flattened_matched.extend(inf_match.matched)
+        flattened_unmatched_gt.extend(inf_match.unmatched_gt)
+        flattened_unmatched_inf.extend(inf_match.unmatched_inf)
+    return InferenceMatches(
+        matched=flattened_matched,
+        unmatched_gt=flattened_unmatched_gt,
+        unmatched_inf=flattened_unmatched_inf,
+    )
+
+
+def _match_inferences(
+    ground_truths: List[GT],
+    inferences: List[Inf],
+    *,
+    ignored_ground_truths: Optional[List[GT]] = None,
+) -> InferenceMatches[GT, Inf]:
+    matched: List[Tuple[GT, Inf]] = []
+    unmatched_inf: List[Inf] = []
+    taken_gts: Set[int] = set()
+
+    gt_objects = ground_truths
+    if ignored_ground_truths:
+        gt_objects = gt_objects + ignored_ground_truths
+
+    for inf in inferences:
+        is_matched = False
+        for g, gt in enumerate(gt_objects):
+            if g in taken_gts:
+                continue
+            if get_label(gt) == get_label(inf):
+                if g < len(ground_truths):
+                    matched.append((gt, inf))
+                taken_gts.add(g)
+                is_matched = True
+                break
+        if not is_matched:
+            unmatched_inf.append(inf)
+    unmatched_gt = [gt for g, gt in enumerate(ground_truths) if g not in taken_gts]
+    return InferenceMatches(matched=matched, unmatched_gt=unmatched_gt, unmatched_inf=unmatched_inf)
+
+
+def get_label(classification: Union[str, Label, ScoredLabel]) -> str:
+    if isinstance(classification, str):
+        return classification
+    return classification.label
+
+
+def filter_inferences(
+    inferences: List[Union[str, Label, ScoredLabel]],
+    confidence_score: Optional[float] = None,
+    labels: Optional[Set[str]] = None,
+) -> List[Union[str, Label, ScoredLabel]]:
+    filtered_by_confidence = (
+        [inf for inf in inferences if inf.score >= confidence_score] if confidence_score else inferences
+    )
+    if labels is None:
+        return filtered_by_confidence
+    return [inf for inf in filtered_by_confidence if get_label(inf) in labels]

--- a/kolena/_experimental/classification/_matching.py
+++ b/kolena/_experimental/classification/_matching.py
@@ -33,13 +33,11 @@ Inf = TypeVar("Inf", bound=Union[str, Label, ScoredLabel])
 @dataclass(frozen=True)
 class InferenceMatches(Generic[GT, Inf]):
     """
-    The result of [`match_inferences`][kolena.metrics.match_inferences], providing lists of matches between
-    ground truth and inference objects, unmatched ground truths, and unmatched inferences. After applying some
-    confidence threshold on returned inference objects, `InferenceMatches` can be used to calculate metrics such as
-    precision and recall.
+    The result of [`match_inferences`][kolena._experimental.classification._matching.match_inferences], providing lists
+    of matches between ground truth and inference objects, unmatched ground truths, and unmatched inferences.
+    `InferenceMatches` can be used to calculate metrics such as precision and recall.
 
-    Objects are of type [`BoundingBox`][kolena.annotation.BoundingBox] or
-    [`Polygon`][kolena.annotation.Polygon], depending on the type of inputs provided to
+    Objects are of type `str` or [`Label`][kolena.annotation.Label], depending on the type of inputs provided to
     [`match_inferences`][kolena.metrics.match_inferences].
     """
 

--- a/kolena/_experimental/classification/_matching.py
+++ b/kolena/_experimental/classification/_matching.py
@@ -155,7 +155,9 @@ def filter_inferences(
     labels: Optional[Set[str]] = None,
 ) -> List[Union[str, Label, ScoredLabel]]:
     filtered_by_confidence = (
-        [inf for inf in inferences if inf.score >= confidence_score] if confidence_score else inferences
+        [inf for inf in inferences if hasattr(inf, "score") and inf.score >= confidence_score]
+        if confidence_score
+        else inferences
     )
     if labels is None:
         return filtered_by_confidence

--- a/kolena/_experimental/classification/dataset.py
+++ b/kolena/_experimental/classification/dataset.py
@@ -32,14 +32,16 @@ from kolena.dataset.dataset import _load_dataset_metadata
 from kolena.errors import IncorrectUsageError
 
 
+def _label_as_dict(raw_label: Union[str, Label, ScoredLabel]) -> Dict[str, Any]:
+    if isinstance(raw_label, str):
+        return dict(label=raw_label)
+    return raw_label._to_dict()
+
+
 def merge(gt: Union[str, Label, ScoredLabel], inf: Union[str, Label, ScoredLabel]) -> Union[str, Dict[str, Any]]:
     if isinstance(gt, str) and isinstance(inf, str):
         return gt
-    if isinstance(gt, str):
-        return inf._to_dict()
-    if isinstance(inf, str):
-        return gt._to_dict()
-    return {**gt._to_dict(), **inf._to_dict()}
+    return {**_label_as_dict(gt), **_label_as_dict(inf)}
 
 
 def datapoint_metrics(

--- a/kolena/_experimental/classification/dataset.py
+++ b/kolena/_experimental/classification/dataset.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import itertools
 from typing import Any
-from typing import cast
 from typing import Dict
 from typing import Iterable
 from typing import Iterator
@@ -37,9 +36,9 @@ def merge(gt: Union[str, Label, ScoredLabel], inf: Union[str, Label, ScoredLabel
     if isinstance(gt, str) and isinstance(inf, str):
         return gt
     if isinstance(gt, str):
-        return inf
+        return inf._to_dict()
     if isinstance(inf, str):
-        return gt
+        return gt._to_dict()
     return {**gt._to_dict(), **inf._to_dict()}
 
 
@@ -134,7 +133,7 @@ def _compute_metrics(
     pred_df.drop(columns=ground_truth, inplace=True)
     yield from _iter_metrics(
         pred_df,
-        cast(List[InferenceMatches], all_object_matches),
+        all_object_matches,
         batch_size=batch_size,
     )
 
@@ -185,6 +184,8 @@ def _iter_multilabel_classification_results(
     _validate_column_present(df, raw_inferences_field)
 
     dataset_metadata = _load_dataset_metadata(dataset_name)
+    if dataset_metadata is None:
+        raise RuntimeError("error retrieving dataset id fields")
     id_fields = dataset_metadata.id_fields
     dataset_df = dataset.download_dataset(dataset_name)
     dataset_df = dataset_df[[*id_fields, ground_truths_field]]

--- a/kolena/_experimental/classification/dataset.py
+++ b/kolena/_experimental/classification/dataset.py
@@ -1,0 +1,287 @@
+# Copyright 2021-2025 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import itertools
+from typing import Any
+from typing import cast
+from typing import Dict
+from typing import Iterable
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Union
+
+import pandas as pd
+import tqdm
+
+from kolena import dataset
+from kolena._experimental.classification._matching import InferenceMatches
+from kolena._experimental.classification._matching import match_inferences
+from kolena.annotation import Label
+from kolena.annotation import ScoredLabel
+from kolena.dataset.dataset import _load_dataset_metadata
+from kolena.errors import IncorrectUsageError
+
+
+def merge(gt: Union[str, Label, ScoredLabel], inf: Union[str, Label, ScoredLabel]) -> Union[str, Dict[str, Any]]:
+    if isinstance(gt, str) and isinstance(inf, str):
+        return gt
+    if isinstance(gt, str):
+        return inf
+    if isinstance(inf, str):
+        return gt
+    return {**gt._to_dict(), **inf._to_dict()}
+
+
+def datapoint_metrics(
+    object_matches: InferenceMatches,
+) -> Dict[str, Any]:
+    tp = [merge(gt, inf) for gt, inf in object_matches.matched]
+    fp = object_matches.unmatched_inf
+    fn = object_matches.unmatched_gt
+    count_tp = len(tp)
+    count_fp = len(fp)
+    count_fn = len(fn)
+    precision = count_tp / (count_tp + count_fp) if count_tp + count_fp > 0 else 0
+    recall = count_tp / (count_tp + count_fn) if count_tp + count_fn > 0 else 0
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0
+    jaccard_index = count_tp / (count_tp + count_fp + count_fn) if count_tp + count_fp + count_fn > 0 else 0
+
+    return dict(
+        TP=tp,
+        FP=fp,
+        FN=fn,
+        count_TP=len(tp),
+        count_FP=len(fp),
+        count_FN=len(fn),
+        is_exact_match=len(fp) + len(fn) == 0,
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        jaccard_index=jaccard_index,
+    )
+
+
+def _iter_metrics(
+    pred_df: pd.DataFrame,
+    all_object_matches: List[InferenceMatches],
+    *,
+    batch_size: int = 10_000,
+) -> Iterator[pd.DataFrame]:
+    for i in tqdm.tqdm(range(0, pred_df.shape[0], batch_size)):
+        metrics = [datapoint_metrics(matches) for matches in all_object_matches[i : i + batch_size]]
+        yield pd.concat([pd.DataFrame(metrics), pred_df.reset_index(drop=True)], axis=1)
+
+
+def _compute_metrics(
+    pred_df: pd.DataFrame,
+    *,
+    ground_truth: str,
+    inference: str,
+    gt_ignore_property: Optional[str] = None,
+    batch_size: int = 10_000,
+    required_match_fields: Optional[List[str]] = None,
+) -> Iterator[pd.DataFrame]:
+    """
+    Compute metrics for object detection.
+
+    :param df: Dataframe for model results.
+    :param ground_truth: Column name for ground truth object annotations
+    :param inference: Column name for inference object annotations
+    :param gt_ignore_property: Field on the ground truth labels used to determine if the label should be
+    ignored. Labels will be ignored if this field exists and is equal to `True`.
+    :param batch_size: number of results to process per iteration.
+    :param Optional[List[str]] required_match_fields: Optionally specify a list of fields that must match between
+        the inference and ground truth for them to be considered a match. This only applies if both the ground truth
+        and inference fields are lists of [`Labels`][kolena.annotation.Label].
+    """
+    idx = {name: i for i, name in enumerate(list(pred_df), start=1)}
+
+    all_object_matches: List[InferenceMatches] = []
+    for record in pred_df.itertuples():
+        ground_truths = record[idx[ground_truth]]
+        inferences = record[idx[inference]]
+        ignored_ground_truths = [
+            gt
+            for gt in ground_truths
+            if gt_ignore_property is not None
+            and hasattr(gt, gt_ignore_property)
+            and isinstance(getattr(gt, gt_ignore_property), bool)
+            and getattr(gt, gt_ignore_property)
+        ]
+        unignored_ground_truths = [gt for gt in ground_truths if gt not in ignored_ground_truths]
+        all_object_matches.append(
+            match_inferences(
+                unignored_ground_truths,
+                inferences,
+                ignored_ground_truths=ignored_ground_truths,
+                required_match_fields=required_match_fields,
+            ),
+        )
+
+    pred_df.drop(columns=ground_truth, inplace=True)
+    yield from _iter_metrics(
+        pred_df,
+        cast(List[InferenceMatches], all_object_matches),
+        batch_size=batch_size,
+    )
+
+
+def _safe_get_label(obj: object) -> Optional[str]:
+    if isinstance(obj, str):
+        return obj
+    if hasattr(obj, "label"):
+        return str(obj.label)
+
+    return None
+
+
+def _safe_get_scored(obj: object) -> Optional[bool]:
+    return hasattr(obj, "score")
+
+
+def _get_labels_from_objects(objs: Iterable[object]) -> List[str]:
+    maybe_labels = {_safe_get_label(obj) for obj in objs}
+    labels = [label for label in maybe_labels if label is not None]
+    return labels
+
+
+def _check_scored(inference: pd.Series) -> bool:
+    scored = {hasattr(inf, "score") for inf in itertools.chain.from_iterable(_filter_null(inference))}
+    return len(scored) == 1 and (True in scored)
+
+
+def _filter_null(series: pd.Series) -> pd.Series:
+    return series[series.notnull()]
+
+
+def _validate_column_present(df: pd.DataFrame, col: str) -> None:
+    if col not in df.columns:
+        raise IncorrectUsageError(f"Missing column '{col}'")
+
+
+def _iter_multilabel_classification_results(
+    dataset_name: str,
+    df: pd.DataFrame,
+    *,
+    ground_truths_field: str = "ground_truths",
+    raw_inferences_field: str = "raw_inferences",
+    gt_ignore_property: Optional[str] = None,
+    batch_size: int = 10_000,
+    required_match_fields: Optional[List[str]] = None,
+) -> Iterator[pd.DataFrame]:
+    _validate_column_present(df, raw_inferences_field)
+
+    dataset_metadata = _load_dataset_metadata(dataset_name)
+    id_fields = dataset_metadata.id_fields
+    dataset_df = dataset.download_dataset(dataset_name)
+    dataset_df = dataset_df[[*id_fields, ground_truths_field]]
+    _validate_column_present(dataset_df, ground_truths_field)
+
+    merged_df = df.merge(dataset_df, on=id_fields)
+    return _compute_metrics(
+        merged_df,
+        ground_truth=ground_truths_field,
+        inference=raw_inferences_field,
+        gt_ignore_property=gt_ignore_property,
+        batch_size=batch_size,
+        required_match_fields=required_match_fields,
+    )
+
+
+def compute_multilabel_classification_results(
+    dataset_name: str,
+    df: pd.DataFrame,
+    *,
+    ground_truths_field: str = "ground_truths",
+    raw_inferences_field: str = "raw_inferences",
+    gt_ignore_property: Optional[str] = None,
+    batch_size: int = 10_000,
+) -> pd.DataFrame:
+    """
+    Compute metrics of the model for the dataset.
+
+    Dataframe `df` should include all id columns that would match to that of corresponding datapoint and
+    an `inference` column that should be a list of either `str` or [`Labels`][kolena.annotation.Label].
+
+    :param dataset_name: Dataset name.
+    :param df: Dataframe for model results.
+    :param ground_truths_field: Field name in datapoint with ground truth labels,
+    defaulting to `"ground_truths"`.
+    :param raw_inferences_field: Column in model result DataFrame with raw inference labels,
+    defaulting to `"raw_inferences"`.
+    :param gt_ignore_property: Field on the ground truth labels used to determine if the label should be
+    ignored. Labels will be ignored if this field exists and is equal to `True`.
+    :param batch_size: number of results to process per iteration.
+    :return: A `DataFrame` of the computed results
+    """
+    results_iter = _iter_multilabel_classification_results(
+        dataset_name,
+        df,
+        ground_truths_field=ground_truths_field,
+        raw_inferences_field=raw_inferences_field,
+        gt_ignore_property=gt_ignore_property,
+        batch_size=batch_size,
+    )
+    return pd.concat(list(results_iter))
+
+
+def upload_multilabel_classification_results(
+    dataset_name: str,
+    model_name: str,
+    df: pd.DataFrame,
+    *,
+    ground_truths_field: str = "ground_truths",
+    raw_inferences_field: str = "raw_inferences",
+    gt_ignore_property: Optional[str] = None,
+    batch_size: int = 10_000,
+    required_match_fields: Optional[List[str]] = None,
+) -> None:
+    """
+    Compute metrics and upload results of the model computed by
+    [`compute_multilabel_classification_results`][kolena._experimental.multilabel_classification.compute_multilabel_classification_results]
+    for the dataset.
+
+    Dataframe `df` should include all id columns that would match to that of corresponding datapoint and
+    an `inference` column that should be a list of either `str` or [`Labels`][kolena.annotation.Label].
+
+    :param dataset_name: Dataset name.
+    :param model_name: Model name.
+    :param df: Dataframe for model results.
+    :param ground_truths_field: Field name in datapoint with ground truth labels,
+    defaulting to `"ground_truths"`.
+    :param raw_inferences_field: Column in model result DataFrame with raw inference labels,
+    defaulting to `"raw_inferences"`.
+    :param gt_ignore_property: Name of a property on the ground truth labels used to determine if the label
+    should be ignored. Labels will be ignored if this property exists and is equal to `True`.
+    :param batch_size: number of results to process per iteration.
+    :param Optional[List[str]] required_match_fields: Optionally specify a list of fields that must match between
+        the inference and ground truth for them to be considered a match. This only applies if both the ground truth
+        and inference fields are lists of [`Labels`][kolena.annotation.Label].
+    :return:
+    """
+
+    results = _iter_multilabel_classification_results(
+        dataset_name,
+        df,
+        ground_truths_field=ground_truths_field,
+        raw_inferences_field=raw_inferences_field,
+        gt_ignore_property=gt_ignore_property,
+        batch_size=batch_size,
+        required_match_fields=required_match_fields,
+    )
+    dataset.upload_results(
+        dataset_name,
+        model_name,
+        results,
+    )

--- a/kolena/_experimental/classification/dataset.py
+++ b/kolena/_experimental/classification/dataset.py
@@ -189,6 +189,10 @@ def _iter_multilabel_classification_results(
     dataset_df = dataset.download_dataset(dataset_name)
     dataset_df = dataset_df[[*id_fields, ground_truths_field]]
     _validate_column_present(dataset_df, ground_truths_field)
+    while ground_truths_field in df.columns:
+        new_ground_truths_field = f"_kolena.rename.{ground_truths_field}"
+        dataset_df = dataset_df.rename(columns={ground_truths_field: new_ground_truths_field})
+        ground_truths_field = new_ground_truths_field
 
     merged_df = df.merge(dataset_df, on=id_fields)
     return _compute_metrics(

--- a/kolena/_experimental/classification/dataset.py
+++ b/kolena/_experimental/classification/dataset.py
@@ -201,7 +201,7 @@ def _iter_multilabel_classification_results(
     )
 
 
-def compute_multilabel_classification_results(
+def _compute_multilabel_classification_results(
     dataset_name: str,
     df: pd.DataFrame,
     *,

--- a/kolena/_experimental/classification/dataset.py
+++ b/kolena/_experimental/classification/dataset.py
@@ -38,16 +38,19 @@ def _label_as_dict(raw_label: Union[str, Label, ScoredLabel]) -> Dict[str, Any]:
     return raw_label._to_dict()
 
 
-def merge(gt: Union[str, Label, ScoredLabel], inf: Union[str, Label, ScoredLabel]) -> Union[str, Dict[str, Any]]:
+def _merge_labels(
+    gt: Union[str, Label, ScoredLabel],
+    inf: Union[str, Label, ScoredLabel],
+) -> Union[str, Dict[str, Any]]:
     if isinstance(gt, str) and isinstance(inf, str):
         return gt
     return {**_label_as_dict(gt), **_label_as_dict(inf)}
 
 
-def datapoint_metrics(
+def _datapoint_metrics(
     object_matches: InferenceMatches,
 ) -> Dict[str, Any]:
-    tp = [merge(gt, inf) for gt, inf in object_matches.matched]
+    tp = [_merge_labels(gt, inf) for gt, inf in object_matches.matched]
     fp = object_matches.unmatched_inf
     fn = object_matches.unmatched_gt
     count_tp = len(tp)
@@ -80,7 +83,7 @@ def _iter_metrics(
     batch_size: int = 10_000,
 ) -> Iterator[pd.DataFrame]:
     for i in tqdm.tqdm(range(0, pred_df.shape[0], batch_size)):
-        metrics = [datapoint_metrics(matches) for matches in all_object_matches[i : i + batch_size]]
+        metrics = [_datapoint_metrics(matches) for matches in all_object_matches[i : i + batch_size]]
         pred_df = pred_df.reset_index(drop=True)
         pred_df["multilabel_classification.metrics"] = metrics
         yield pred_df
@@ -234,7 +237,8 @@ def upload_multilabel_classification_results(
     :param ground_truths_field: Field name in datapoint with ground truth labels,
     defaulting to `"ground_truths"`.
     :param raw_inferences_field: Column in model result DataFrame with raw inference labels,
-    defaulting to `"raw_inferences"`.
+    defaulting to `"raw_inferences"`. These inferences will be directly matched against the ground truths, and
+    should be pre-filtered for any disqualifying factors, such as confidence.
     :param gt_ignore_property: Name of a property on the ground truth labels used to determine if the label
     should be ignored. Labels will be ignored if this property exists and is equal to `True`.
     :param batch_size: number of results to process per iteration.

--- a/kolena/_experimental/classification/dataset.py
+++ b/kolena/_experimental/classification/dataset.py
@@ -65,10 +65,10 @@ def datapoint_metrics(
         count_FP=len(fp),
         count_FN=len(fn),
         is_exact_match=len(fp) + len(fn) == 0,
-        precision=precision,
-        recall=recall,
-        f1=f1,
-        jaccard_index=jaccard_index,
+        Precision=precision,
+        Recall=recall,
+        F1_Score=f1,
+        Jaccard_Index=jaccard_index,
     )
 
 
@@ -80,7 +80,9 @@ def _iter_metrics(
 ) -> Iterator[pd.DataFrame]:
     for i in tqdm.tqdm(range(0, pred_df.shape[0], batch_size)):
         metrics = [datapoint_metrics(matches) for matches in all_object_matches[i : i + batch_size]]
-        yield pd.concat([pd.DataFrame(metrics), pred_df.reset_index(drop=True)], axis=1)
+        pred_df = pred_df.reset_index(drop=True)
+        pred_df["multilabel_classification.metrics"] = metrics
+        yield pred_df
 
 
 def _compute_metrics(
@@ -96,8 +98,8 @@ def _compute_metrics(
     Compute metrics for object detection.
 
     :param df: Dataframe for model results.
-    :param ground_truth: Column name for ground truth object annotations
-    :param inference: Column name for inference object annotations
+    :param ground_truth: Column name for ground truth object labels
+    :param inference: Column name for inference object labels
     :param gt_ignore_property: Field on the ground truth labels used to determine if the label should be
     ignored. Labels will be ignored if this field exists and is equal to `True`.
     :param batch_size: number of results to process per iteration.

--- a/kolena/_experimental/classification/dataset.py
+++ b/kolena/_experimental/classification/dataset.py
@@ -223,9 +223,7 @@ def upload_multilabel_classification_results(
     required_match_fields: Optional[List[str]] = None,
 ) -> None:
     """
-    Compute metrics and upload results of the model computed by
-    [`compute_multilabel_classification_results`][kolena._experimental.multilabel_classification.compute_multilabel_classification_results]
-    for the dataset.
+    Compute metrics and upload results of the model for the dataset.
 
     Dataframe `df` should include all id columns that would match to that of corresponding datapoint and
     an `inference` column that should be a list of either `str` or scored / un-scored

--- a/kolena/_experimental/classification/dataset.py
+++ b/kolena/_experimental/classification/dataset.py
@@ -94,7 +94,7 @@ def _compute_metrics(
     required_match_fields: Optional[List[str]] = None,
 ) -> Iterator[pd.DataFrame]:
     """
-    Compute metrics for object detection.
+    Compute metrics for multilabel classification.
 
     :param df: Dataframe for model results.
     :param ground_truth: Column name for ground truth object labels
@@ -206,43 +206,6 @@ def _iter_multilabel_classification_results(
     )
 
 
-def _compute_multilabel_classification_results(
-    dataset_name: str,
-    df: pd.DataFrame,
-    *,
-    ground_truths_field: str = "ground_truths",
-    raw_inferences_field: str = "raw_inferences",
-    gt_ignore_property: Optional[str] = None,
-    batch_size: int = 10_000,
-) -> pd.DataFrame:
-    """
-    Compute metrics of the model for the dataset.
-
-    Dataframe `df` should include all id columns that would match to that of corresponding datapoint and
-    an `inference` column that should be a list of either `str` or [`Labels`][kolena.annotation.Label].
-
-    :param dataset_name: Dataset name.
-    :param df: Dataframe for model results.
-    :param ground_truths_field: Field name in datapoint with ground truth labels,
-    defaulting to `"ground_truths"`.
-    :param raw_inferences_field: Column in model result DataFrame with raw inference labels,
-    defaulting to `"raw_inferences"`.
-    :param gt_ignore_property: Field on the ground truth labels used to determine if the label should be
-    ignored. Labels will be ignored if this field exists and is equal to `True`.
-    :param batch_size: number of results to process per iteration.
-    :return: A `DataFrame` of the computed results
-    """
-    results_iter = _iter_multilabel_classification_results(
-        dataset_name,
-        df,
-        ground_truths_field=ground_truths_field,
-        raw_inferences_field=raw_inferences_field,
-        gt_ignore_property=gt_ignore_property,
-        batch_size=batch_size,
-    )
-    return pd.concat(list(results_iter))
-
-
 def upload_multilabel_classification_results(
     dataset_name: str,
     model_name: str,
@@ -260,7 +223,8 @@ def upload_multilabel_classification_results(
     for the dataset.
 
     Dataframe `df` should include all id columns that would match to that of corresponding datapoint and
-    an `inference` column that should be a list of either `str` or [`Labels`][kolena.annotation.Label].
+    an `inference` column that should be a list of either `str` or scored / un-scored
+    [`Labels`][kolena.annotation.Label].
 
     :param dataset_name: Dataset name.
     :param model_name: Model name.

--- a/kolena/_experimental/object_detection/dataset.py
+++ b/kolena/_experimental/object_detection/dataset.py
@@ -367,6 +367,10 @@ def _iter_object_detection_results(
     dataset_df = dataset.download_dataset(dataset_name)
     dataset_df = dataset_df[["locator", ground_truths_field]]
     _validate_column_present(dataset_df, ground_truths_field)
+    while ground_truths_field in df.columns:
+        new_ground_truths_field = f"_kolena.rename.{ground_truths_field}"
+        dataset_df = dataset_df.rename(columns={ground_truths_field: new_ground_truths_field})
+        ground_truths_field = new_ground_truths_field
 
     merged_df = df.merge(dataset_df, on=["locator"])
     return _compute_metrics(


### PR DESCRIPTION
### Linked issue(s)
Fixes: KOL-7882

### What change does this PR introduce and why?

Add client implementation for uploading multilabel classification results

This supports datapoint level metrics for multilabel classification flows. It is similar to the object detection helper function, but notably:
- Handles both string and annotation type labels
- (Currently) does not factor in threshold based operations

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
