### PR TITLE
chore: pin pandera

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "numpy >=1.26,<3; python_version >= '3.12'",
     "pandas >=1.1,<3; python_version < '3.12'",
     "pandas >=2.1.1,<3; python_version >= '3.12'",
-    "pandera>=0.22.1,<1",
+    "pandera>=0.22.1,<0.24",
     "pydantic>=1.10,<3",
     "dacite>=1.6,<2",
     "requests>=2.20,<3",


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-8171

### What change does this PR introduce and why?

[Pandera's newest 0.24.0 version](https://github.com/unionai-oss/pandera/releases/tag/v0.24.0) has moved the df-related stuff from `pandera` to `pandera.pandas`, and requires explicitly installing with `pandera[pandas]` option. This PR pins the max version to under 0.24 to avoid importing issue - otherwise may see `AttributeError: module 'pandera' has no attribute 'DataFrameModel'` when doing `import pandera as pa .... pa.DataFrameModel`.

Considered bumping to 0.24 but that's not possible in certain environments such as Databricks notebook that several customers use given requirements on numpy and pandas, so think it's better for now to use lower versions of pandera that can work.


### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
