### PR TITLE
chore: example of pii data detection before upload_dataset

### DIFF
--- a/examples/dataset/personal_data_detection/README.md
+++ b/examples/dataset/personal_data_detection/README.md
@@ -1,0 +1,39 @@
+# Example Integration: Personal Data Detection
+
+This example uses a subset of the [IMDB dataset](https://developer.imdb.com/non-commercial-datasets/) to demonstrate
+checking for the presence of Personal Identifiable Information (PII) using
+[the Piiranha model](https://huggingface.co/iiiorg/piiranha-v1-detect-personal-information) prior to uploading the
+dataset to Kolena.
+
+## Setup
+
+This project uses [uv](https://docs.astral.sh/uv/) for packaging and Python dependency management. To get started,
+install project dependencies from [`pyproject.toml`](./pyproject.toml) by running:
+
+```shell
+uv sync
+```
+
+## Usage
+
+The data for this example integration lives in the publicly accessible S3 bucket `s3://kolena-public-examples`.
+
+First, ensure that the `KOLENA_TOKEN` environment variable is populated in your environment. See our
+[initialization documentation](https://docs.kolena.com/installing-kolena/#initialization) for details.
+
+This project defines a script [`upload_dataset.py`](personal_data_detection/upload_dataset.py) which loads the IMDB
+dataset, and runs the Piiranha-v1 model to ensure that there are no PII data before uploading to Kolena. Given that the
+Piiranha-v1 model may have false positives, one can optionally specify an allow list of types of PII data to allow in
+this check, such as city and username.
+
+```shell
+$ uv run personal_data_detection/upload_dataset.py --help
+usage: upload_dataset.py [-h] [--dataset DATASET] [--allowed_pii_types ALLOWED_PII_TYPES [ALLOWED_PII_TYPES ...]]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --dataset DATASET     Optionally specify a custom name for the dataset.
+  --allowed_pii_types ALLOWED_PII_TYPES [ALLOWED_PII_TYPES ...]
+                        Types of PII data to allow in the upload.
+                        For instance, to allow surnames and cities, use '--allowed_pii_types I-SURNAME I-CITY'
+```

--- a/examples/dataset/personal_data_detection/personal_data_detection/__init__.py
+++ b/examples/dataset/personal_data_detection/personal_data_detection/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021-2025 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/dataset/personal_data_detection/personal_data_detection/constants.py
+++ b/examples/dataset/personal_data_detection/personal_data_detection/constants.py
@@ -1,0 +1,18 @@
+# Copyright 2021-2025 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BUCKET = "kolena-public-examples"
+TASK = "personal-data-detection"
+
+IMDB_DATASET = "imdb_dataset"

--- a/examples/dataset/personal_data_detection/personal_data_detection/constants.py
+++ b/examples/dataset/personal_data_detection/personal_data_detection/constants.py
@@ -14,5 +14,6 @@
 
 BUCKET = "kolena-public-examples"
 TASK = "personal-data-detection"
+DATASET = "imdb_dataset"
 
-IMDB_DATASET = "imdb_dataset"
+DATA_FILEPATH = f"s3://{BUCKET}/{TASK}/{DATASET}.csv"

--- a/examples/dataset/personal_data_detection/personal_data_detection/upload_dataset.py
+++ b/examples/dataset/personal_data_detection/personal_data_detection/upload_dataset.py
@@ -26,6 +26,8 @@ def run(args: Namespace) -> None:
     df = pd.read_csv(DATA_FILEPATH)
     if not detect_pii_in_dataframe(df, allowed_pii_types=args.allowed_pii_types):
         upload_dataset(args.dataset, df)
+    else:
+        print("Skipped uploading the dataset to Kolena because PII data was detected.")
 
 
 def main() -> None:

--- a/examples/dataset/personal_data_detection/personal_data_detection/upload_dataset.py
+++ b/examples/dataset/personal_data_detection/personal_data_detection/upload_dataset.py
@@ -15,17 +15,15 @@ from argparse import ArgumentParser
 from argparse import Namespace
 
 import pandas as pd
-from personal_data_detection.constants import BUCKET
-from personal_data_detection.constants import IMDB_DATASET
-from personal_data_detection.constants import TASK
+from personal_data_detection.constants import DATA_FILEPATH
+from personal_data_detection.constants import DATASET
 from personal_data_detection.utils import detect_pii_in_dataframe
 
 from kolena.dataset import upload_dataset
 
 
 def run(args: Namespace) -> None:
-    filelpath = f"s3://{BUCKET}/{TASK}/{IMDB_DATASET}.csv"
-    df = pd.read_csv(filelpath)
+    df = pd.read_csv(DATA_FILEPATH)
     if not detect_pii_in_dataframe(df, allowed_pii_types=args.allowed_pii_types):
         upload_dataset(args.dataset, df)
 
@@ -35,7 +33,7 @@ def main() -> None:
     ap.add_argument(
         "--dataset",
         type=str,
-        default=IMDB_DATASET,
+        default=DATASET,
         help="Optionally specify a custom name for the dataset.",
     )
     ap.add_argument(

--- a/examples/dataset/personal_data_detection/personal_data_detection/upload_dataset.py
+++ b/examples/dataset/personal_data_detection/personal_data_detection/upload_dataset.py
@@ -1,0 +1,51 @@
+# Copyright 2021-2025 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+from argparse import Namespace
+
+import pandas as pd
+from personal_data_detection.constants import BUCKET
+from personal_data_detection.constants import IMDB_DATASET
+from personal_data_detection.constants import TASK
+from personal_data_detection.utils import detect_pii_in_dataframe
+
+from kolena.dataset import upload_dataset
+
+
+def run(args: Namespace) -> None:
+    filelpath = f"s3://{BUCKET}/{TASK}/{IMDB_DATASET}.csv"
+    df = pd.read_csv(filelpath)
+    if not detect_pii_in_dataframe(df, allowed_pii_types=args.allowed_pii_types):
+        upload_dataset(args.dataset, df)
+
+
+def main() -> None:
+    ap = ArgumentParser()
+    ap.add_argument(
+        "--dataset",
+        type=str,
+        default=IMDB_DATASET,
+        help="Optionally specify a custom name for the dataset.",
+    )
+    ap.add_argument(
+        "--allowed_pii_types",
+        nargs="+",
+        default=[],
+        help="Types of PII data to allow in the upload.",
+    )
+    run(ap.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dataset/personal_data_detection/personal_data_detection/upload_dataset.py
+++ b/examples/dataset/personal_data_detection/personal_data_detection/upload_dataset.py
@@ -40,7 +40,8 @@ def main() -> None:
         "--allowed_pii_types",
         nargs="+",
         default=[],
-        help="Types of PII data to allow in the upload.",
+        help="Types of PII data to allow in the upload. For instance, to allow given names and surnames,"
+        " use '--allowed_pii_types I-GIVENNAME I-SURNAME'",
     )
     run(ap.parse_args())
 

--- a/examples/dataset/personal_data_detection/personal_data_detection/utils.py
+++ b/examples/dataset/personal_data_detection/personal_data_detection/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from typing import Set
 
+import pandas as pd
 import torch
 from transformers import AutoModelForTokenClassification
 from transformers import AutoTokenizer
@@ -25,8 +26,13 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 model.to(device)
 
 
-def detect_pii_in_dataframe() -> None:
-    pass
+def detect_pii_in_dataframe(df: pd.DataFrame, allowed_pii_types: Set[str] = set()) -> bool:
+    for datapoint in df.to_dict(orient="records"):
+        for key in datapoint:
+            if detect_pii_in_string(str(datapoint[key]), allowed_pii_types=allowed_pii_types):
+                print(f"pii data found in column '{key}'")
+                return True
+    return False
 
 
 def detect_pii_in_string(text: str, allowed_pii_types: Set[str] = set()) -> bool:

--- a/examples/dataset/personal_data_detection/personal_data_detection/utils.py
+++ b/examples/dataset/personal_data_detection/personal_data_detection/utils.py
@@ -1,0 +1,73 @@
+# Copyright 2021-2025 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import torch
+from transformers import AutoModelForTokenClassification
+from transformers import AutoTokenizer
+
+PII_MODEL_NAME = "iiiorg/piiranha-v1-detect-personal-information"
+
+tokenizer = AutoTokenizer.from_pretrained(PII_MODEL_NAME)
+model = AutoModelForTokenClassification.from_pretrained(PII_MODEL_NAME)
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+model.to(device)
+
+
+def detect_pii_in_dataframe() -> None:
+    pass
+
+
+def detect_pii_in_string(text: str) -> bool:
+    # Tokenize input text
+    inputs = tokenizer(text, return_tensors="pt", truncation=True, padding=True)
+    inputs = {k: v.to(device) for k, v in inputs.items()}
+
+    # Get the model predictions
+    with torch.no_grad():
+        outputs = model(**inputs)
+
+    # Get the predicted labels
+    predictions = torch.argmax(outputs.logits, dim=-1)
+
+    # Convert token predictions to word predictions
+    encoded_inputs = tokenizer.encode_plus(text, return_offsets_mapping=True, add_special_tokens=True)
+    offset_mapping = encoded_inputs["offset_mapping"]
+
+    is_pii = False
+    pii_data_start = 0
+    pii_data_end = 0
+    pii_type = ""
+
+    for i, (start, end) in enumerate(offset_mapping):
+        if start == end:  # Special token
+            continue
+
+        label = predictions[0][i].item()
+        if label != model.config.label2id["O"]:  # Non-O label
+            current_pii_type = model.config.id2label[label]
+            if not is_pii:
+                is_pii = True
+                pii_data_start = start
+                pii_type = current_pii_type
+            elif pii_type == current_pii_type:
+                pii_data_end = end + 1
+            elif pii_type != current_pii_type:
+                # break out of the loop if the current pii data has finished scanning
+                break
+        elif is_pii:
+            break
+
+    if is_pii:
+        print(f"[{pii_type}] data detected: {text[pii_data_start:pii_data_end]}")
+        return True
+    return False

--- a/examples/dataset/personal_data_detection/personal_data_detection/utils.py
+++ b/examples/dataset/personal_data_detection/personal_data_detection/utils.py
@@ -20,7 +20,7 @@ from transformers import AutoTokenizer
 
 PII_MODEL_NAME = "iiiorg/piiranha-v1-detect-personal-information"
 
-tokenizer = AutoTokenizer.from_pretrained(PII_MODEL_NAME)
+tokenizer = AutoTokenizer.from_pretrained(PII_MODEL_NAME, model_max_length=512)
 model = AutoModelForTokenClassification.from_pretrained(PII_MODEL_NAME)
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 model.to(device)

--- a/examples/dataset/personal_data_detection/personal_data_detection/utils.py
+++ b/examples/dataset/personal_data_detection/personal_data_detection/utils.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Set
+
 import torch
 from transformers import AutoModelForTokenClassification
 from transformers import AutoTokenizer
@@ -27,7 +29,7 @@ def detect_pii_in_dataframe() -> None:
     pass
 
 
-def detect_pii_in_string(text: str) -> bool:
+def detect_pii_in_string(text: str, allowed_pii_types: Set[str] = set()) -> bool:
     # Tokenize input text
     inputs = tokenizer(text, return_tensors="pt", truncation=True, padding=True)
     inputs = {k: v.to(device) for k, v in inputs.items()}
@@ -52,9 +54,9 @@ def detect_pii_in_string(text: str) -> bool:
         if start == end:  # Special token
             continue
 
-        label = predictions[0][i].item()
-        if label != model.config.label2id["O"]:  # Non-O label
-            current_pii_type = model.config.id2label[label]
+        pred_id = predictions[0][i].item()
+        if pred_id != model.config.label2id["O"] and model.config.id2label[pred_id] not in allowed_pii_types:
+            current_pii_type = model.config.id2label[pred_id]
             if not is_pii:
                 is_pii = True
                 pii_data_start = start

--- a/examples/dataset/personal_data_detection/pyproject.toml
+++ b/examples/dataset/personal_data_detection/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "personal_data_detection"
+version = "0.1.0"
+description = "Example Kolena integration for personal data detection"
+authors = [
+    { name = "Kolena Engineering", email = "eng@kolena.com" }
+]
+license = "Apache-2.0"
+requires-python = ">=3.9,<3.12"
+
+dependencies = [
+    "kolena>=1.64.0,<2",
+    "torch>=2.7.1",
+    "transformers>=4.52.4",
+]
+
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=2.17,<3",
+    "pytest>=7,<8",
+    "pytest-depends>=1.0.1,<2",
+    "setuptools>=80.9.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/dataset/personal_data_detection/pyproject.toml
+++ b/examples/dataset/personal_data_detection/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.9,<3.12"
 
 dependencies = [
     "kolena>=1.64.0,<2",
+    "s3fs>=2025.5.1",
     "torch>=2.7.1",
     "transformers>=4.52.4",
 ]

--- a/examples/dataset/personal_data_detection/tests/test_upload_dataset.py
+++ b/examples/dataset/personal_data_detection/tests/test_upload_dataset.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 import uuid
 from argparse import Namespace
+from io import StringIO
 from typing import List
+from unittest.mock import patch
 
 import pytest
 from personal_data_detection.upload_dataset import run as upload_dataset_main
@@ -35,7 +37,12 @@ from kolena.dataset import list_datasets
 def test__upload_dataset(allowed_pii_types: List[str], should_upload: bool) -> None:
     dataset_name = str(uuid.uuid4())
     args = Namespace(dataset=dataset_name, allowed_pii_types=allowed_pii_types)
-    upload_dataset_main(args)
 
-    existing_datasets = list_datasets()
-    assert (dataset_name in existing_datasets) == should_upload
+    with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+        upload_dataset_main(args)
+
+        existing_datasets = list_datasets()
+        assert (dataset_name in existing_datasets) == should_upload
+        if not should_upload:
+            printed_message = mock_stdout.getvalue()
+            assert "Skipped uploading the dataset to Kolena because PII data was detected." in printed_message

--- a/examples/dataset/personal_data_detection/tests/test_upload_dataset.py
+++ b/examples/dataset/personal_data_detection/tests/test_upload_dataset.py
@@ -1,0 +1,41 @@
+# Copyright 2021-2025 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import uuid
+from argparse import Namespace
+from typing import List
+
+import pytest
+from personal_data_detection.upload_dataset import run as upload_dataset_main
+
+from kolena.dataset import list_datasets
+
+
+@pytest.mark.parametrize(
+    "allowed_pii_types, should_upload",
+    [
+        ([], False),
+        (["I-USERNAME"], False),
+        (["I-USERNAME", "I-GIVENNAME"], False),
+        (["I-GIVENNAME", "I-SURNAME"], False),
+        (["I-USERNAME", "I-GIVENNAME", "I-SURNAME"], True),
+        (["I-USERNAME", "I-GIVENNAME", "I-SURNAME", "I-TELEPHONENUM"], True),
+    ],
+)
+def test__upload_dataset(allowed_pii_types: List[str], should_upload: bool) -> None:
+    dataset_name = str(uuid.uuid4())
+    args = Namespace(dataset=dataset_name, allowed_pii_types=allowed_pii_types)
+    upload_dataset_main(args)
+
+    existing_datasets = list_datasets()
+    assert (dataset_name in existing_datasets) == should_upload

--- a/examples/dataset/personal_data_detection/tests/test_utils.py
+++ b/examples/dataset/personal_data_detection/tests/test_utils.py
@@ -16,7 +16,9 @@ from typing import Optional
 from typing import Set
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
+from personal_data_detection.utils import detect_pii_in_dataframe
 from personal_data_detection.utils import detect_pii_in_string
 
 
@@ -62,3 +64,17 @@ def test__detect_pii_in_string(
     assert is_pii == expected_is_pii
     if expected_printed_message:
         assert expected_printed_message in printed_message
+
+
+def test__detect_pii_in_dataframe__no_pii() -> None:
+    with patch("personal_data_detection.utils.detect_pii_in_string", return_value=False):
+        assert not detect_pii_in_dataframe(df=pd.DataFrame())
+
+
+def test__detect_pii_in_dataframe__has_pii() -> None:
+    column_name = "name"
+    with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+        with patch("personal_data_detection.utils.detect_pii_in_string", return_value=True):
+            assert detect_pii_in_dataframe(df=pd.DataFrame([{column_name: "kolena"}]))
+            printed_message = mock_stdout.getvalue()
+            assert f"pii data found in column '{column_name}'" in printed_message

--- a/examples/dataset/personal_data_detection/tests/test_utils.py
+++ b/examples/dataset/personal_data_detection/tests/test_utils.py
@@ -1,0 +1,38 @@
+# Copyright 2021-2025 Kolena Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from io import StringIO
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+from personal_data_detection.utils import detect_pii_in_string
+
+
+@pytest.mark.parametrize(
+    "text, expected_is_pii, expected_printed_message",
+    [
+        ("random", False, None),
+        ("My phone number is 5455-123-4567.", True, "[I-TELEPHONENUM] data detected:  5455-123-4567."),
+        ("My name is Obee Nobi.", True, "[I-GIVENNAME] data detected:  Obee"),
+        ("I live at 432423 Deka St, Tanooti. My phone number is ...", True, "[I-BUILDINGNUM] data detected:  432423"),
+    ],
+)
+def test__detect_pii_in_string(text: str, expected_is_pii: bool, expected_printed_message: Optional[str]) -> None:
+    with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+        is_pii = detect_pii_in_string(text)
+        printed_message = mock_stdout.getvalue()
+
+    assert is_pii == expected_is_pii
+    if expected_printed_message:
+        assert expected_printed_message in printed_message

--- a/examples/dataset/personal_data_detection/tests/test_utils.py
+++ b/examples/dataset/personal_data_detection/tests/test_utils.py
@@ -49,6 +49,12 @@ from personal_data_detection.utils import detect_pii_in_string
             True,
             "[I-USERNAME] data detected: coco-2014-v",
         ),
+        (
+            "She lives in San Francisco and is 50 years old",
+            {},
+            True,
+            "[I-CITY] data detected:  San Francisco",
+        ),
     ],
 )
 def test__detect_pii_in_string(

--- a/examples/dataset/personal_data_detection/tests/test_utils.py
+++ b/examples/dataset/personal_data_detection/tests/test_utils.py
@@ -41,6 +41,12 @@ from personal_data_detection.utils import detect_pii_in_string
             True,
             "[I-EMAIL] data detected:  kaola@kolena.com",
         ),
+        (
+            "s3://kolena-public-examples/coco-2014-val/data/COCO_val2014_000000215244.jpg",
+            {},
+            True,
+            "[I-USERNAME] data detected: coco-2014-v",
+        ),
     ],
 )
 def test__detect_pii_in_string(

--- a/examples/dataset/personal_data_detection/tests/test_utils.py
+++ b/examples/dataset/personal_data_detection/tests/test_utils.py
@@ -34,6 +34,13 @@ from personal_data_detection.utils import detect_pii_in_string
         ),
         ("ninja", {"I-USERNAME"}, False, None),
         ("ninja", {}, True, "[I-USERNAME] data detected: ninja"),
+        ("800-820-8820", {}, True, "[I-TELEPHONENUM] data detected: 800-820-8820"),
+        (
+            "I can be reached at kaola@kolena.com or 800-555-6789",
+            {},
+            True,
+            "[I-EMAIL] data detected:  kaola@kolena.com",
+        ),
     ],
 )
 def test__detect_pii_in_string(

--- a/examples/dataset/personal_data_detection/tests/test_utils.py
+++ b/examples/dataset/personal_data_detection/tests/test_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from io import StringIO
 from typing import Optional
+from typing import Set
 from unittest.mock import patch
 
 import pytest
@@ -20,17 +21,29 @@ from personal_data_detection.utils import detect_pii_in_string
 
 
 @pytest.mark.parametrize(
-    "text, expected_is_pii, expected_printed_message",
+    "text, allowed_pii_types, expected_is_pii, expected_printed_message",
     [
-        ("random", False, None),
-        ("My phone number is 5455-123-4567.", True, "[I-TELEPHONENUM] data detected:  5455-123-4567."),
-        ("My name is Obee Nobi.", True, "[I-GIVENNAME] data detected:  Obee"),
-        ("I live at 432423 Deka St, Tanooti. My phone number is ...", True, "[I-BUILDINGNUM] data detected:  432423"),
+        ("random", {}, False, None),
+        ("My phone number is 5455-123-4567.", {}, True, "[I-TELEPHONENUM] data detected:  5455-123-4567."),
+        ("My name is Obee Nobi.", {}, True, "[I-GIVENNAME] data detected:  Obee"),
+        (
+            "I live at 432423 Deka St, Tanooti. My phone number is ...",
+            {},
+            True,
+            "[I-BUILDINGNUM] data detected:  432423",
+        ),
+        ("ninja", {"I-USERNAME"}, False, None),
+        ("ninja", {}, True, "[I-USERNAME] data detected: ninja"),
     ],
 )
-def test__detect_pii_in_string(text: str, expected_is_pii: bool, expected_printed_message: Optional[str]) -> None:
+def test__detect_pii_in_string(
+    text: str,
+    allowed_pii_types: Set[str],
+    expected_is_pii: bool,
+    expected_printed_message: Optional[str],
+) -> None:
     with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-        is_pii = detect_pii_in_string(text)
+        is_pii = detect_pii_in_string(text, allowed_pii_types=allowed_pii_types)
         printed_message = mock_stdout.getvalue()
 
     assert is_pii == expected_is_pii


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-8187

### What change does this PR introduce and why?
Create an example where we utilize a publicly available model on HuggingFace to check whether the dataframe contains PII data before uploading to Kolena as a dataset. Specifically this PR uses [the Piiranha model](https://huggingface.co/iiiorg/piiranha-v1-detect-personal-information) which has decent precision and recall metrics.

Note that given the nature of the data on which the Piiranha model was trained, it works better on natural languages in the form of sentences or paragraphs than values in a table that is typical to Kolena. For example, an image locator `s3://kolena-public-examples/coco-2014-val/data/COCO_val2014_000000215244.jpg` would be flagged as containing PII data with `coco-2014-v` detected as a username. To have a way to bypass such noises, this PR allows the user to specify a list of `allowed_pii_types` to bypass the check.

This example dataset was detected by the Piiranha as having username, given name, and surname:
```
$ uv run personal_data_detection/upload_dataset.py                                     
[I-USERNAME] data detected: tt5117670
pii data found in column 'id'

$ uv run personal_data_detection/upload_dataset.py --allowed_pii_types I-USERNAME
[I-GIVENNAME] data detected: 
pii data found in column 'director'

$ uv run personal_data_detection/upload_dataset.py --allowed_pii_types I-USERNAME I-GIVENNAME I-SURNAME
kolena> initialized
kolena> connected to ......
```


### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
