### PR TITLE
chore: fix build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 homepage = "https://kolena.com"
 documentation = "https://docs.kolena.com"
 readme = "README.md"
-license = { expression = "Apache-2.0" }
+license = { text = "Apache-2.0" }
 keywords = ["Kolena", "ML", "testing"]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 homepage = "https://kolena.com"
 documentation = "https://docs.kolena.com"
 readme = "README.md"
-license = "Apache-2.0"
+license = { expression = "Apache-2.0" }
 keywords = ["Kolena", "ML", "testing"]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -64,7 +64,7 @@ metrics = [
 kolena = 'kolena._utils.cli:run'
 
 [build-system]
-requires = ["hatchling", "packaging>=24.2"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ metrics = [
 kolena = 'kolena._utils.cli:run'
 
 [build-system]
-requires = ["hatchling<=1.25.0"]
+requires = ["hatchling", "packaging>=24.2"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?
Build for https://github.com/kolenaIO/kolena/pull/764 errored out with:
```
Checking dist/kolena-1.62.0.tar.gz: ERROR    InvalidDistribution: Invalid distribution metadata: license-expression 
         introduced in metadata version 2.4, not 2.3    
```

Looks like we'll have to stick with hactchling >1.25.0 for our package metadata. Taking a closer look at the[ hatchling logic regarding licenses](https://github.com/pypa/hatch/blob/4ebce0e1fe8bf0fcdef587a704c207a063d72575/backend/src/hatchling/metadata/core.py#L657):
- What caused the original issue was [here](https://github.com/pypa/hatch/blob/4ebce0e1fe8bf0fcdef587a704c207a063d72575/backend/src/hatchling/metadata/core.py#L676-L683) where we had the license data as a simple string, and hatchling tried to import from packaging 24.2
- With this change, we'll instead use [this block](https://github.com/pypa/hatch/blob/4ebce0e1fe8bf0fcdef587a704c207a063d72575/backend/src/hatchling/metadata/core.py#L704-L708) which avoids the problematic import

What this means is that the license info on PyPI will look slightly different than our current one:
<img width="284" alt="image" src="https://github.com/user-attachments/assets/bd9ef781-5459-4fc6-b94b-b4d618d406b0" />

After this change, I expect it to look similar to the following which comes from [here](https://github.com/reflex-dev/reflex/blob/96ff0b57a60579c37b529b86c1d857dce90661c1/pyproject.toml#L5):
<img width="293" alt="image" src="https://github.com/user-attachments/assets/eb954666-c64f-45b1-99dc-6af2a7386114" />

i.e. we'll lose the link to license expressions but I doubt that it matters...


Testing:
With `%pip install git+https://github.com/kolenaIO/kolena.git@nan/fix-build-second-pass` in a Databricks notebook
<img width="805" alt="image" src="https://github.com/user-attachments/assets/3e6cc16c-ce7f-4cbc-bb7d-dfcf15b5c14b" />


### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
