### PR TITLE
feat: support editing dataset description programmatically

### DIFF
--- a/kolena/_api/v2/dataset.py
+++ b/kolena/_api/v2/dataset.py
@@ -38,6 +38,7 @@ class RegisterRequest:
     append_only: bool = False
     tags: Optional[List[str]] = None
     dataset_tags: Optional[List[str]] = None
+    description: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/kolena/dataset/dataset.py
+++ b/kolena/dataset/dataset.py
@@ -267,6 +267,7 @@ def _send_upload_dataset_request(
     append_only: bool = False,
     commit_tags: Optional[List[str]] = None,
     dataset_tags: Optional[List[str]] = None,
+    description: Optional[str] = None,
 ) -> EntityData:
     request = RegisterRequest(
         name=name,
@@ -276,6 +277,7 @@ def _send_upload_dataset_request(
         append_only=append_only,
         tags=commit_tags,
         dataset_tags=dataset_tags,
+        description=description,
     )
     response = krequests.post(Path.REGISTER, json=asdict(request))
     krequests.raise_for_status(response)
@@ -292,6 +294,7 @@ def _upload_dataset(
     append_only: bool = False,
     commit_tags: Optional[List[str]] = None,
     dataset_tags: Optional[List[str]] = None,
+    description: Optional[str] = None,
 ) -> None:
     prepared_id_fields, load_uuid = _prepare_upload_dataset_request(name, df, id_fields=id_fields)
 
@@ -303,6 +306,7 @@ def _upload_dataset(
         append_only=append_only,
         commit_tags=commit_tags,
         dataset_tags=dataset_tags,
+        description=description,
     )
     log.info(f"uploaded dataset '{name}' ({get_dataset_url(dataset_id=data.id)})")
 
@@ -316,6 +320,7 @@ def upload_dataset(
     commit_tags: Optional[List[str]] = None,
     dataset_tags: Optional[List[str]] = None,
     append_only: bool = False,
+    description: Optional[str] = None,
 ) -> None:
     """
     Create or update a dataset with the contents of the provided DataFrame `df`.
@@ -336,6 +341,7 @@ def upload_dataset(
         and existing datapoints absent from the input dataframe will be removed from the dataset. If `True`, new
         datapoints from the input dataframe will be added, and existing datapoints will be modified if present in the
         input dataframe, but no datapoints will be deleted from the datasets. This behaves like an `UPSERT` operation.
+    :param description: Optionally specify the description of the dataset.
     """
     _upload_dataset(
         name,
@@ -344,6 +350,7 @@ def upload_dataset(
         commit_tags=commit_tags,
         dataset_tags=dataset_tags,
         append_only=append_only,
+        description=description,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dev-dependencies = [
     # insiders fork installed out-of-band in docs/setup_insiders.sh
     "mkdocs-material>=9.2,<10",
     "mkdocstrings>=0.25,<1",
-    "mkdocstrings-python>=1.11.1,<2",
+    "mkdocstrings-python==1.11.1",
     "mkdocs-git-committers-plugin-2>=1,<2",
     "mkdocs-git-revision-date-localized-plugin>=1,<2",
 ]

--- a/tests/integration/dataset/test_dataset.py
+++ b/tests/integration/dataset/test_dataset.py
@@ -389,3 +389,36 @@ def test__download_dataset__preserve_none() -> None:
     assert fetched_df_dp["a"][0] is None
     assert np.isinf(fetched_df_dp["a"][1])
     assert np.isnan(fetched_df_dp["a"][2])
+
+
+def test__upload_dataset__with_description() -> None:
+    name = with_test_prefix(f"{__file__}::test__upload_dataset__with_description")
+    datapoints = [dict(locator=fake_locator(i, name), value=i + 100) for i in range(20)]
+    columns = ["locator", "value"]
+    description_v1 = "description version 1"
+
+    # create a dataset with description
+    upload_dataset(name, pd.DataFrame(datapoints, columns=columns), id_fields=["locator"], description=description_v1)
+    dataset = _load_dataset_metadata(name)
+    assert dataset.description == description_v1
+
+    # update the dataset along with its description
+    description_v2 = "description version 2"
+    upload_dataset(
+        name,
+        pd.DataFrame(datapoints[:-1], columns=columns),
+        id_fields=["locator"],
+        description=description_v2,
+    )
+    dataset = _load_dataset_metadata(name)
+    assert dataset.description == description_v2
+
+    # update the dataset while keeping the description unchanged
+    upload_dataset(
+        name,
+        pd.DataFrame(datapoints[:-2], columns=columns),
+        id_fields=["locator"],
+        description=description_v2,
+    )
+    dataset = _load_dataset_metadata(name)
+    assert dataset.description == description_v2


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-7913

### What change does this PR introduce and why?
Add new parameter to `upload_dataset` call to include a string `description` to support programmatically specifying the dataset description during creation/update.

This corresponds to https://github.com/kolenaIO/shipyard/pull/2606 from the backend. Integration test is expected to fail before the backend change is in production. However, tested locally with my dev workspace [here](https://trunk.kolena.io/nan/dataset?datasetId=38).

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
