### PR TITLE
chore: `noindex,nofollow` on docs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 
+{% block site_meta %}
+    {{ super() }}
+    <meta name="robots" content="noindex,nofollow" />
+{% endblock %}
+
 {% block htmltitle %}
 <title>{{ page.title | striptags }}{% if (page.meta is defined and page.meta.description is defined) %}: {{ page.meta.description }}{% endif %} · {{ config.site_name }}</title>
 {% endblock %}


### PR DESCRIPTION
### Linked issue(s)
N/A

### What change does this PR introduce and why?
Set `noindex,nofollow` for docs pages. Ref discussion [here](https://kolena-io.slack.com/archives/C01TZNNQQSZ/p1750191059392039)

Validated by running the docs locally, and verifying that the docs pages have the new headers
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/cfc26307-9915-4162-a7f0-66c336724446" />


### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
