### PR TITLE
feat: support key-value metadata on models

### DIFF
--- a/kolena/_api/v2/model.py
+++ b/kolena/_api/v2/model.py
@@ -20,6 +20,9 @@ from typing import Optional
 from typing import Union
 
 from kolena._api.v1.batched_load import BatchedLoad
+from kolena._utils.pydantic_v1 import StrictFloat
+from kolena._utils.pydantic_v1 import StrictInt
+from kolena._utils.pydantic_v1 import StrictStr
 from kolena._utils.pydantic_v1.dataclasses import dataclass
 
 
@@ -57,6 +60,7 @@ class UploadResultsRequest:
     dataset_id: int
     sources: Optional[List[Dict[str, str]]]
     tags: List[str] = field(default_factory=list)
+    metadata: Optional[Dict[str, Union[StrictInt, StrictFloat, StrictStr, None]]] = None
 
 
 @dataclass(frozen=True)

--- a/kolena/dataset/evaluation.py
+++ b/kolena/dataset/evaluation.py
@@ -43,6 +43,9 @@ from kolena._utils.consts import BatchSize
 from kolena._utils.endpoints import get_platform_url
 from kolena._utils.endpoints import serialize_models_url
 from kolena._utils.instrumentation import with_event
+from kolena._utils.pydantic_v1 import StrictFloat
+from kolena._utils.pydantic_v1 import StrictInt
+from kolena._utils.pydantic_v1 import StrictStr
 from kolena._utils.pydantic_v1.dataclasses import dataclass
 from kolena._utils.serde import from_dict
 from kolena._utils.state import API_V2
@@ -92,6 +95,8 @@ class ModelEntity:
     """Unique name of the model."""
     tags: List[str]
     """Tags associated with the model."""
+    metadata: Optional[Dict[str, Union[StrictInt, StrictFloat, StrictStr, None]]] = None
+    """Metadata associated with the model."""
 
 
 @dataclass(frozen=True)
@@ -191,6 +196,7 @@ def _send_upload_results_request(
     dataset_id: int,
     sources: Optional[List[Dict[str, str]]],
     tags: List[str] = [],
+    metadata: Optional[Dict[str, Union[StrictInt, StrictFloat, StrictStr, None]]] = None,
 ) -> UploadResultsResponse:
     request = UploadResultsRequest(
         model=model,
@@ -198,6 +204,7 @@ def _send_upload_results_request(
         dataset_id=dataset_id,
         sources=sources,
         tags=tags,
+        metadata=metadata,
     )
     response = krequests.post(Path.UPLOAD_RESULTS, json=asdict(request))
     krequests.raise_for_status(response)
@@ -336,10 +343,11 @@ def _upload_results(
     sources: Optional[List[Dict[str, str]]] = DEFAULT_SOURCES,
     thresholded_fields: Optional[List[str]] = None,
     tags: List[str] = [],
+    metadata: Optional[Dict[str, Union[StrictInt, StrictFloat, StrictStr, None]]] = None,
 ) -> UploadResultsResponse:
     load_uuid, dataset_id, total_rows = _prepare_upload_results_request(dataset, results, thresholded_fields, tags)
 
-    response = _send_upload_results_request(model, load_uuid, dataset_id, sources=sources, tags=tags)
+    response = _send_upload_results_request(model, load_uuid, dataset_id, sources=sources, tags=tags, metadata=metadata)
     if isinstance(response.eval_config_id, list):
         models = [serialize_models_url(response.model_id, eval_config_id) for eval_config_id in response.eval_config_id]
     else:
@@ -366,6 +374,7 @@ def upload_results(
     results: Union[DataFrame, List[EvalConfigResults]],
     thresholded_fields: Optional[List[str]] = None,
     tags: List[str] = [],
+    metadata: Optional[Dict[str, Union[StrictInt, StrictFloat, StrictStr, None]]] = None,
 ) -> None:
     """
     This function is used for uploading the results from a specified model on a given dataset.
@@ -376,10 +385,11 @@ def upload_results(
     :param thresholded_fields: Optional columns in result DataFrame containing data associated with different
      thresholds.
     :param tags: Optional list of tags to be associated with the model.
+    :param metadata: Optional dictionary of string key to values tobe associated with the model.
 
     :return: None
     """
-    _upload_results(dataset, model, results, thresholded_fields=thresholded_fields, tags=tags)
+    _upload_results(dataset, model, results, thresholded_fields=thresholded_fields, tags=tags, metadata=metadata)
 
 
 def _get_models(

--- a/tests/integration/dataset/test_evaluation.py
+++ b/tests/integration/dataset/test_evaluation.py
@@ -759,3 +759,34 @@ def test__upload_results__with_tags() -> None:
     assert len(models) == 1
     assert models[0].name == model_name
     assert set(models[0].tags) == set(model_tags)
+
+
+def test__upload_results__with_metadata() -> None:
+    dataset_name = with_test_prefix(f"{__file__}::test__upload_results__with_metadata")
+    model_name = with_test_prefix(f"{__file__}::test__upload_results__with_metadata")
+    df_dp = get_df_dp()
+    dp_columns = [JOIN_COLUMN, "locator"]
+    upload_dataset(dataset_name, df_dp[3:10][dp_columns], id_fields=ID_FIELDS)
+
+    metadata = {
+        "string-key": "string-val",
+        "int-key": 1,
+        "float-key": 2.0,
+        "null-key": None,
+    }
+    df_result = get_df_result()
+    response = _upload_results(
+        dataset_name,
+        model_name,
+        df_result,
+        metadata=metadata,
+    )
+    assert response.n_inserted == 7
+    assert response.n_updated == 0
+    assert response.model_id is not None
+    assert response.eval_config_id is not None
+
+    models = get_models(dataset_name)
+    assert len(models) == 1
+    assert models[0].name == model_name
+    assert models[0].metadata == metadata

--- a/tests/integration/dataset/test_evaluation.py
+++ b/tests/integration/dataset/test_evaluation.py
@@ -733,3 +733,29 @@ def test__download_results__with_properties() -> None:
         check_like=True,
         check_dtype=False,
     )
+
+
+def test__upload_results__with_tags() -> None:
+    dataset_name = with_test_prefix(f"{__file__}::test__upload_results__with_tags")
+    model_name = with_test_prefix(f"{__file__}::test__upload_results__with_tags")
+    df_dp = get_df_dp()
+    dp_columns = [JOIN_COLUMN, "locator", "width", "height", "city"]
+    upload_dataset(dataset_name, df_dp[3:10][dp_columns], id_fields=ID_FIELDS)
+
+    model_tags = ["model-tag-1", "model-tag-n"]
+    df_result = get_df_result()
+    response = _upload_results(
+        dataset_name,
+        model_name,
+        df_result,
+        tags=model_tags,
+    )
+    assert response.n_inserted == 7
+    assert response.n_updated == 0
+    assert response.model_id is not None
+    assert response.eval_config_id is not None
+
+    models = get_models(dataset_name)
+    assert len(models) == 1
+    assert models[0].name == model_name
+    assert set(models[0].tags) == set(model_tags)


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-8043

### What change does this PR introduce and why?
Allow users to specify a key-val style metadata to be associated with models. Corresponds to [this backend change](https://github.com/kolenaIO/shipyard/pull/2625).

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [x] Relevant docs have been added / updated
