### PR TITLE
feat: optionally include datapoint_id when downloading dataset

### DIFF
--- a/kolena/dataset/dataset.py
+++ b/kolena/dataset/dataset.py
@@ -405,12 +405,9 @@ def _iter_dataset(
     """
     for df_batch in _iter_dataset_raw(name, commit, batch_size, include_extracted_properties, filters):
         df = _to_deserialized_dataframe(df_batch, column=COL_DATAPOINT)
-        if not include_datapoint_id:
-            yield df
-        else:
-            datapoint_ids = df_batch[_FIELD_ID]
-            df[_FIELD_KOLENA_DATAPOINT_ID] = datapoint_ids
-            yield df
+        if include_datapoint_id:
+            df[_FIELD_KOLENA_DATAPOINT_ID] = df_batch[_FIELD_ID]
+        yield df
 
 
 @with_event(event_name=EventAPI.Event.FETCH_DATASET)

--- a/kolena/dataset/dataset.py
+++ b/kolena/dataset/dataset.py
@@ -70,6 +70,7 @@ _FIELD_ID = "id"
 _FIELD_LOCATOR = "locator"
 _FIELD_FILE_EXTENSION = "file_extension"
 _FIELD_TEXT = "text"
+_FIELD_KOLENA_DATAPOINT_ID = "kolena_datapoint_id"
 
 
 class DatapointType(str, Enum):
@@ -397,12 +398,19 @@ def _iter_dataset(
     batch_size: int = BatchSize.LOAD_SAMPLES.value,
     include_extracted_properties: bool = False,
     filters: Optional[Filters] = None,
+    include_datapoint_id: bool = False,
 ) -> Iterator[pd.DataFrame]:
     """
     Get an iterator over datapoints in the dataset.
     """
     for df_batch in _iter_dataset_raw(name, commit, batch_size, include_extracted_properties, filters):
-        yield _to_deserialized_dataframe(df_batch, column=COL_DATAPOINT)
+        df = _to_deserialized_dataframe(df_batch, column=COL_DATAPOINT)
+        if not include_datapoint_id:
+            yield df
+        else:
+            datapoint_ids = df_batch[_FIELD_ID]
+            df[_FIELD_KOLENA_DATAPOINT_ID] = datapoint_ids
+            yield df
 
 
 @with_event(event_name=EventAPI.Event.FETCH_DATASET)
@@ -412,6 +420,7 @@ def download_dataset(
     commit: Optional[str] = None,
     include_extracted_properties: bool = False,
     filters: Optional[Filters] = None,
+    include_datapoint_id: bool = False,
 ) -> pd.DataFrame:
     """
     Download an entire dataset given its name.
@@ -419,11 +428,22 @@ def download_dataset(
     :param name: The name of the dataset.
     :param commit: The commit hash for version control. Get the latest commit when this value is `None`.
     :param include_extracted_properties: If True, include kolena extracted properties from automated extractions
-     in the dataset as separate columns
+     in the dataset as separate columns.
     :param filters: [Experimental] Optional filter to specify which datapoints should be downloaded.
+    :param include_datapoint_id: If True, include the internal Kolena datapoint ID as a separate column named
+    `kolena_datapoint_id`.
     :return: A DataFrame containing the specified dataset.
     """
-    df_batches = list(_iter_dataset(name, commit, BatchSize.LOAD_SAMPLES.value, include_extracted_properties, filters))
+    df_batches = list(
+        _iter_dataset(
+            name,
+            commit,
+            BatchSize.LOAD_SAMPLES.value,
+            include_extracted_properties,
+            filters,
+            include_datapoint_id,
+        ),
+    )
     log.info(f"downloaded dataset '{name}'")
     df_dataset = pd.concat(df_batches, ignore_index=True) if df_batches else pd.DataFrame()
     return df_dataset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev-dependencies = [
     "mkdocs>=1.4.3,<2",
     "cairosvg>=2.7.0,<3",
     # insiders fork installed out-of-band in docs/setup_insiders.sh
-    "mkdocs-material>=9.2,<10",
+    "mkdocs-material==9.6.14",
     "mkdocstrings>=0.25,<1",
     "mkdocstrings-python==1.11.1",
     "mkdocs-git-committers-plugin-2>=1,<2",

--- a/tests/integration/dataset/test_dataset.py
+++ b/tests/integration/dataset/test_dataset.py
@@ -89,7 +89,7 @@ def test__upload_dataset() -> None:
                 LabeledBoundingBox(label="cat", top_left=[i, i], bottom_right=[i + 10, i + 10]),
                 LabeledBoundingBox(label="dog", top_left=[i + 5, i + 5], bottom_right=[i + 20, i + 20]),
             ],
-            time_str=Timestamp(value=f"12/31/2024, 00:00:{'{:02d}'.format(i)}", format="%m/%d/%Y, %H:%M:%S"),
+            time_str=Timestamp(value=f"12/31/2024, 00:00:{f'{i:02d}'}", format="%m/%d/%Y, %H:%M:%S"),
             time_num=Timestamp(epoch_time=1735689600 + i),
         )
         for i in range(20)
@@ -491,6 +491,56 @@ def test__download_dataset__with_filters(
     loaded_datapoints = download_dataset(name, filters=filters)
     loaded_datapoints = loaded_datapoints.sort_values(by="value").reset_index(drop=True)
     assert_frame_equal(loaded_datapoints, expected_datapoints, columns)
+
+
+def test__download_dataset__include_datapoint_id() -> None:
+    name = with_test_prefix(f"{__file__}::test__download_dataset__include_datapoint_id")
+    datapoints = [
+        dict(
+            locator=fake_locator(i, name),
+            width=i + 200,
+            height=i - 100,
+            city=random.choice(["new york", "waterloo"]),
+        )
+        for i in range(20)
+    ]
+    columns = ["locator", "width", "height", "city"]
+
+    partial_dataset_size = 7
+    upload_dataset(name, pd.DataFrame(datapoints[:partial_dataset_size], columns=columns), id_fields=["locator"])
+
+    df_downloaded = download_dataset(name, include_datapoint_id=True).sort_values("width", ignore_index=True)
+    loaded_datapoints = df_downloaded.reindex(columns=columns)
+    expected = pd.DataFrame(datapoints[:partial_dataset_size], columns=columns)
+    assert_frame_equal(loaded_datapoints, expected)
+    datapoint_ids_v1 = set(df_downloaded["kolena_datapoint_id"].tolist())
+    # datapoint ids should be unique
+    assert len(datapoint_ids_v1) == partial_dataset_size
+
+    # replaces the dataset
+    upload_dataset(name, pd.DataFrame(datapoints[partial_dataset_size:], columns=columns), id_fields=["locator"])
+    df_downloaded = download_dataset(name, include_datapoint_id=True).sort_values("width", ignore_index=True)
+    loaded_datapoints = df_downloaded.reindex(columns=columns)
+    expected = pd.DataFrame(datapoints[partial_dataset_size:], columns=columns)
+    assert_frame_equal(loaded_datapoints, expected)
+    datapoint_ids_v2 = set(df_downloaded["kolena_datapoint_id"].tolist())
+    assert len(datapoint_ids_v2) == len(datapoints) - partial_dataset_size
+    assert not datapoint_ids_v2.intersection(datapoint_ids_v1)
+    # datapoint ids of new upload should be greater than previous upload
+    assert max(datapoint_ids_v1) < min(datapoint_ids_v2)
+
+    # add back datapoints
+    upload_dataset(name, pd.DataFrame(datapoints, columns=columns), id_fields=["locator"])
+    df_downloaded = download_dataset(name, include_datapoint_id=True).sort_values("width", ignore_index=True)
+    loaded_datapoints = df_downloaded.reindex(columns=columns)
+    expected = pd.DataFrame(datapoints, columns=columns)
+    assert_frame_equal(loaded_datapoints, expected)
+    datapoint_ids_v3 = set(df_downloaded["kolena_datapoint_id"].tolist())
+    assert len(datapoint_ids_v3) == len(datapoints)
+    assert datapoint_ids_v2.issubset(datapoint_ids_v3)
+    assert not datapoint_ids_v3.intersection(datapoint_ids_v1)
+    datapoint_ids_v3_newly_added = datapoint_ids_v3 - datapoint_ids_v2
+    assert max(datapoint_ids_v2) < min(datapoint_ids_v3_newly_added)
 
 
 def test__delete_dataset() -> None:


### PR DESCRIPTION
### Linked issue(s)
Resolves KOL-8232.

### What change does this PR introduce and why?
Optionally return datapoint ids when downloading a dataset in a column named `kolena_datapoint_id`. This can be used by customers to construct urls to find the exact datapoint in UI.

### Please check if the PR fulfills these requirements

- [x] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
