### PR TITLE
chore: relax upper bound for numpy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ packages = [
 requires-python = ">=3.8,<3.13"
 
 dependencies = [
-    "numpy >=1.19,<2; python_version < '3.12'",
-    "numpy >=1.26,<2; python_version >= '3.12'",
+    "numpy >=1.19,<3; python_version < '3.12'",
+    "numpy >=1.26,<3; python_version >= '3.12'",
     "pandas >=1.1,<3; python_version < '3.12'",
     "pandas >=2.1.1,<3; python_version >= '3.12'",
     "pandera>=0.22.1,<1",


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-8080

### What change does this PR introduce and why?
Relax the `numpy<2` constraint. This was added as part of https://github.com/kolenaIO/kolena/pull/622 which cited an issue with pandera. This has been [fixed on pandera side after v0.20](https://github.com/unionai-oss/pandera/releases/tag/v0.20.0), and [we have bumped pandera](https://github.com/kolenaIO/kolena/pull/736/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) to v0.22.1.

Testing
- With https://github.com/kolenaIO/kolena/commit/fa24b87e0c0853c33a7b51fe78f924ff50bed4cf, ran the age estimation example:

```
(kolena_client) (base) ➜  age_estimation git:(nan/test-numpy-2) ✗ uv sync                                                         
warning: `VIRTUAL_ENV=/Users/nanwei/Desktop/kolena_dev/kolena_client/.venv` does not match the project environment path `.venv` and will be ignored
Using Python 3.9.18
Removed virtual environment at: .venv
Creating virtualenv at: .venv
Resolved 71 packages in 299ms
   Built age-estimation @ file:///Users/nanwei/Desktop/kolena_dev/kolena_client/examples/dataset/age_estimation
   Built kolena @ file:///Users/nanwei/Desktop/kolena_dev/kolena_client
Prepared 3 packages in 359ms
Installed 69 packages in 293ms
 + age-estimation==0.1.0 (from file:///Users/nanwei/Desktop/kolena_dev/kolena_client/examples/dataset/age_estimation)
..........
 + numpy==2.0.2
..........
(kolena_client) (base) ➜  age_estimation git:(nan/test-numpy-2) ✗ uv run pytest -vv tests/test_age_estimation.py                                                     
warning: `VIRTUAL_ENV=/Users/nanwei/Desktop/kolena_dev/kolena_client/.venv` does not match the project environment path `.venv` and will be ignored
======================================================================================================= test session starts =======================================================================================================
platform darwin -- Python 3.9.18, pytest-7.4.4, pluggy-1.5.0 -- /Users/nanwei/Desktop/kolena_dev/kolena_client/examples/dataset/age_estimation/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/nanwei/Desktop/kolena_dev/kolena_client
configfile: pyproject.toml
plugins: typeguard-4.4.1, depends-1.0.1
collected 3 items                                                                                                                                                                                                                 

tests/test_age_estimation.py::test__upload_dataset PASSED                                                                                                                                                                   [ 33%]
tests/test_age_estimation.py::test__upload_results_deepface PASSED                                                                                                                                                          [ 66%]
tests/test_age_estimation.py::test__upload_results_ssrnet PASSED                                                                                                                                                            [100%]
..........
============================================================================================ 3 passed, 3 warnings in 94.40s (0:01:34) =============================================================================================
```


### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
