### PR TITLE
chore: pin hatchling version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ metrics = [
 kolena = 'kolena._utils.cli:run'
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling<=1.25.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?
After hatchling 1.25.0, [this change](https://github.com/pypa/hatch/pull/1788/files) requires packaging 24.2 which is not always possible in certain environments. For example, in a Databricks notebook, running `%pip install kolena` would lead to the following:
```
Collecting kolena
  Using cached kolena-1.61.0.tar.gz (119 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [21 lines of output]
      Traceback (most recent call last):
        File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-a9388985-ca8a-48d7-92db-6167cbe118f2/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-a9388985-ca8a-48d7-92db-6167cbe118f2/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-a9388985-ca8a-48d7-92db-6167cbe118f2/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 178, in prepare_metadata_for_build_wheel
          whl_basename = backend.build_wheel(metadata_directory, config_settings)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-53ro4hds/overlay/lib/python3.11/site-packages/hatchling/build.py", line 58, in build_wheel
          return os.path.basename(next(builder.build(directory=wheel_directory, versions=['standard'])))
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-53ro4hds/overlay/lib/python3.11/site-packages/hatchling/builders/plugin/interface.py", line 90, in build
          self.metadata.validate_fields()
        File "/tmp/pip-build-env-53ro4hds/overlay/lib/python3.11/site-packages/hatchling/metadata/core.py", line 266, in validate_fields
          self.core.validate_fields()
        File "/tmp/pip-build-env-53ro4hds/overlay/lib/python3.11/site-packages/hatchling/metadata/core.py", line 1366, in validate_fields
          getattr(self, attribute)
        File "/tmp/pip-build-env-53ro4hds/overlay/lib/python3.11/site-packages/hatchling/metadata/core.py", line 677, in license
          from packaging.licenses import canonicalize_license_expression
      ModuleNotFoundError: No module named 'packaging.licenses'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```

Doing `%pip install packaging==24.2` does not fix the issue because the build happens in another isolated environment. This PR pins the build system version to avoid this issue.

Testing:
<img width="1384" alt="image" src="https://github.com/user-attachments/assets/e2a1b77d-044b-41a9-8135-ba2cf36818b5" />

The error message on numpy seems safe to ignore


### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
