### PR TITLE
fix: Export delete_dataset directly from kolena.dataset

### DIFF
--- a/kolena/dataset/__init__.py
+++ b/kolena/dataset/__init__.py
@@ -14,6 +14,7 @@
 # noreorder
 from kolena.dataset.dataset import upload_dataset
 from kolena.dataset.dataset import download_dataset
+from kolena.dataset.dataset import delete_dataset
 from kolena.dataset.evaluation import upload_results
 from kolena.dataset.evaluation import download_results
 from kolena.dataset.evaluation import EvalConfigResults
@@ -30,6 +31,7 @@ __all__ = [
     "Filters",
     "GeneralFieldFilter",
     "download_dataset",
+    "delete_dataset",
     "upload_results",
     "download_results",
     "EvalConfigResults",

--- a/tests/integration/dataset/test_dataset.py
+++ b/tests/integration/dataset/test_dataset.py
@@ -26,6 +26,7 @@ from kolena._api.v2.dataset import CommitData
 from kolena._experimental.special_data_type import Timestamp
 from kolena.annotation import BoundingBox
 from kolena.annotation import LabeledBoundingBox
+from kolena.dataset import delete_dataset
 from kolena.dataset import download_dataset
 from kolena.dataset import Filters
 from kolena.dataset import GeneralFieldFilter
@@ -33,7 +34,6 @@ from kolena.dataset import list_datasets
 from kolena.dataset import upload_dataset
 from kolena.dataset.dataset import _fetch_dataset_history
 from kolena.dataset.dataset import _load_dataset_metadata
-from kolena.dataset.dataset import delete_dataset
 from kolena.errors import InputValidationError
 from kolena.errors import NotFoundError
 from tests.integration.helper import assert_frame_equal


### PR DESCRIPTION
### Linked issue(s)
None

### What change does this PR introduce and why?
Export delete_dataset directly from kolena.dataset

This was previously not exported in the same way as our other dataset methods.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
