### PR TITLE
fix: Remove polyfill dependency

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,7 +221,6 @@ extra_css:
 
 extra_javascript:
   - assets/javascript/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:


### PR DESCRIPTION
### Linked issue(s)

KOL-8333

### What change does this PR introduce and why?

Remove polyfill dependency

Apparently cdn.polyfill.io has had malicious Javascript injections. We don't really need it as modern browsers will be fine without it.

### Please check if the PR fulfills these requirements

- [ ] Include reference to internal ticket and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Relevant tests for the changes have been added
- [ ] Relevant docs have been added / updated
