### PR TITLE
chore: bump upper bound for pillow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "requests>=2.20,<3",
     "requests-toolbelt<2",
     "tqdm>=4,<5",
-    "Pillow>=10.0.1,<11",
+    "Pillow>=10.0.1,<13",
     "retrying>=1.3.3,<2",
     "Shapely>=1.8.5,<3",
     "termcolor>=1.1,<3",


### PR DESCRIPTION
### Linked issue(s)

Bump upper bound for pillow to unblock customers. We have limited uses for PIL and [they seem safe](https://github.com/kolenaIO/kolena/blob/0b147d4f8352c7e9fc60e8b1a54cc2d9391d0c98/kolena/workflow/visualization/_utils.py#L44-L47)

### What change does this PR introduce and why?

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
